### PR TITLE
Align report artifact audit logging with hypertable schema

### DIFF
--- a/reports/storage.py
+++ b/reports/storage.py
@@ -57,32 +57,39 @@ class AuditLogWriter:
             }
         )
         params = {
+            "event_id": hashlib.sha256(
+                f"{entity_id}:{event_time.isoformat()}".encode("utf-8")
+            ).hexdigest(),
+            "entity_type": "report_artifact",
+            "entity_id": entity_id,
             "actor": actor,
             "action": "report.artifact.stored",
-            "target": entity_id,
-            "created_at": event_time,
+            "event_time": event_time,
             "payload": payload,
         }
 
-        self._session.execute(
-            """
+        insert_audit_log_sql = """
             INSERT INTO audit_logs (
+                event_id,
+                entity_type,
+                entity_id,
                 actor,
                 action,
-                target,
-                created_at,
+                event_time,
                 payload
             )
             VALUES (
+                %(event_id)s,
+                %(entity_type)s,
+                %(entity_id)s,
                 %(actor)s,
                 %(action)s,
-                %(target)s,
-                %(created_at)s,
+                %(event_time)s,
                 %(payload)s::jsonb
             )
-            """,
-            params,
-        )
+        """
+
+        self._session.execute(insert_audit_log_sql, params)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- update the audit log writer to populate the hypertable columns and store metadata in the payload JSONB field
- add coverage ensuring the storage layer issues INSERTs targeting audit_logs and the payload column

## Testing
- pytest tests/reports/test_storage.py

------
https://chatgpt.com/codex/tasks/task_e_68dcff8394d883219c832bb63fb6a4f0