### PR TITLE
Respect forwarded TLS scheme in secrets service

### DIFF
--- a/deploy/k8s/base/ingress/ingress.yaml
+++ b/deploy/k8s/base/ingress/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+    # Ensure upstream services see the original TLS scheme via X-Forwarded-Proto.
+    nginx.ingress.kubernetes.io/use-forwarded-headers: "true"
 spec:
   rules:
     - host: risk.aether.local

--- a/services/secrets/main.py
+++ b/services/secrets/main.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from services.common.adapters import KrakenSecretManager
 from services.common.schemas import (
@@ -11,9 +12,12 @@ from services.common.schemas import (
     KrakenSecretStatusResponse,
 )
 from services.common.security import require_admin_account, require_mfa_context
+from services.secrets.middleware import ForwardedSchemeMiddleware, TRUSTED_HOSTS
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 
 app = FastAPI(title="Secrets Service")
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=TRUSTED_HOSTS)
+app.add_middleware(ForwardedSchemeMiddleware)
 
 _audit_store = AuditLogStore()
 _audit_logger = TimescaleAuditLogger(_audit_store)

--- a/services/secrets/middleware.py
+++ b/services/secrets/middleware.py
@@ -1,0 +1,52 @@
+"""Shared middleware utilities for the secrets services."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from starlette.datastructures import Headers
+
+TRUSTED_HOSTS: Sequence[str] = (
+    "risk.aether.local",
+    "*.aether.svc.cluster.local",
+    "localhost",
+    "127.0.0.1",
+    "testserver",
+)
+
+
+class ForwardedSchemeMiddleware:
+    """ASGI middleware that normalizes the scheme from ingress headers."""
+
+    def __init__(self, app, header_names: Iterable[str] | None = None) -> None:
+        self.app = app
+        self.header_names = tuple(
+            header.lower() for header in (header_names or ("x-forwarded-proto", "x-forwarded-scheme"))
+        )
+
+    async def __call__(self, scope, receive, send):  # type: ignore[override]
+        if scope.get("type") not in {"http", "websocket"}:
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        scheme_override: str | None = None
+
+        for header in self.header_names:
+            value = headers.get(header)
+            if value:
+                forwarded = value.split(",")[0].strip()
+                if forwarded:
+                    scheme_override = forwarded.lower()
+                    break
+
+        if scheme_override:
+            scope = dict(scope)
+            scope["scheme"] = scheme_override
+
+        await self.app(scope, receive, send)
+
+
+__all__ = [
+    "ForwardedSchemeMiddleware",
+    "TRUSTED_HOSTS",
+]

--- a/services/secrets/middleware.py
+++ b/services/secrets/middleware.py
@@ -1,6 +1,7 @@
 """Shared middleware utilities for the secrets services."""
 from __future__ import annotations
 
+import os
 from typing import Iterable, Sequence
 
 from starlette.datastructures import Headers
@@ -12,6 +13,20 @@ TRUSTED_HOSTS: Sequence[str] = (
     "127.0.0.1",
     "testserver",
 )
+
+
+def _load_trusted_proxy_clients() -> tuple[str, ...]:
+    """Return the set of proxy client hosts whose scheme overrides are trusted."""
+
+    value = os.getenv("SECRETS_TRUSTED_PROXY_CLIENTS")
+    if not value:
+        return ("127.0.0.1", "::1", "testclient")
+
+    clients = tuple(host.strip() for host in value.split(",") if host.strip())
+    return clients or ("127.0.0.1", "::1", "testclient")
+
+
+TRUSTED_PROXY_CLIENTS: tuple[str, ...] = _load_trusted_proxy_clients()
 
 
 class ForwardedSchemeMiddleware:
@@ -30,6 +45,8 @@ class ForwardedSchemeMiddleware:
 
         headers = Headers(scope=scope)
         scheme_override: str | None = None
+        original_scheme = scope.get("scheme")
+        normalized_original = original_scheme.lower() if isinstance(original_scheme, str) else None
 
         for header in self.header_names:
             value = headers.get(header)
@@ -39,8 +56,10 @@ class ForwardedSchemeMiddleware:
                     scheme_override = forwarded.lower()
                     break
 
-        if scheme_override:
+        if scheme_override and scheme_override != normalized_original:
             scope = dict(scope)
+            scope["aether_original_scheme"] = normalized_original
+            scope["aether_forwarded_scheme"] = scheme_override
             scope["scheme"] = scheme_override
 
         await self.app(scope, receive, send)
@@ -49,4 +68,5 @@ class ForwardedSchemeMiddleware:
 __all__ = [
     "ForwardedSchemeMiddleware",
     "TRUSTED_HOSTS",
+    "TRUSTED_PROXY_CLIENTS",
 ]

--- a/tests/secrets/test_transport.py
+++ b/tests/secrets/test_transport.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402  # pragma: no cover
+
+from services.secrets.secrets_service import app  # noqa: E402
+
+
+@pytest.fixture(name="client")
+def client_fixture() -> TestClient:
+    return TestClient(app)
+
+
+def test_forwarded_proto_allows_secure_requests(client: TestClient) -> None:
+    response = client.post(
+        "/secrets/kraken/test",
+        json={
+            "account_id": "company",
+            "api_key": "apikey-123",
+            "api_secret": "secret-value-123",
+        },
+        headers={
+            "X-Account-ID": "company",
+            "X-MFA-Context": "verified",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert response.status_code == 204

--- a/tests/secrets/test_transport.py
+++ b/tests/secrets/test_transport.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
+from fastapi import status  # noqa: E402  # pragma: no cover
 from fastapi.testclient import TestClient  # noqa: E402  # pragma: no cover
 
+from services.secrets import middleware  # noqa: E402  # pragma: no cover
 from services.secrets.secrets_service import app  # noqa: E402
 
 
@@ -29,3 +31,29 @@ def test_forwarded_proto_allows_secure_requests(client: TestClient) -> None:
     )
 
     assert response.status_code == 204
+
+
+def test_forwarded_proto_rejected_for_untrusted_clients(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from services.secrets import secrets_service
+
+    monkeypatch.setattr(secrets_service, "TRUSTED_PROXY_CLIENTS", ("127.0.0.1",))
+    monkeypatch.setattr(middleware, "TRUSTED_PROXY_CLIENTS", ("127.0.0.1",))
+
+    response = client.post(
+        "/secrets/kraken/test",
+        json={
+            "account_id": "company",
+            "api_key": "apikey-123",
+            "api_secret": "secret-value-123",
+        },
+        headers={
+            "X-Account-ID": "company",
+            "X-MFA-Context": "verified",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "TLS termination required (https only)."


### PR DESCRIPTION
## Summary
- ensure the secrets service treats ingress-forwarded HTTPS schemes as secure
- add shared middleware configuring trusted hosts and respecting forwarded proto headers
- document the expected X-Forwarded-Proto header on the ingress manifest and cover the behavior with a regression test

## Testing
- pytest tests/secrets

------
https://chatgpt.com/codex/tasks/task_e_68dd2bda5ef08321aeb9f174e7388c12