### PR TITLE
Add alert manager integration and Prometheus metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,14 @@
 """Application factory wiring services, middleware, and routers."""
 from __future__ import annotations
 
+import os
+
 from fastapi import FastAPI
 
 from accounts.service import AccountsService
 from auth.routes import get_auth_service, router as auth_router
 from auth.service import AdminRepository, AuthService, SessionStore
+from services.alert_manager import setup_alerting
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 from shared.correlation import CorrelationIdMiddleware
 
@@ -36,6 +39,9 @@ def create_app() -> FastAPI:
     app.state.session_store = session_store
     app.state.auth_service = auth_service
     app.state.accounts_service = accounts_service
+
+    alertmanager_url = os.getenv("ALERTMANAGER_URL")
+    setup_alerting(app, alertmanager_url=alertmanager_url)
 
     return app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi>=0.110",
     "pyotp>=2.9.0",
     "email-validator>=2.1",
+    "prometheus-client>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.111.0
 uvicorn>=0.30.0
 httpx>=0.27.0
+prometheus-client>=0.20

--- a/services/alert_manager.py
+++ b/services/alert_manager.py
@@ -1,0 +1,324 @@
+"""Alert manager utilities for Prometheus metrics and Alertmanager pushes."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from fastapi import FastAPI
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, REGISTRY
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class RiskEvent:
+    """Structured risk engine event emitted by the trading system."""
+
+    event_type: str
+    severity: str
+    description: str
+    labels: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OMSError:
+    """Order management system error."""
+
+    error_code: str
+    description: str
+    severity: str = "warning"
+    labels: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class DriftSignal:
+    """Model drift detection signal from monitoring services."""
+
+    detector: str
+    model: str
+    score: float
+    threshold: float
+    labels: Dict[str, str] = field(default_factory=dict)
+
+
+class AlertMetrics:
+    """Container for Prometheus metrics used by alerting pathways."""
+
+    def __init__(self, registry: Optional[CollectorRegistry] = None) -> None:
+        metric_kwargs = {"registry": registry} if registry is not None else {}
+
+        self.registry = registry or REGISTRY
+        self.risk_events_total = Counter(
+            "aether_risk_events_total",
+            "Risk engine events observed by the alert manager.",
+            ("event_type", "severity"),
+            **metric_kwargs,
+        )
+        self.oms_errors_total = Counter(
+            "aether_oms_errors_total",
+            "Order management system errors observed by the alert manager.",
+            ("error_code", "severity"),
+            **metric_kwargs,
+        )
+        self.drift_score = Gauge(
+            "aether_drift_detector_score",
+            "Latest score reported by each drift detector.",
+            ("detector", "model"),
+            **metric_kwargs,
+        )
+        self.latency_ms = Histogram(
+            "aether_alert_latency_ms",
+            "Latency in milliseconds for named operations monitored by alerting.",
+            ("name",),
+            buckets=(5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000),
+            **metric_kwargs,
+        )
+        self.fee_spike_pct = Gauge(
+            "aether_fee_spike_pct",
+            "Fee spike percentage observed for an account.",
+            ("account_id",),
+            **metric_kwargs,
+        )
+        self.trade_rejections_total = Counter(
+            "aether_trade_rejections_total",
+            "Total trade rejections observed per account.",
+            ("account_id",),
+            **metric_kwargs,
+        )
+
+
+_metrics_lock = threading.Lock()
+_metrics: Optional[AlertMetrics] = None
+
+
+def get_alert_metrics(registry: Optional[CollectorRegistry] = None) -> AlertMetrics:
+    """Return the configured alert metrics, creating them if necessary."""
+
+    global _metrics
+    with _metrics_lock:
+        if _metrics is None:
+            _metrics = AlertMetrics(registry=registry)
+        return _metrics
+
+
+def configure_metrics(registry: Optional[CollectorRegistry] = None) -> AlertMetrics:
+    """Reset and configure metrics, primarily useful for tests."""
+
+    global _metrics
+    with _metrics_lock:
+        _metrics = AlertMetrics(registry=registry)
+        return _metrics
+
+
+class AlertManager:
+    """Coordinates Prometheus metrics and Alertmanager notifications."""
+
+    def __init__(
+        self,
+        metrics: AlertMetrics,
+        alertmanager_url: Optional[str] = None,
+        timeout: float = 5.0,
+        push_severities: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.metrics = metrics
+        self.alertmanager_url = alertmanager_url or os.getenv("ALERTMANAGER_URL")
+        self.timeout = timeout
+        self.push_severities = {s.lower() for s in (push_severities or ("critical", "high"))}
+        self._trade_rejection_counts: Dict[str, int] = defaultdict(int)
+
+    # ------------------------------------------------------------------
+    # Event ingestion helpers
+    # ------------------------------------------------------------------
+    def handle_risk_event(self, event: RiskEvent) -> None:
+        """Consume a risk event and emit metrics/alerts."""
+
+        severity = event.severity.lower()
+        self.metrics.risk_events_total.labels(event.event_type, severity).inc()
+        if severity in self.push_severities:
+            self._push_alert(
+                alert_name="RiskEngineEvent",
+                severity=severity,
+                description=event.description or event.event_type,
+                labels={"event_type": event.event_type, **event.labels},
+            )
+
+    def handle_oms_error(self, error: OMSError) -> None:
+        """Consume an OMS error and emit metrics/alerts."""
+
+        severity = error.severity.lower()
+        self.metrics.oms_errors_total.labels(error.error_code, severity).inc()
+        if severity in self.push_severities:
+            self._push_alert(
+                alert_name="OMSError",
+                severity=severity,
+                description=error.description or error.error_code,
+                labels={"error_code": error.error_code, **error.labels},
+            )
+
+    def handle_drift_signal(self, signal: DriftSignal) -> None:
+        """Consume a drift signal and emit metrics/alerts when threshold reached."""
+
+        self.metrics.drift_score.labels(signal.detector, signal.model).set(signal.score)
+        if signal.score >= signal.threshold:
+            self._push_alert(
+                alert_name="ModelDriftDetected",
+                severity="warning",
+                description=
+                f"Drift detector {signal.detector} for {signal.model} exceeded threshold {signal.threshold} with score {signal.score}",
+                labels={
+                    "detector": signal.detector,
+                    "model": signal.model,
+                    **signal.labels,
+                },
+            )
+
+    def on_latency(self, name: str, latency_ms: float) -> None:
+        self.metrics.latency_ms.labels(name).observe(latency_ms)
+        if latency_ms >= 5000:
+            self._push_alert(
+                alert_name="LatencySpike",
+                severity="warning",
+                description=f"Observed latency of {latency_ms:.2f}ms for {name}",
+                labels={"name": name},
+            )
+
+    def on_fee_spike(self, account_id: str, fee_pct: float) -> None:
+        self.metrics.fee_spike_pct.labels(account_id).set(fee_pct)
+        if fee_pct >= 5:
+            self._push_alert(
+                alert_name="FeeSpike",
+                severity="warning",
+                description=f"Account {account_id} fee spike {fee_pct:.2f}%",
+                labels={"account_id": account_id},
+            )
+
+    def on_trade_rejection(self, account_id: str) -> None:
+        self.metrics.trade_rejections_total.labels(account_id).inc()
+        self._trade_rejection_counts[account_id] += 1
+        if self._trade_rejection_counts[account_id] >= 5:
+            self._push_alert(
+                alert_name="TradeRejections",
+                severity="warning",
+                description=f"Account {account_id} experienced repeated trade rejections.",
+                labels={"account_id": account_id},
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _push_alert(
+        self,
+        alert_name: str,
+        severity: str,
+        description: str,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> None:
+        if not self.alertmanager_url:
+            return
+
+        payload = {
+            "labels": {
+                "alertname": alert_name,
+                "severity": severity,
+                **(labels or {}),
+            },
+            "annotations": {
+                "description": description,
+            },
+            "startsAt": datetime.now(timezone.utc).isoformat(),
+        }
+
+        try:
+            encoded_payload = json.dumps([payload]).encode("utf-8")
+            req = urllib_request.Request(
+                self.alertmanager_url,
+                data=encoded_payload,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib_request.urlopen(req, timeout=self.timeout):
+                pass
+        except urllib_error.URLError as exc:  # pragma: no cover - network failures are logged
+            logger.warning("Failed to push alert to Alertmanager", exc_info=exc)
+
+
+_alert_manager_lock = threading.Lock()
+_alert_manager: Optional[AlertManager] = None
+
+
+def set_alert_manager(manager: Optional[AlertManager]) -> None:
+    global _alert_manager
+    with _alert_manager_lock:
+        _alert_manager = manager
+
+
+def get_alert_manager_instance() -> Optional[AlertManager]:
+    return _alert_manager
+
+
+# ----------------------------------------------------------------------
+# Helper functions requested by the prompt
+# ----------------------------------------------------------------------
+def alert_latency(name: str, ms: float) -> None:
+    manager = get_alert_manager_instance()
+    metrics = get_alert_metrics()
+    metrics.latency_ms.labels(name).observe(ms)
+    if manager:
+        manager.on_latency(name, ms)
+
+
+def alert_fee_spike(account_id: str, fee_pct: float) -> None:
+    manager = get_alert_manager_instance()
+    metrics = get_alert_metrics()
+    metrics.fee_spike_pct.labels(account_id).set(fee_pct)
+    if manager:
+        manager.on_fee_spike(account_id, fee_pct)
+
+
+def alert_trade_rejections(account_id: str) -> None:
+    manager = get_alert_manager_instance()
+    metrics = get_alert_metrics()
+    metrics.trade_rejections_total.labels(account_id).inc()
+    if manager:
+        manager.on_trade_rejection(account_id)
+
+
+def setup_alerting(app: FastAPI, alertmanager_url: Optional[str] = None) -> None:
+    """Register startup/shutdown hooks for metrics and alert manager wiring."""
+
+    @app.on_event("startup")
+    async def _configure_alerting() -> None:  # pragma: no cover - FastAPI lifecycle
+        metrics = get_alert_metrics()
+        manager = AlertManager(metrics=metrics, alertmanager_url=alertmanager_url)
+        set_alert_manager(manager)
+        app.state.alert_manager = manager
+
+    @app.on_event("shutdown")
+    async def _clear_alerting() -> None:  # pragma: no cover - FastAPI lifecycle
+        set_alert_manager(None)
+        if hasattr(app.state, "alert_manager"):
+            delattr(app.state, "alert_manager")
+
+
+__all__ = [
+    "AlertManager",
+    "AlertMetrics",
+    "DriftSignal",
+    "OMSError",
+    "RiskEvent",
+    "alert_fee_spike",
+    "alert_latency",
+    "alert_trade_rejections",
+    "configure_metrics",
+    "get_alert_manager_instance",
+    "get_alert_metrics",
+    "setup_alerting",
+]
+

--- a/tests/services/test_alert_manager.py
+++ b/tests/services/test_alert_manager.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from prometheus_client import CollectorRegistry
+
+from services.alert_manager import (
+    AlertManager,
+    DriftSignal,
+    OMSError,
+    RiskEvent,
+    alert_fee_spike,
+    alert_latency,
+    alert_trade_rejections,
+    configure_metrics,
+    get_alert_metrics,
+    setup_alerting,
+)
+
+
+def test_handle_risk_event_increments_metric() -> None:
+    registry = CollectorRegistry()
+    metrics = configure_metrics(registry)
+    manager = AlertManager(metrics=metrics, alertmanager_url=None)
+
+    manager.handle_risk_event(
+        RiskEvent(event_type="limit_breach", severity="warning", description="")
+    )
+
+    value = registry.get_sample_value(
+        "aether_risk_events_total",
+        {"event_type": "limit_breach", "severity": "warning"},
+    )
+    assert value == 1.0
+
+
+def test_handle_oms_error_increments_metric() -> None:
+    registry = CollectorRegistry()
+    metrics = configure_metrics(registry)
+    manager = AlertManager(metrics=metrics, alertmanager_url=None)
+
+    manager.handle_oms_error(
+        OMSError(error_code="REJECT", description="Order rejected", severity="critical")
+    )
+
+    value = registry.get_sample_value(
+        "aether_oms_errors_total",
+        {"error_code": "REJECT", "severity": "critical"},
+    )
+    assert value == 1.0
+
+
+def test_handle_drift_signal_sets_gauge() -> None:
+    registry = CollectorRegistry()
+    metrics = configure_metrics(registry)
+    manager = AlertManager(metrics=metrics, alertmanager_url=None)
+
+    manager.handle_drift_signal(
+        DriftSignal(detector="ks", model="alpha", score=0.7, threshold=0.6)
+    )
+
+    value = registry.get_sample_value(
+        "aether_drift_detector_score",
+        {"detector": "ks", "model": "alpha"},
+    )
+    assert value == 0.7
+
+
+def test_helper_functions_record_metrics() -> None:
+    registry = CollectorRegistry()
+    configure_metrics(registry)
+
+    alert_latency("risk_engine", 125)
+    alert_fee_spike("acct-1", 3.5)
+    alert_trade_rejections("acct-1")
+
+    metrics = get_alert_metrics()
+    # Histogram helper functions expose _count/_sum samples for verification.
+    latency_count = registry.get_sample_value(
+        "aether_alert_latency_ms_count", {"name": "risk_engine"}
+    )
+    fee_gauge = registry.get_sample_value(
+        "aether_fee_spike_pct", {"account_id": "acct-1"}
+    )
+    trade_count = registry.get_sample_value(
+        "aether_trade_rejections_total", {"account_id": "acct-1"}
+    )
+
+    assert metrics is not None
+    assert latency_count == 1.0
+    assert fee_gauge == 3.5
+    assert trade_count == 1.0
+
+
+def test_setup_alerting_binds_manager_to_app_state() -> None:
+    registry = CollectorRegistry()
+    configure_metrics(registry)
+
+    app = FastAPI()
+    setup_alerting(app)
+
+    with TestClient(app):
+        assert hasattr(app.state, "alert_manager")
+        assert isinstance(app.state.alert_manager, AlertManager)


### PR DESCRIPTION
## Summary
- add an alert manager module that records Prometheus metrics and optionally pushes alerts to Alertmanager
- integrate the FastAPI application startup flow with the alert manager and expose helper alert functions
- cover the alert manager module with dedicated unit tests and add the prometheus-client dependency

## Testing
- pytest tests/services/test_alert_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68dd00739828832188372a3b537019eb