### PR TITLE
Refactor policy service to shared schemas

### DIFF
--- a/policy_service.py
+++ b/policy_service.py
@@ -4,188 +4,55 @@ from __future__ import annotations
 
 import os
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import httpx
 from fastapi import FastAPI, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from services.models.model_server import Intent, predict_intent
-
+from services.common.schemas import (
+    ActionTemplate,
+    BookSnapshot,
+    ConfidenceMetrics,
+    FeeBreakdown,
+    PolicyDecisionRequest,
+    PolicyDecisionResponse,
+    PolicyState,
+)
+from services.models.model_server import predict_intent
 
 from metrics import record_abstention_rate, record_drift_score, setup_metrics
 
+FEES_SERVICE_URL = os.getenv("FEES_SERVICE_URL", "http://fees-service")
+FEES_REQUEST_TIMEOUT = float(os.getenv("FEES_REQUEST_TIMEOUT", "1.0"))
+CONFIDENCE_THRESHOLD = float(os.getenv("POLICY_CONFIDENCE_THRESHOLD", "0.55"))
 
+KRAKEN_PRECISION: Dict[str, Dict[str, float]] = {
+    "BTC-USD": {"tick": 0.1, "lot": 0.0001},
+    "ETH-USD": {"tick": 0.01, "lot": 0.001},
+    "SOL-USD": {"tick": 0.001, "lot": 0.01},
+}
 
-
-class BookSnapshotPayload(BaseModel):
-    """Minimal book snapshot used to evaluate the intent."""
-
-    mid_price: float = Field(..., gt=0.0, description="Mid price used during evaluation")
-    spread_bps: float = Field(
-        ..., ge=0.0, description="Bid/ask spread in basis points at decision time"
-    )
-    imbalance: float = Field(
-        ..., ge=-1.0, le=1.0, description="Normalized order book imbalance"
-    )
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [
-                {
-                    "mid_price": 30125.4,
-                    "spread_bps": 2.4,
-                    "imbalance": 0.12,
-                }
-            ]
-        }
-    )
-
-
-FeaturesPayload = Union[List[float], Dict[str, float]]
-
-
-class PolicyDecisionRequest(BaseModel):
-    """Incoming payload describing the desired trade and market context."""
-
-    account_id: str = Field(..., description="Trading account identifier")
-    symbol: str = Field(..., description="Kraken trading pair, e.g. BTC-USD")
-    side: str = Field(..., pattern="^(?i)(buy|sell)$", description="Intended trade side")
-    qty: float = Field(..., gt=0.0, description="Requested order quantity")
-    price: float = Field(..., gt=0.0, description="Requested limit price")
-    impact_bps: float = Field(
-        0.0,
-        ge=0.0,
-        description="Estimated market impact in basis points to include in the gate",
-    )
-    features: FeaturesPayload = Field(
-        default_factory=list,
-        description="Feature vector consumed by the intent model",
-    )
-    book_snapshot: BookSnapshotPayload = Field(
-        ..., description="Order book snapshot aligned with the request"
-    )
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [
-                {
-                    "account_id": "company",
-                    "symbol": "BTC-USD",
-                    "side": "buy",
-                    "qty": 0.5234,
-                    "price": 30120.45,
-                    "impact_bps": 1.2,
-                    "features": [0.4, -0.1, 2.8],
-                    "book_snapshot": {
-                        "mid_price": 30125.4,
-                        "spread_bps": 2.4,
-                        "imbalance": 0.12,
-                    },
-                }
-            ]
-        }
-    )
-
-    @field_validator("symbol")
-    @classmethod
-    def _normalize_symbol(cls, value: str) -> str:
-        return value.upper()
-
-    @property
-    def features_vector(self) -> List[float]:
-        """Return the model-ready feature vector."""
-
-        payload = self.features
-        if isinstance(payload, dict):
-            return [float(v) for _, v in sorted(payload.items())]
-        if isinstance(payload, (list, tuple)):
-            return [float(v) for v in payload]
-        return []
-
-
-class PolicyDecisionResponse(BaseModel):
-    """Decision payload returned by the policy service."""
-
-    account_id: str = Field(..., description="Trading account identifier")
-    symbol: str = Field(..., description="Trading pair evaluated")
-    action: str = Field(..., description="Model-selected action (maker/taker/hold)")
-    side: str = Field(..., description="Execution side (buy/sell/none)")
-    order_type: str = Field(..., description="Order type to use when approved")
-    qty: float = Field(..., ge=0.0, description="Quantity snapped to Kraken precision")
-    price: float = Field(..., ge=0.0, description="Price snapped to Kraken precision")
-    limit_px: float | None = Field(
-        None, description="Limit price to submit when action proceeds"
-    )
-    tif: str | None = Field(None, description="Optional time-in-force policy")
-    take_profit_bps: float = Field(
-        ..., ge=0.0, description="Take-profit distance suggested by the model"
-    )
-    stop_loss_bps: float = Field(
-        ..., ge=0.0, description="Stop-loss distance suggested by the model"
-    )
-    expected_edge_bps: float = Field(
-        ..., description="Edge associated with the selected action"
-    )
-    spread_bps: float = Field(..., ge=0.0, description="Spread at decision time")
-    effective_fee_bps: float = Field(
-        ..., ge=0.0, description="Effective fee fetched from the fee service"
-    )
-    impact_bps: float = Field(..., ge=0.0, description="Impact cost incorporated in the gate")
-    expected_cost_bps: float = Field(
-        ..., ge=0.0, description="Total expected cost including spread, fees, and impact"
-    )
-    confidence: float = Field(
-        ..., ge=0.0, le=1.0, description="Overall confidence score from the model"
-    )
-    approved: bool = Field(..., description="Whether the decision passed gating")
-    reason: str | None = Field(None, description="Optional rejection reason")
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [
-                {
-                    "account_id": "company",
-                    "symbol": "BTC-USD",
-                    "action": "maker",
-                    "side": "buy",
-                    "order_type": "limit",
-                    "qty": 0.5234,
-                    "price": 30120.5,
-                    "limit_px": 30120.5,
-                    "tif": "GTC",
-                    "take_profit_bps": 24.0,
-                    "stop_loss_bps": 12.0,
-                    "expected_edge_bps": 18.6,
-                    "spread_bps": 2.4,
-                    "effective_fee_bps": 4.0,
-                    "impact_bps": 1.2,
-                    "expected_cost_bps": 7.6,
-                    "confidence": 0.82,
-                    "approved": True,
-                    "reason": None,
-                }
-            ]
-        }
-    )
-
-
-app = FastAPI(title="Policy Service")
+app = FastAPI(title="Policy Service", version="2.0.0")
 setup_metrics(app)
 
 
-app = FastAPI(title="Policy Service", version="2.0.0")
+def _default_state() -> PolicyState:
+    return PolicyState(regime="unknown", volatility=0.0, liquidity_score=0.0, conviction=0.0)
 
 
 def _resolve_precision(symbol: str) -> Dict[str, float]:
     return KRAKEN_PRECISION.get(symbol.upper(), {"tick": 0.01, "lot": 0.0001})
 
 
-async def _fetch_effective_fee(
-    account_id: str, symbol: str, liquidity: str, notional: float
-) -> float:
-    """Fetch effective fee basis points for the decision."""
+def _snap(value: float, step: float) -> float:
+    if step <= 0:
+        return float(value)
+    quant = Decimal(str(step))
+    snapped = (Decimal(str(value)) / quant).to_integral_value(rounding=ROUND_HALF_UP) * quant
+    return float(snapped)
 
+
+async def _fetch_effective_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
     liquidity_normalized = liquidity.lower() if liquidity else "maker"
     if liquidity_normalized not in {"maker", "taker"}:
         liquidity_normalized = "maker"
@@ -202,12 +69,12 @@ async def _fetch_effective_fee(
         try:
             response = await client.get("/fees/effective", params=params, headers=headers)
             response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - surface upstream errors
             raise HTTPException(
                 status_code=exc.response.status_code,
                 detail="Fee service returned an error",
             ) from exc
-        except httpx.HTTPError as exc:
+        except httpx.HTTPError as exc:  # pragma: no cover - network failures
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Unable to contact fee service",
@@ -231,39 +98,13 @@ async def _fetch_effective_fee(
         ) from exc
 
 
-def _select_template(intent: Intent, liquidity: str):
-    templates = intent.action_templates or []
-    for template in templates:
-        if template.name.lower() == liquidity.lower():
-            return template
-    if templates:
-        return max(templates, key=lambda template: template.edge_bps)
-    return ()
-
-
-def _confidence(intent: Intent) -> float:
-    metrics = intent.confidence
-    if metrics.overall_confidence is not None:
-        return float(metrics.overall_confidence)
-    composite = (
-        metrics.model_confidence
-        + metrics.state_confidence
-        + metrics.execution_confidence
-    ) / 3.0
-    return float(round(composite, 4))
-
-
 @app.get("/health", tags=["health"])
 async def health() -> Dict[str, str]:
-    """Liveness probe for the service."""
-
     return {"status": "ok"}
 
 
 @app.get("/ready", tags=["health"])
 async def ready() -> Dict[str, str]:
-    """Readiness probe ensuring critical dependencies are importable."""
-
     if predict_intent is None:  # pragma: no cover - defensive guard
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -278,11 +119,9 @@ async def ready() -> Dict[str, str]:
     status_code=status.HTTP_200_OK,
 )
 async def decide_policy(request: PolicyDecisionRequest) -> PolicyDecisionResponse:
-    """Evaluate the latest intent and return a gated execution decision."""
-
-    precision = _resolve_precision(request.symbol)
+    precision = _resolve_precision(request.instrument)
     snapped_price = _snap(request.price, precision["tick"])
-    snapped_qty = _snap(request.qty, precision["lot"])
+    snapped_qty = _snap(request.quantity, precision["lot"])
 
     if snapped_price <= 0 or snapped_qty <= 0:
         raise HTTPException(
@@ -290,31 +129,141 @@ async def decide_policy(request: PolicyDecisionRequest) -> PolicyDecisionRespons
             detail="Snapped price or quantity is non-positive",
         )
 
-
-    try:
-        response = PolicyDecisionResponse(**result)
-    except ValidationError as exc:
+    if request.book_snapshot is None:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Model response failed validation",
-        ) from exc
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Book snapshot is required for policy evaluation",
+        )
 
-    drift = 0.0
-    account_state = request.account_state or {}
-    if isinstance(account_state, dict):
-        raw = account_state.get("drift_score", 0.0)
-        try:
-            drift = float(raw)
-        except (TypeError, ValueError):
-            drift = 0.0
-    record_drift_score(request.account_id, request.symbol, drift)
+    book_snapshot = request.book_snapshot
+    features: List[float] = [float(value) for value in request.features]
 
-    abstain = 0.0
-    action = (response.action or "").lower()
-    side = (response.side or "").lower()
-    if action in {"hold", "abstain"} or side in {"none", "flat"}:
-        abstain = 1.0
-    record_abstention_rate(request.account_id, request.symbol, abstain)
+    intent = predict_intent(
+        account_id=request.account_id,
+        symbol=request.instrument,
+        features=features,
+        book_snapshot=book_snapshot,
+    )
+
+    notional = float(Decimal(str(snapped_price)) * Decimal(str(snapped_qty)))
+    maker_fee_bps = await _fetch_effective_fee(request.account_id, request.instrument, "maker", notional)
+    taker_fee_bps = await _fetch_effective_fee(request.account_id, request.instrument, "taker", notional)
+
+    effective_fee = FeeBreakdown(
+        currency=request.fee.currency,
+        maker=round(maker_fee_bps, 4),
+        taker=round(taker_fee_bps, 4),
+        maker_detail=request.fee.maker_detail,
+        taker_detail=request.fee.taker_detail,
+    )
+
+    caller_confidence = request.confidence
+    confidence = intent.confidence
+    if caller_confidence is not None:
+        confidence = ConfidenceMetrics(
+            model_confidence=max(confidence.model_confidence, caller_confidence.model_confidence),
+            state_confidence=max(confidence.state_confidence, caller_confidence.state_confidence),
+            execution_confidence=max(
+                confidence.execution_confidence, caller_confidence.execution_confidence
+            ),
+            overall_confidence=max(
+                confidence.overall_confidence or 0.0,
+                caller_confidence.overall_confidence or 0.0,
+            ),
+        )
+
+    expected_edge = float(intent.edge_bps or 0.0)
+    maker_edge = round(expected_edge - effective_fee.maker, 4)
+    taker_edge = round(expected_edge - effective_fee.taker, 4)
+
+    template_lookup = {template.name.lower(): template for template in intent.action_templates or []}
+    maker_template = template_lookup.get("maker")
+    taker_template = template_lookup.get("taker")
+
+    action_templates = [
+        ActionTemplate(
+            name="maker",
+            venue_type="maker",
+            edge_bps=maker_edge,
+            fee_bps=round(effective_fee.maker, 4),
+            confidence=round(
+                maker_template.confidence if maker_template else confidence.execution_confidence, 4
+            ),
+        ),
+        ActionTemplate(
+            name="taker",
+            venue_type="taker",
+            edge_bps=taker_edge,
+            fee_bps=round(effective_fee.taker, 4),
+            confidence=round(
+                taker_template.confidence
+                if taker_template
+                else confidence.execution_confidence * 0.95,
+                4,
+            ),
+        ),
+    ]
+
+    selected_template = next(
+        (
+            template
+            for template in action_templates
+            if template.name.lower() == (intent.selected_action or "").lower()
+        ),
+        None,
+    )
+    if selected_template is None and action_templates:
+        selected_template = max(action_templates, key=lambda template: template.edge_bps)
+
+    fee_adjusted_edge = selected_template.edge_bps if selected_template else 0.0
+
+    approved = (
+        intent.approved
+        and fee_adjusted_edge > 0
+        and (confidence.overall_confidence or 0.0) >= CONFIDENCE_THRESHOLD
+    )
+
+    reason = intent.reason
+    selected_action = intent.selected_action or "abstain"
+    if not approved:
+        if reason is None:
+            if (confidence.overall_confidence or 0.0) < CONFIDENCE_THRESHOLD:
+                reason = "Confidence below threshold"
+            else:
+                reason = "Fee-adjusted edge non-positive"
+        selected_action = "abstain"
+        fee_adjusted_edge = min(fee_adjusted_edge, 0.0)
+    else:
+        selected_action = selected_template.name if selected_template else selected_action
+
+    take_profit = request.take_profit_bps or intent.take_profit_bps or 0.0
+    stop_loss = request.stop_loss_bps or intent.stop_loss_bps or 0.0
+
+    state_model = request.state or _default_state()
+    drift_value = getattr(state_model, "conviction", 0.0)
+    try:
+        drift_value = float(drift_value)
+    except (TypeError, ValueError):
+        drift_value = 0.0
+
+    record_drift_score(request.account_id, request.instrument, drift_value)
+    abstain_metric = 0.0 if approved and selected_action != "abstain" else 1.0
+    record_abstention_rate(request.account_id, request.instrument, abstain_metric)
+
+    response = PolicyDecisionResponse(
+        approved=approved,
+        reason=reason,
+        effective_fee=effective_fee,
+        expected_edge_bps=round(expected_edge, 4),
+        fee_adjusted_edge_bps=round(fee_adjusted_edge, 4),
+        selected_action=selected_action,
+        action_templates=action_templates,
+        confidence=confidence,
+        features=features,
+        book_snapshot=book_snapshot,
+        state=state_model,
+        take_profit_bps=round(float(take_profit), 4),
+        stop_loss_bps=round(float(stop_loss), 4),
+    )
 
     return response
-

--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
-from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 if "metrics" not in sys.modules:
@@ -15,71 +15,97 @@ if "metrics" not in sys.modules:
     metrics_stub.record_drift_score = lambda *args, **kwargs: None
     sys.modules["metrics"] = metrics_stub
 
-from services.policy import policy_service
+from services.common.schemas import ActionTemplate, ConfidenceMetrics, PolicyDecisionResponse
+
+import policy_service
 
 
 @dataclass
 class DataclassIntent:
-    action: str
-    side: str
-    qty: float
-    preference: str
-    type: str
-    limit_px: float | None
-    tif: str | None
-    tp: float | None
-    sl: float | None
-    expected_edge_bps: float
-    expected_cost_bps: float
-    confidence: float
+    edge_bps: float
+    confidence: ConfidenceMetrics
+    take_profit_bps: float
+    stop_loss_bps: float
+    selected_action: str
+    action_templates: list[ActionTemplate]
+    approved: bool
+    reason: str | None = None
 
 
-def test_decide_policy_accepts_dataclass_intent(monkeypatch):
-    expected_intent = DataclassIntent(
-        action="enter",
-        side="buy",
-        qty=5.0,
-        preference="maker",
-        type="limit",
-        limit_px=101.5,
-        tif="GTC",
-        tp=120.0,
-        sl=95.0,
-        expected_edge_bps=25.0,
-        expected_cost_bps=6.5,
-        confidence=0.87,
+@pytest.fixture(name="client")
+def _client() -> TestClient:
+    return TestClient(policy_service.app)
+
+
+def test_decide_policy_accepts_dataclass_intent(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    intent = DataclassIntent(
+        edge_bps=20.0,
+        confidence=ConfidenceMetrics(
+            model_confidence=0.4,
+            state_confidence=0.4,
+            execution_confidence=0.4,
+            overall_confidence=0.4,
+        ),
+        take_profit_bps=30.0,
+        stop_loss_bps=10.0,
+        selected_action="maker",
+        action_templates=[
+            ActionTemplate(
+                name="maker",
+                venue_type="maker",
+                edge_bps=20.0,
+                fee_bps=0.0,
+                confidence=0.5,
+            ),
+            ActionTemplate(
+                name="taker",
+                venue_type="taker",
+                edge_bps=18.0,
+                fee_bps=0.0,
+                confidence=0.45,
+            ),
+        ],
+        approved=True,
     )
 
-    monkeypatch.setattr(
-        policy_service,
-        "models",
-        SimpleNamespace(predict_intent=lambda **_: expected_intent),
-    )
+    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
+        return {"maker": 4.0, "taker": 7.0}[liquidity]
 
-    client = TestClient(policy_service.app)
+    monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
+    monkeypatch.setattr(policy_service, "predict_intent", lambda **_: intent)
 
     payload = {
         "account_id": str(uuid4()),
-        "symbol": "BTC-USD",
+        "order_id": "unit-test",
+        "instrument": "BTC-USD",
+        "side": "BUY",
+        "quantity": 0.5,
+        "price": 100.0,
+        "fee": {"currency": "USD", "maker": 4.0, "taker": 6.0},
         "features": [0.1, -0.2, 0.3],
-        "book_snapshot": {"bid": 30_000, "ask": 30_010},
-        "account_state": {"positions": {}},
+        "book_snapshot": {"mid_price": 100.5, "spread_bps": 2.0, "imbalance": 0.1},
+        "state": {
+            "regime": "expansion",
+            "volatility": 0.2,
+            "liquidity_score": 0.9,
+            "conviction": 0.7,
+        },
+        "confidence": {
+            "model_confidence": 0.9,
+            "state_confidence": 0.85,
+            "execution_confidence": 0.88,
+        },
     }
 
     response = client.post("/policy/decide", json=payload)
-
     assert response.status_code == 200
-    assert response.json() == {
-        "action": expected_intent.action,
-        "side": expected_intent.side,
-        "qty": expected_intent.qty,
-        "preference": expected_intent.preference,
-        "type": expected_intent.type,
-        "limit_px": expected_intent.limit_px,
-        "tif": expected_intent.tif,
-        "tp": expected_intent.tp,
-        "sl": expected_intent.sl,
-        "expected_edge_bps": expected_intent.expected_edge_bps,
-        "expected_cost_bps": expected_intent.expected_cost_bps,
-        "confidence": expected_intent.confidence,
-    }
+
+    body = PolicyDecisionResponse.model_validate(response.json())
+
+    assert body.approved is True
+    assert body.selected_action == "maker"
+    assert body.fee_adjusted_edge_bps == pytest.approx(16.0)
+    assert body.confidence.overall_confidence >= 0.8
+    assert body.state.regime == "expansion"
+    assert body.effective_fee.maker == pytest.approx(4.0)
+    assert body.effective_fee.taker == pytest.approx(7.0)

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -1,12 +1,24 @@
+"""Integration tests for the standalone policy service module."""
+
 from __future__ import annotations
 
+import sys
+import types
 from decimal import Decimal
+from typing import List
 
 import pytest
 from fastapi.testclient import TestClient
 
+if "metrics" not in sys.modules:
+    metrics_stub = types.ModuleType("metrics")
+    metrics_stub.setup_metrics = lambda app: None
+    metrics_stub.record_abstention_rate = lambda *args, **kwargs: None
+    metrics_stub.record_drift_score = lambda *args, **kwargs: None
+    sys.modules["metrics"] = metrics_stub
+
 import policy_service
-from services.common.schemas import ActionTemplate, ConfidenceMetrics
+from services.common.schemas import ActionTemplate, ConfidenceMetrics, PolicyDecisionResponse
 from services.models.model_server import Intent
 
 
@@ -15,15 +27,7 @@ def _client() -> TestClient:
     return TestClient(policy_service.app)
 
 
-def _intent(
-    *,
-    edge_bps: float,
-    maker_edge: float,
-    taker_edge: float,
-    approved: bool,
-    selected: str,
-    reason: str | None = None,
-) -> Intent:
+def _intent(*, edge_bps: float, approved: bool, selected: str, reason: str | None = None) -> Intent:
     return Intent(
         edge_bps=edge_bps,
         confidence=ConfidenceMetrics(
@@ -39,16 +43,16 @@ def _intent(
             ActionTemplate(
                 name="maker",
                 venue_type="maker",
-                edge_bps=maker_edge,
+                edge_bps=edge_bps,
                 fee_bps=0.0,
-                confidence=0.9,
+                confidence=0.91,
             ),
             ActionTemplate(
                 name="taker",
                 venue_type="taker",
-                edge_bps=taker_edge,
+                edge_bps=edge_bps - 4.0,
                 fee_bps=0.0,
-                confidence=0.85,
+                confidence=0.82,
             ),
         ],
         approved=approved,
@@ -56,13 +60,17 @@ def _intent(
     )
 
 
+def _validate_response(payload: dict) -> PolicyDecisionResponse:
+    return PolicyDecisionResponse.model_validate(payload)
+
+
 def test_policy_decide_approves_when_edge_beats_costs(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    recorded: dict[str, object] = {}
+    recorded: List[dict[str, object]] = []
 
     async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
-        recorded.update(
+        recorded.append(
             {
                 "account_id": account_id,
                 "symbol": symbol,
@@ -70,94 +78,108 @@ def test_policy_decide_approves_when_edge_beats_costs(
                 "notional": notional,
             }
         )
-        return 4.5
+        return {"maker": 4.5, "taker": 7.5}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
         policy_service,
         "predict_intent",
-        lambda **_: _intent(
-            edge_bps=22.0,
-            maker_edge=18.0,
-            taker_edge=12.0,
-            approved=True,
-            selected="maker",
-        ),
+        lambda **_: _intent(edge_bps=22.0, approved=True, selected="maker"),
     )
 
     payload = {
         "account_id": "company",
-        "symbol": "btc-usd",
-        "side": "buy",
-        "qty": 0.1234567,
+        "order_id": "abc-123",
+        "instrument": "BTC-USD",
+        "side": "BUY",
+        "quantity": 0.1234567,
         "price": 30120.4567,
-        "impact_bps": 1.0,
-        "features": {"alpha": 0.4, "beta": -0.1, "gamma": 2.8},
+        "fee": {"currency": "USD", "maker": 4.0, "taker": 6.0},
+        "features": [0.4, -0.1, 2.8],
         "book_snapshot": {"mid_price": 30125.4, "spread_bps": 2.4, "imbalance": 0.05},
     }
 
     response = client.post("/policy/decide", json=payload)
     assert response.status_code == 200
-    data = response.json()
 
-    assert data["approved"] is True
-    assert data["action"] == "maker"
-    assert data["side"] == "buy"
-    assert data["qty"] == pytest.approx(0.1235)
-    assert data["price"] == pytest.approx(30120.5)
-    assert data["limit_px"] == pytest.approx(30120.5)
-    assert data["effective_fee_bps"] == pytest.approx(4.5)
-    assert data["expected_edge_bps"] == pytest.approx(18.0)
-    assert data["expected_cost_bps"] == pytest.approx(7.9)
+    body = _validate_response(response.json())
 
-    expected_notional = float(Decimal("30120.5") * Decimal("0.1235"))
-    assert recorded == {
-        "account_id": "company",
-        "symbol": "BTC-USD",
-        "liquidity": "maker",
-        "notional": pytest.approx(expected_notional),
-    }
+    assert body.approved is True
+    assert body.selected_action == "maker"
+    assert body.effective_fee.maker == pytest.approx(4.5)
+    assert body.effective_fee.taker == pytest.approx(7.5)
+    assert body.expected_edge_bps == pytest.approx(22.0)
+    assert body.fee_adjusted_edge_bps == pytest.approx(17.5)
+
+    maker_template = next(template for template in body.action_templates if template.name == "maker")
+    taker_template = next(template for template in body.action_templates if template.name == "taker")
+    assert maker_template.edge_bps == pytest.approx(17.5)
+    assert maker_template.fee_bps == pytest.approx(4.5)
+    assert taker_template.edge_bps == pytest.approx(14.5)
+    assert taker_template.fee_bps == pytest.approx(7.5)
+
+    assert body.features == pytest.approx(payload["features"])  # type: ignore[arg-type]
+    assert body.book_snapshot.mid_price == pytest.approx(payload["book_snapshot"]["mid_price"])
+    assert body.state.regime == "unknown"
+    assert body.take_profit_bps == pytest.approx(25.0)
+    assert body.stop_loss_bps == pytest.approx(12.0)
+
+    snapped_price = Decimal("30120.5")
+    snapped_quantity = Decimal("0.1235")
+    expected_notional = float(snapped_price * snapped_quantity)
+    assert recorded == [
+        {
+            "account_id": "company",
+            "symbol": "BTC-USD",
+            "liquidity": "maker",
+            "notional": pytest.approx(expected_notional),
+        },
+        {
+            "account_id": "company",
+            "symbol": "BTC-USD",
+            "liquidity": "taker",
+            "notional": pytest.approx(expected_notional),
+        },
+    ]
 
 
 def test_policy_decide_rejects_when_costs_exceed_edge(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    async def _fake_fee(*_: object, **__: object) -> float:
-        return 9.0
+    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
+        return {"maker": 18.0, "taker": 21.0}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
         policy_service,
         "predict_intent",
-        lambda **_: _intent(
-            edge_bps=10.0,
-            maker_edge=8.0,
-            taker_edge=6.0,
-            approved=True,
-            selected="maker",
-        ),
+        lambda **_: _intent(edge_bps=10.0, approved=True, selected="maker"),
     )
 
     payload = {
         "account_id": "company",
-        "symbol": "BTC-USD",
-        "side": "sell",
-        "qty": 0.25,
+        "order_id": "def-456",
+        "instrument": "BTC-USD",
+        "side": "SELL",
+        "quantity": 0.25,
         "price": 25000.0,
-        "impact_bps": 3.0,
+        "fee": {"currency": "USD", "maker": 4.0, "taker": 6.0},
         "features": [0.1, 0.2],
         "book_snapshot": {"mid_price": 25010.0, "spread_bps": 4.0, "imbalance": -0.2},
     }
 
     response = client.post("/policy/decide", json=payload)
     assert response.status_code == 200
-    data = response.json()
 
-    assert data["approved"] is False
-    assert data["action"] == "hold"
-    assert data["side"] == "none"
-    assert data["qty"] == 0.0
-    assert data["reason"] == "Fee-adjusted edge non-positive"
+    body = _validate_response(response.json())
+
+    assert body.approved is False
+    assert body.selected_action == "abstain"
+    assert body.reason == "Fee-adjusted edge non-positive"
+    assert body.fee_adjusted_edge_bps == pytest.approx(-8.0)
+
+    maker_template = next(template for template in body.action_templates if template.name == "maker")
+    assert maker_template.edge_bps <= 0.0
 
 
 def test_health_endpoints(client: TestClient) -> None:
@@ -168,4 +190,3 @@ def test_health_endpoints(client: TestClient) -> None:
     assert ready.status_code == 200
     assert health.json() == {"status": "ok"}
     assert ready.json() == {"status": "ready"}
-


### PR DESCRIPTION
## Summary
- replace bespoke policy request/response models with the shared schemas and update the endpoint to build canonical responses, including fee, confidence, and action template data
- add precision snapping, fee fetching, and gating logic aligned with the shared schema expectations
- update policy service API tests to post the new payload format and assert against PolicyDecisionResponse and ensure dataclass intents remain supported

## Testing
- pytest tests/test_policy_service_api.py tests/policy/test_policy_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd333281748321b517b395e6a8060e