### PR TITLE
Fix policy effective fee parsing for flat responses

### DIFF
--- a/policy_service.py
+++ b/policy_service.py
@@ -214,16 +214,14 @@ async def _fetch_effective_fee(
             ) from exc
 
     payload = response.json()
-    fee_payload = payload.get("fee") if isinstance(payload, dict) else None
-    if not isinstance(fee_payload, dict):
+    if not isinstance(payload, dict):
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Fee service response malformed",
         )
 
-    key = "maker" if liquidity_normalized == "maker" else "taker"
     try:
-        return float(fee_payload[key])
+        return float(payload["bps"])
     except (KeyError, TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,


### PR DESCRIPTION
## Summary
- update `_fetch_effective_fee` to parse the flat `EffectiveFeeResponse` payload returned by the fee service
- add a targeted unit test that exercises `_fetch_effective_fee` with a mocked httpx client and stubs required dependencies
- ensure the policy service API tests can run without the Prometheus client by providing lightweight metrics stubs and an anyio backend fixture

## Testing
- pytest tests/test_policy_service_api.py -k fetch_effective_fee


------
https://chatgpt.com/codex/tasks/task_e_68dd333282188321b8ccc1f79ec83a4b