### PR TITLE
Handle dataclass intents in policy service

### DIFF
--- a/services/policy/policy_service.py
+++ b/services/policy/policy_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
@@ -90,6 +91,13 @@ def decide_policy_intent(request: PolicyDecisionRequest) -> PolicyIntent:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to generate policy intent.",
         ) from exc
+
+    if is_dataclass(intent_payload):
+        intent_payload = asdict(intent_payload)
+    elif hasattr(intent_payload, "model_dump") and callable(intent_payload.model_dump):
+        intent_payload = intent_payload.model_dump()
+    elif hasattr(intent_payload, "dict") and callable(intent_payload.dict):
+        intent_payload = intent_payload.dict()
 
     if not isinstance(intent_payload, dict):
         raise HTTPException(

--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+if "metrics" not in sys.modules:
+    metrics_stub = types.ModuleType("metrics")
+    metrics_stub.setup_metrics = lambda app: None
+    metrics_stub.record_abstention_rate = lambda *args, **kwargs: None
+    metrics_stub.record_drift_score = lambda *args, **kwargs: None
+    sys.modules["metrics"] = metrics_stub
+
+from services.policy import policy_service
+
+
+@dataclass
+class DataclassIntent:
+    action: str
+    side: str
+    qty: float
+    preference: str
+    type: str
+    limit_px: float | None
+    tif: str | None
+    tp: float | None
+    sl: float | None
+    expected_edge_bps: float
+    expected_cost_bps: float
+    confidence: float
+
+
+def test_decide_policy_accepts_dataclass_intent(monkeypatch):
+    expected_intent = DataclassIntent(
+        action="enter",
+        side="buy",
+        qty=5.0,
+        preference="maker",
+        type="limit",
+        limit_px=101.5,
+        tif="GTC",
+        tp=120.0,
+        sl=95.0,
+        expected_edge_bps=25.0,
+        expected_cost_bps=6.5,
+        confidence=0.87,
+    )
+
+    monkeypatch.setattr(
+        policy_service,
+        "models",
+        SimpleNamespace(predict_intent=lambda **_: expected_intent),
+    )
+
+    client = TestClient(policy_service.app)
+
+    payload = {
+        "account_id": str(uuid4()),
+        "symbol": "BTC-USD",
+        "features": [0.1, -0.2, 0.3],
+        "book_snapshot": {"bid": 30_000, "ask": 30_010},
+        "account_state": {"positions": {}},
+    }
+
+    response = client.post("/policy/decide", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "action": expected_intent.action,
+        "side": expected_intent.side,
+        "qty": expected_intent.qty,
+        "preference": expected_intent.preference,
+        "type": expected_intent.type,
+        "limit_px": expected_intent.limit_px,
+        "tif": expected_intent.tif,
+        "tp": expected_intent.tp,
+        "sl": expected_intent.sl,
+        "expected_edge_bps": expected_intent.expected_edge_bps,
+        "expected_cost_bps": expected_intent.expected_cost_bps,
+        "confidence": expected_intent.confidence,
+    }


### PR DESCRIPTION
## Summary
- normalize policy intents returned by the model into dictionaries so dataclass responses are accepted
- add a fastapi test covering a successful decision path and validating the serialized response

## Testing
- pytest tests/policy/test_policy_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2cf32ae08321959e0fff20a84008