### PR TITLE
Ensure policy service registers metrics endpoint

### DIFF
--- a/services/policy/policy_service.py
+++ b/services/policy/policy_service.py
@@ -62,7 +62,9 @@ class PolicyIntent(BaseModel):
     confidence: float = Field(..., description="Confidence score for the decision")
 
 
-app = FastAPI(title="Policy Service")
+APP_VERSION = "2.0.0"
+
+app = FastAPI(title="Policy Service", version=APP_VERSION)
 setup_metrics(app)
 
 


### PR DESCRIPTION
## Summary
- instantiate the policy FastAPI app once with version metadata and attach metrics
- update the policy service tests to stub a metrics endpoint and add coverage for /metrics

## Testing
- pytest tests/policy/test_policy_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd333454108321a1037d3377c3bf05