### PR TITLE
Add SQLAlchemy and psycopg dependencies for universe service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ authors = [{name = "Aether", email = "admin@example.com"}]
 requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.110",
+    "psycopg[binary]>=3.1",
     "pyotp>=2.9.0",
+    "sqlalchemy>=2.0",
     "email-validator>=2.1",
     "prometheus-client>=0.20",
     "watchdog>=3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ uvicorn>=0.30.0
 httpx>=0.27.0
 prometheus-client>=0.20
 watchdog>=3.0
+sqlalchemy>=2.0
+psycopg[binary]>=3.1
 


### PR DESCRIPTION
## Summary
- add sqlalchemy and psycopg packages required by the Timescale-backed universe service to pyproject metadata
- mirror the new database driver dependencies in requirements.txt to keep runtime installs aligned

## Testing
- not run (dependency manifest update only)

------
https://chatgpt.com/codex/tasks/task_e_68dd053f58708321aaa31363fea10954