### PR TITLE
Add main pipeline workflow for main branch delivery

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,0 +1,191 @@
+name: Main Branch Delivery Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  quality-checks:
+    name: Lint, Type Check, and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install ruff black mypy pytest pytest-cov
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Black
+        run: black --check .
+
+      - name: Mypy
+        run: mypy .
+
+      - name: Pytest with coverage
+        run: pytest --maxfail=1 --disable-warnings --cov=. --cov-report=xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+
+  sast-scan:
+    name: Static Application Security Scan
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy SAST scan
+        uses: aquasecurity/trivy-action@0.21.0
+        with:
+          scan-type: fs
+          severity: CRITICAL
+          security-checks: vuln,secret,config
+          exit-code: '1'
+          format: table
+
+  build-and-release:
+    name: Build, Sign, and Publish Images
+    runs-on: ubuntu-latest
+    needs:
+      - quality-checks
+      - sast-scan
+    env:
+      REGISTRY: ghcr.io
+    strategy:
+      matrix:
+        build:
+          - name: kraken-ws-ingest
+            context: deploy/docker/kraken-ws-ingest
+            dockerfile: deploy/docker/kraken-ws-ingest/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine image coordinates
+        id: image_meta
+        run: |
+          IMAGE_ID="${REGISTRY}/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')/${{ matrix.build.name }}"
+          echo "image_id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${IMAGE_ID}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${IMAGE_ID}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GHCR
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image with Buildah
+        id: buildah
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ steps.image_meta.outputs.image_id }}
+          tags: |
+            latest
+            ${{ github.sha }}
+          context: ${{ matrix.build.context }}
+          containerfiles: ${{ matrix.build.dockerfile }}
+
+      - name: Push image to GHCR
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.buildah.outputs.image }}
+          tags: ${{ steps.buildah.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM
+        id: sbom
+        uses: anchore/syft-action@v1
+        with:
+          image: ${{ steps.image_meta.outputs.sha_tag }}
+          output-file: sbom-${{ matrix.build.name }}.spdx.json
+          format: spdx-json
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.build.name }}
+          path: sbom-${{ matrix.build.name }}.spdx.json
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign image with Cosign
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY "${{ steps.image_meta.outputs.sha_tag }}"
+          cosign sign --key env://COSIGN_PRIVATE_KEY "${{ steps.image_meta.outputs.latest_tag }}"
+
+      - name: Attach SBOM attestation
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          cosign attest --key env://COSIGN_PRIVATE_KEY --predicate "sbom-${{ matrix.build.name }}.spdx.json" --type spdx "${{ steps.image_meta.outputs.sha_tag }}"
+
+  argocd-sync:
+    name: Trigger ArgoCD Sync
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ArgoCD CLI
+        run: |
+          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/v2.9.3/argocd-linux-amd64
+          chmod +x argocd
+          sudo mv argocd /usr/local/bin/
+
+      - name: Login to ArgoCD
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          argocd login "$ARGOCD_SERVER" --auth-token "$ARGOCD_AUTH_TOKEN" --insecure
+
+      - name: Sync applications
+        run: |
+          argocd app sync aether-risk-staging
+          argocd app wait aether-risk-staging --health --timeout 600
+          argocd app sync aether-risk-prod
+          argocd app wait aether-risk-prod --health --timeout 600


### PR DESCRIPTION
## Summary
- add a main-branch workflow that runs Ruff, Black, Mypy, and Pytest with cached dependencies and uploads coverage
- gate deployments on a critical-severity Trivy SAST scan before building images with Buildah, generating SBOMs, and signing via Cosign
- trigger an ArgoCD sync after the Buildah job pushes signed images to GHCR

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd0b34f79883218cbc1fe3db352a93