### PR TITLE
Add Kubernetes manifests for core services

### DIFF
--- a/deploy/k8s/base/aether-services/deployment-fees.yaml
+++ b/deploy/k8s/base/aether-services/deployment-fees.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fees-service
+  labels:
+    app: fees-service
+    app.kubernetes.io/name: fees-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: fees-service
+  template:
+    metadata:
+      labels:
+        app: fees-service
+        app.kubernetes.io/name: fees-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: fees-service
+          image: ghcr.io/aether/fees-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/deployment-oms.yaml
+++ b/deploy/k8s/base/aether-services/deployment-oms.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oms-service
+  labels:
+    app: oms-service
+    app.kubernetes.io/name: oms-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: oms-service
+  template:
+    metadata:
+      labels:
+        app: oms-service
+        app.kubernetes.io/name: oms-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: oms-service
+          image: ghcr.io/aether/oms-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/deployment-policy.yaml
+++ b/deploy/k8s/base/aether-services/deployment-policy.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-service
+  labels:
+    app: policy-service
+    app.kubernetes.io/name: policy-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: policy-service
+  template:
+    metadata:
+      labels:
+        app: policy-service
+        app.kubernetes.io/name: policy-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: policy-service
+          image: ghcr.io/aether/policy-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/deployment-risk.yaml
+++ b/deploy/k8s/base/aether-services/deployment-risk.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: risk-service
+  labels:
+    app: risk-service
+    app.kubernetes.io/name: risk-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: risk-service
+  template:
+    metadata:
+      labels:
+        app: risk-service
+        app.kubernetes.io/name: risk-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: risk-service
+          image: ghcr.io/aether/risk-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/deployment-secrets.yaml
+++ b/deploy/k8s/base/aether-services/deployment-secrets.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-service
+  labels:
+    app: secrets-service
+    app.kubernetes.io/name: secrets-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: secrets-service
+  template:
+    metadata:
+      labels:
+        app: secrets-service
+        app.kubernetes.io/name: secrets-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: secrets-service
+          image: ghcr.io/aether/secrets-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/deployment-universe.yaml
+++ b/deploy/k8s/base/aether-services/deployment-universe.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: universe-service
+  labels:
+    app: universe-service
+    app.kubernetes.io/name: universe-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: universe-service
+  template:
+    metadata:
+      labels:
+        app: universe-service
+        app.kubernetes.io/name: universe-service
+        app.kubernetes.io/component: api
+      annotations:
+        checksum/kraken-secrets: "$(KRAKEN_SECRET_HASH)"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: universe-service
+          image: ghcr.io/aether/universe-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: KRAKEN_SECRETS_BASE
+              value: /var/run/secrets/kraken
+            - name: AETHER_COMPANY_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/company/credentials.json
+            - name: AETHER_DIRECTOR_1_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-1/credentials.json
+            - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
+              value: /var/run/secrets/kraken/director-2/credentials.json
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: kraken-credentials
+              mountPath: /var/run/secrets/kraken
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: kraken-credentials
+          projected:
+            defaultMode: 0440
+            sources:
+              - secret:
+                  name: kraken-keys-company
+                  items:
+                    - key: credentials.json
+                      path: company/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-1
+                  items:
+                    - key: credentials.json
+                      path: director-1/credentials.json
+                  optional: true
+              - secret:
+                  name: kraken-keys-director-2
+                  items:
+                    - key: credentials.json
+                      path: director-2/credentials.json
+                  optional: true
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/hpa-fees.yaml
+++ b/deploy/k8s/base/aether-services/hpa-fees.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fees-service
+  labels:
+    app: fees-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fees-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/hpa-oms.yaml
+++ b/deploy/k8s/base/aether-services/hpa-oms.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: oms-service
+  labels:
+    app: oms-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: oms-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/hpa-policy.yaml
+++ b/deploy/k8s/base/aether-services/hpa-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: policy-service
+  labels:
+    app: policy-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: policy-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/hpa-risk.yaml
+++ b/deploy/k8s/base/aether-services/hpa-risk.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: risk-service
+  labels:
+    app: risk-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: risk-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/hpa-secrets.yaml
+++ b/deploy/k8s/base/aether-services/hpa-secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: secrets-service
+  labels:
+    app: secrets-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: secrets-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/hpa-universe.yaml
+++ b/deploy/k8s/base/aether-services/hpa-universe.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: universe-service
+  labels:
+    app: universe-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: universe-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/deploy/k8s/base/aether-services/ingress-fees.yaml
+++ b/deploy/k8s/base/aether-services/ingress-fees.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fees-service
+  labels:
+    app: fees-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - fees.aether.example.com
+      secretName: fees-service-tls
+  rules:
+    - host: fees.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fees-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/ingress-oms.yaml
+++ b/deploy/k8s/base/aether-services/ingress-oms.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oms-service
+  labels:
+    app: oms-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - oms.aether.example.com
+      secretName: oms-service-tls
+  rules:
+    - host: oms.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oms-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/ingress-policy.yaml
+++ b/deploy/k8s/base/aether-services/ingress-policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: policy-service
+  labels:
+    app: policy-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - policy.aether.example.com
+      secretName: policy-service-tls
+  rules:
+    - host: policy.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: policy-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/ingress-risk.yaml
+++ b/deploy/k8s/base/aether-services/ingress-risk.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: risk-service
+  labels:
+    app: risk-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - risk.aether.example.com
+      secretName: risk-service-tls
+  rules:
+    - host: risk.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: risk-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/ingress-secrets.yaml
+++ b/deploy/k8s/base/aether-services/ingress-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: secrets-service
+  labels:
+    app: secrets-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - secrets.aether.example.com
+      secretName: secrets-service-tls
+  rules:
+    - host: secrets.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: secrets-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/ingress-universe.yaml
+++ b/deploy/k8s/base/aether-services/ingress-universe.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: universe-service
+  labels:
+    app: universe-service
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - universe.aether.example.com
+      secretName: universe-service-tls
+  rules:
+    - host: universe.aether.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: universe-service
+                port:
+                  number: 80

--- a/deploy/k8s/base/aether-services/kustomization.yaml
+++ b/deploy/k8s/base/aether-services/kustomization.yaml
@@ -1,0 +1,56 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment-policy.yaml
+  - deployment-risk.yaml
+  - deployment-oms.yaml
+  - deployment-fees.yaml
+  - deployment-secrets.yaml
+  - deployment-universe.yaml
+  - service-policy.yaml
+  - service-risk.yaml
+  - service-oms.yaml
+  - service-fees.yaml
+  - service-secrets.yaml
+  - service-universe.yaml
+  - hpa-policy.yaml
+  - hpa-risk.yaml
+  - hpa-oms.yaml
+  - hpa-fees.yaml
+  - hpa-secrets.yaml
+  - hpa-universe.yaml
+  - networkpolicy-policy.yaml
+  - networkpolicy-risk.yaml
+  - networkpolicy-oms.yaml
+  - networkpolicy-fees.yaml
+  - networkpolicy-secrets.yaml
+  - networkpolicy-universe.yaml
+  - ingress-policy.yaml
+  - ingress-risk.yaml
+  - ingress-oms.yaml
+  - ingress-fees.yaml
+  - ingress-secrets.yaml
+  - ingress-universe.yaml
+  - pdb-policy.yaml
+  - pdb-risk.yaml
+  - pdb-oms.yaml
+  - pdb-fees.yaml
+  - pdb-secrets.yaml
+  - pdb-universe.yaml
+
+configMapGenerator:
+  - name: kraken-secret-checksums
+    literals:
+      - combined=placeholder
+    options:
+      disableNameSuffixHash: true
+
+vars:
+  - name: KRAKEN_SECRET_HASH
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: kraken-secret-checksums
+    fieldref:
+      fieldpath: data.combined

--- a/deploy/k8s/base/aether-services/networkpolicy-fees.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-fees.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-fees
+  labels:
+    app: fees-service
+spec:
+  podSelector:
+    matchLabels:
+      app: fees-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/networkpolicy-oms.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-oms.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-oms
+  labels:
+    app: oms-service
+spec:
+  podSelector:
+    matchLabels:
+      app: oms-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/networkpolicy-policy.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-policy
+  labels:
+    app: policy-service
+spec:
+  podSelector:
+    matchLabels:
+      app: policy-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/networkpolicy-risk.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-risk.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-risk
+  labels:
+    app: risk-service
+spec:
+  podSelector:
+    matchLabels:
+      app: risk-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/networkpolicy-secrets.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-secrets.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-secrets
+  labels:
+    app: secrets-service
+spec:
+  podSelector:
+    matchLabels:
+      app: secrets-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/networkpolicy-universe.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-universe.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-kraken-coingecko-universe
+  labels:
+    app: universe-service
+spec:
+  podSelector:
+    matchLabels:
+      app: universe-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+          ports:
+            - protocol: TCP
+              port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+          ports:
+            - protocol: TCP
+              port: 443

--- a/deploy/k8s/base/aether-services/pdb-fees.yaml
+++ b/deploy/k8s/base/aether-services/pdb-fees.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fees-service
+  labels:
+    app: fees-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: fees-service

--- a/deploy/k8s/base/aether-services/pdb-oms.yaml
+++ b/deploy/k8s/base/aether-services/pdb-oms.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: oms-service
+  labels:
+    app: oms-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: oms-service

--- a/deploy/k8s/base/aether-services/pdb-policy.yaml
+++ b/deploy/k8s/base/aether-services/pdb-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: policy-service
+  labels:
+    app: policy-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: policy-service

--- a/deploy/k8s/base/aether-services/pdb-risk.yaml
+++ b/deploy/k8s/base/aether-services/pdb-risk.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: risk-service
+  labels:
+    app: risk-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: risk-service

--- a/deploy/k8s/base/aether-services/pdb-secrets.yaml
+++ b/deploy/k8s/base/aether-services/pdb-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: secrets-service
+  labels:
+    app: secrets-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: secrets-service

--- a/deploy/k8s/base/aether-services/pdb-universe.yaml
+++ b/deploy/k8s/base/aether-services/pdb-universe.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: universe-service
+  labels:
+    app: universe-service
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: universe-service

--- a/deploy/k8s/base/aether-services/service-fees.yaml
+++ b/deploy/k8s/base/aether-services/service-fees.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fees-service
+  labels:
+    app: fees-service
+    app.kubernetes.io/name: fees-service
+spec:
+  selector:
+    app: fees-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/aether-services/service-oms.yaml
+++ b/deploy/k8s/base/aether-services/service-oms.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oms-service
+  labels:
+    app: oms-service
+    app.kubernetes.io/name: oms-service
+spec:
+  selector:
+    app: oms-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/aether-services/service-policy.yaml
+++ b/deploy/k8s/base/aether-services/service-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-service
+  labels:
+    app: policy-service
+    app.kubernetes.io/name: policy-service
+spec:
+  selector:
+    app: policy-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/aether-services/service-risk.yaml
+++ b/deploy/k8s/base/aether-services/service-risk.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: risk-service
+  labels:
+    app: risk-service
+    app.kubernetes.io/name: risk-service
+spec:
+  selector:
+    app: risk-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/aether-services/service-secrets.yaml
+++ b/deploy/k8s/base/aether-services/service-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: secrets-service
+  labels:
+    app: secrets-service
+    app.kubernetes.io/name: secrets-service
+spec:
+  selector:
+    app: secrets-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/aether-services/service-universe.yaml
+++ b/deploy/k8s/base/aether-services/service-universe.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: universe-service
+  labels:
+    app: universe-service
+    app.kubernetes.io/name: universe-service
+spec:
+  selector:
+    app: universe-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - fastapi
   - ingress
   - networkpolicies
+  - aether-services
 commonLabels:
   app.kubernetes.io/part-of: aether-risk
 

--- a/deploy/k8s/overlays/production/kustomization.yaml
+++ b/deploy/k8s/overlays/production/kustomization.yaml
@@ -35,3 +35,6 @@ patches:
         path: /data/environment
         value: production
 
+patchesStrategicMerge:
+  - patches/aether-services.yaml
+

--- a/deploy/k8s/overlays/production/patches/aether-services.yaml
+++ b/deploy/k8s/overlays/production/patches/aether-services.yaml
@@ -1,0 +1,155 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-service
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: policy-service
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 750m
+              memory: 1536Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: policy-service
+spec:
+  minReplicas: 3
+  maxReplicas: 8
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: risk-service
+spec:
+  replicas: 4
+  template:
+    spec:
+      containers:
+        - name: risk-service
+          resources:
+            requests:
+              cpu: 400m
+              memory: 768Mi
+            limits:
+              cpu: 1500m
+              memory: 2Gi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: risk-service
+spec:
+  minReplicas: 4
+  maxReplicas: 12
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oms-service
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: oms-service
+          resources:
+            requests:
+              cpu: 300m
+              memory: 512Mi
+            limits:
+              cpu: 900m
+              memory: 1536Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: oms-service
+spec:
+  minReplicas: 3
+  maxReplicas: 9
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fees-service
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: fees-service
+          resources:
+            requests:
+              cpu: 200m
+              memory: 384Mi
+            limits:
+              cpu: 600m
+              memory: 1Gi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fees-service
+spec:
+  minReplicas: 2
+  maxReplicas: 6
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-service
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: secrets-service
+          resources:
+            requests:
+              cpu: 200m
+              memory: 384Mi
+            limits:
+              cpu: 600m
+              memory: 1Gi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: secrets-service
+spec:
+  minReplicas: 2
+  maxReplicas: 6
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: universe-service
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: universe-service
+          resources:
+            requests:
+              cpu: 280m
+              memory: 512Mi
+            limits:
+              cpu: 840m
+              memory: 1280Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: universe-service
+spec:
+  minReplicas: 3
+  maxReplicas: 9

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -35,3 +35,6 @@ patches:
         path: /data/environment
         value: staging
 
+patchesStrategicMerge:
+  - patches/aether-services.yaml
+

--- a/deploy/k8s/overlays/staging/patches/aether-services.yaml
+++ b/deploy/k8s/overlays/staging/patches/aether-services.yaml
@@ -1,0 +1,155 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: policy-service
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: policy-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: risk-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: risk-service
+          resources:
+            requests:
+              cpu: 150m
+              memory: 384Mi
+            limits:
+              cpu: 400m
+              memory: 768Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: risk-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oms-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: oms-service
+          resources:
+            requests:
+              cpu: 150m
+              memory: 384Mi
+            limits:
+              cpu: 400m
+              memory: 768Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: oms-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fees-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: fees-service
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fees-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: secrets-service
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: secrets-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: universe-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: universe-service
+          resources:
+            requests:
+              cpu: 120m
+              memory: 320Mi
+            limits:
+              cpu: 350m
+              memory: 640Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: universe-service
+spec:
+  minReplicas: 1
+  maxReplicas: 3


### PR DESCRIPTION
## Summary
- add base Kubernetes manifests for the policy, risk, oms, fees, secrets, and universe services including deployments, services, HPAs, PodDisruptionBudgets, network policies, and TLS-enabled ingresses
- mount per-account Kraken credential secrets with checksum-driven restart annotations and tighten pod security contexts
- introduce staging and production overlays to tune replicas and resources for the new services

## Testing
- not run (kustomize is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd0b2c660c83218963f9a6c2d88ee7