### PR TITLE
Refine risk validation request and engine handling

### DIFF
--- a/services/common/schemas.py
+++ b/services/common/schemas.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 from pydantic import BaseModel, Field, model_validator
@@ -127,17 +127,155 @@ class PolicyDecisionResponse(BaseModel):
     stop_loss_bps: float = Field(..., description="Configured stop-loss distance")
 
 
-class RiskValidationRequest(BaseModel):
-    account_id: str = Field(..., description="Trading account identifier")
-    instrument: str = Field(..., description="Instrument identifier for the intent")
-    net_exposure: float = Field(..., description="Net exposure after order")
-    gross_notional: float = Field(..., ge=0.0, description="Gross notional value of the order")
+class RiskIntentMetrics(BaseModel):
+    """Risk metrics produced by the policy engine for a specific intent."""
+
+    net_exposure: float = Field(..., description="Projected net exposure after applying the intent")
+    gross_notional: float = Field(..., ge=0.0, description="Gross notional value for the intent")
     projected_loss: float = Field(..., ge=0.0, description="Projected incremental loss for the trading day")
     projected_fee: float = Field(..., ge=0.0, description="Projected incremental fees for the trading day")
     var_95: float = Field(..., ge=0.0, description="Projected 95% VaR for the intent")
     spread_bps: float = Field(..., ge=0.0, description="Expected spread in basis points")
-    latency_ms: float = Field(..., ge=0.0, description="Observed order latency in milliseconds")
-    fee: FeeBreakdown = Field(..., description="Fees associated with the order")
+    latency_ms: float = Field(..., ge=0.0, description="Observed decision latency in milliseconds")
+
+
+class PolicyDecisionPayload(BaseModel):
+    """Container for the policy decision request/response pair."""
+
+    request: PolicyDecisionRequest = Field(..., description="Original policy decision request")
+    response: Optional[PolicyDecisionResponse] = Field(
+        None, description="Optional policy decision response produced by the policy engine"
+    )
+
+    def resolved_fee(self) -> FeeBreakdown:
+        if self.response is not None:
+            return self.response.effective_fee
+        return self.request.fee
+
+
+class RiskIntentPayload(BaseModel):
+    """Full policy intent envelope supplied to the risk service."""
+
+    policy_decision: PolicyDecisionPayload = Field(
+        ..., description="Policy decision request/response context for the intent"
+    )
+    metrics: RiskIntentMetrics = Field(..., description="Risk-related metrics for the intent")
+    book_snapshot: Optional[BookSnapshot] = Field(
+        None, description="Book snapshot aligned with the policy evaluation"
+    )
+    state: Optional[PolicyState] = Field(
+        None, description="Policy state context aligned with the decision"
+    )
+    confidence: Optional[ConfidenceMetrics] = Field(
+        None, description="Confidence metrics carried from the policy engine"
+    )
+
+    @model_validator(mode="after")
+    def _populate_defaults(self) -> "RiskIntentPayload":  # type: ignore[override]
+        if self.book_snapshot is None:
+            if self.policy_decision.response is not None:
+                self.book_snapshot = self.policy_decision.response.book_snapshot
+            elif self.policy_decision.request.book_snapshot is not None:
+                self.book_snapshot = self.policy_decision.request.book_snapshot
+
+        if self.state is None:
+            if self.policy_decision.response is not None:
+                self.state = self.policy_decision.response.state
+            elif self.policy_decision.request.state is not None:
+                self.state = self.policy_decision.request.state
+
+        if self.confidence is None and self.policy_decision.response is not None:
+            self.confidence = self.policy_decision.response.confidence
+
+        return self
+
+
+class PortfolioState(BaseModel):
+    """Snapshot of the portfolio used to contextualise risk checks."""
+
+    nav: float = Field(..., gt=0.0, description="Total net asset value for the account")
+    loss_to_date: float = Field(..., ge=0.0, description="Realised losses accrued today")
+    fee_to_date: float = Field(..., ge=0.0, description="Fees accrued today")
+    instrument_exposure: Dict[str, float] = Field(
+        default_factory=dict,
+        description="Existing gross exposure by instrument prior to this intent",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional additional portfolio metadata for auditing",
+    )
+
+
+class RiskValidationRequest(BaseModel):
+    account_id: str = Field(..., description="Trading account identifier")
+    intent: RiskIntentPayload = Field(..., description="Policy intent and metrics for validation")
+    portfolio_state: PortfolioState = Field(..., description="Current portfolio state summary")
+
+    instrument: Optional[str] = Field(
+        None, description="Instrument identifier for the intent"
+    )
+    net_exposure: Optional[float] = Field(
+        None, description="Net exposure after order"
+    )
+    gross_notional: Optional[float] = Field(
+        None, ge=0.0, description="Gross notional value of the order"
+    )
+    projected_loss: Optional[float] = Field(
+        None, ge=0.0, description="Projected incremental loss for the trading day"
+    )
+    projected_fee: Optional[float] = Field(
+        None, ge=0.0, description="Projected incremental fees for the trading day"
+    )
+    var_95: Optional[float] = Field(
+        None, ge=0.0, description="Projected 95% VaR for the intent"
+    )
+    spread_bps: Optional[float] = Field(
+        None, ge=0.0, description="Expected spread in basis points"
+    )
+    latency_ms: Optional[float] = Field(
+        None, ge=0.0, description="Observed order latency in milliseconds"
+    )
+    fee: Optional[FeeBreakdown] = Field(
+        None, description="Fees associated with the order"
+    )
+
+    @model_validator(mode="after")
+    def _populate_summaries(self) -> "RiskValidationRequest":  # type: ignore[override]
+        decision = self.intent.policy_decision
+        metrics = self.intent.metrics
+
+        if self.instrument is None:
+            self.instrument = decision.request.instrument
+
+        scalar_defaults = {
+            "net_exposure": metrics.net_exposure,
+            "gross_notional": metrics.gross_notional,
+            "projected_loss": metrics.projected_loss,
+            "projected_fee": metrics.projected_fee,
+            "var_95": metrics.var_95,
+            "spread_bps": metrics.spread_bps,
+            "latency_ms": metrics.latency_ms,
+        }
+
+        for field_name, default_value in scalar_defaults.items():
+            if getattr(self, field_name) is None:
+                setattr(self, field_name, default_value)
+
+        if self.fee is None:
+            self.fee = decision.resolved_fee()
+
+        missing = [
+            name
+            for name in ["instrument", *scalar_defaults.keys(), "fee"]
+            if getattr(self, name) is None
+        ]
+        if missing:
+            raise ValueError(
+                "Missing required scalar summaries derived from intent: "
+                + ", ".join(sorted(missing))
+            )
+
+        return self
 
 
 class RiskValidationResponse(BaseModel):

--- a/tests/risk/test_endpoints.py
+++ b/tests/risk/test_endpoints.py
@@ -16,17 +16,73 @@ def client_fixture() -> TestClient:
 
 @pytest.fixture(name="base_payload")
 def base_payload_fixture() -> dict[str, object]:
+    fee = {"currency": "USD", "maker": 0.1, "taker": 0.2}
     return {
         "account_id": "admin-eu",
-        "instrument": "ETH-USD",
-        "net_exposure": 100_000.0,
-        "gross_notional": 25_000.0,
-        "projected_loss": 10_000.0,
-        "projected_fee": 500.0,
-        "var_95": 50_000.0,
-        "spread_bps": 12.5,
-        "latency_ms": 120.0,
-        "fee": {"currency": "USD", "maker": 0.1, "taker": 0.2},
+        "intent": {
+            "policy_decision": {
+                "request": {
+                    "account_id": "admin-eu",
+                    "order_id": "order-001",
+                    "instrument": "ETH-USD",
+                    "side": "BUY",
+                    "quantity": 10.0,
+                    "price": 2_500.0,
+                    "fee": fee,
+                },
+                "response": {
+                    "approved": True,
+                    "reason": None,
+                    "effective_fee": fee,
+                    "expected_edge_bps": 20.0,
+                    "fee_adjusted_edge_bps": 19.5,
+                    "selected_action": "maker",
+                    "action_templates": [
+                        {
+                            "name": "maker",
+                            "venue_type": "maker",
+                            "edge_bps": 20.0,
+                            "fee_bps": 5.0,
+                            "confidence": 0.9,
+                        }
+                    ],
+                    "confidence": {
+                        "model_confidence": 0.9,
+                        "state_confidence": 0.85,
+                        "execution_confidence": 0.88,
+                    },
+                    "features": [0.1, 0.2],
+                    "book_snapshot": {
+                        "mid_price": 2_500.0,
+                        "spread_bps": 12.5,
+                        "imbalance": 0.05,
+                    },
+                    "state": {
+                        "regime": "normal",
+                        "volatility": 0.45,
+                        "liquidity_score": 0.75,
+                        "conviction": 0.6,
+                    },
+                    "take_profit_bps": 25.0,
+                    "stop_loss_bps": 15.0,
+                },
+            },
+            "metrics": {
+                "net_exposure": 100_000.0,
+                "gross_notional": 25_000.0,
+                "projected_loss": 10_000.0,
+                "projected_fee": 500.0,
+                "var_95": 50_000.0,
+                "spread_bps": 12.5,
+                "latency_ms": 120.0,
+            },
+        },
+        "portfolio_state": {
+            "nav": 1_000_000.0,
+            "loss_to_date": 5_000.0,
+            "fee_to_date": 500.0,
+            "instrument_exposure": {"ETH-USD": 75_000.0},
+        },
     }
 
 
@@ -34,8 +90,10 @@ def base_payload_fixture() -> dict[str, object]:
 def test_validate_risk_authorized_accounts(client: TestClient, base_payload: dict[str, object], account_id: str) -> None:
     payload = deepcopy(base_payload)
     payload["account_id"] = account_id
+    payload["intent"]["policy_decision"]["request"]["account_id"] = account_id
     if account_id == "admin-us":
-        payload["instrument"] = "SOL-USD"
+        payload["intent"]["policy_decision"]["request"]["instrument"] = "SOL-USD"
+        payload["portfolio_state"]["instrument_exposure"] = {"SOL-USD": 50_000.0}
 
     response = client.post("/risk/validate", json=payload, headers={"X-Account-ID": account_id})
 
@@ -56,6 +114,7 @@ def test_validate_risk_rejects_non_admin(client: TestClient, base_payload: dict[
 def test_validate_risk_mismatched_account(client: TestClient, base_payload: dict[str, object]) -> None:
     payload = deepcopy(base_payload)
     payload["account_id"] = "admin-us"
+    payload["intent"]["policy_decision"]["request"]["account_id"] = "admin-us"
     response = client.post("/risk/validate", json=payload, headers={"X-Account-ID": "admin-eu"})
 
     assert response.status_code == 403


### PR DESCRIPTION
## Summary
- restructure the risk validation schema to embed the policy decision envelope, metrics, and portfolio snapshot required by the Soloing API
- update the risk engine to evaluate exposure, VaR, fee, and diversification checks directly from the enriched intent/portfolio data while preserving telemetry writes
- refresh risk service unit and endpoint tests to exercise the new payload shape and confirm pass/fail behaviour against configured limits

## Testing
- pytest tests/risk/test_validate.py tests/risk/test_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfe000eb08321a68bc576761683c6