### PR TITLE
Add kill switch service for risk shutdown

### DIFF
--- a/kill_switch.py
+++ b/kill_switch.py
@@ -1,0 +1,57 @@
+"""FastAPI endpoint for triggering an immediate trading kill switch."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
+
+from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter
+from services.common.security import require_admin_account
+
+app = FastAPI(title="Kill Switch Service")
+
+
+def _normalize_account(account_id: str) -> str:
+    """Normalize account identifiers to canonical form."""
+
+    normalized = account_id.strip().lower()
+    if not normalized:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Account identifier must not be empty.",
+        )
+    return normalized
+
+
+@app.post("/risk/kill")
+def trigger_kill_switch(
+    account_id: str = Query(..., min_length=1),
+    actor_account: str = Depends(require_admin_account),
+) -> Dict[str, Any]:
+    """Trigger the kill switch for the provided account."""
+
+    normalized_account = _normalize_account(account_id)
+
+    activation_ts = datetime.now(timezone.utc)
+
+    timescale = TimescaleAdapter(account_id=normalized_account)
+    timescale.set_kill_switch(
+        engaged=True,
+        reason="Manual kill switch activation",
+        actor=actor_account,
+    )
+
+    kafka = KafkaNATSAdapter(account_id=normalized_account)
+    kafka.publish(
+        topic="risk.events",
+        payload={
+            "event": "KILL_SWITCH_TRIGGERED",
+            "account_id": normalized_account,
+            "actor": actor_account,
+            "timestamp": activation_ts.isoformat(),
+            "actions": ["CANCEL_OPEN_ORDERS", "FLATTEN_POSITIONS"],
+        },
+    )
+
+    return {"status": "ok", "ts": activation_ts.isoformat()}

--- a/tests/services/test_kill_switch.py
+++ b/tests/services/test_kill_switch.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from kill_switch import app
+from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter
+
+
+def setup_function() -> None:
+    KafkaNATSAdapter.reset()
+    TimescaleAdapter.reset()
+
+
+def test_trigger_kill_switch_publishes_event_and_sets_state() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/risk/kill",
+        params={"account_id": "Alpha"},
+        headers={"X-Account-ID": "company"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert "ts" in payload
+
+    history = KafkaNATSAdapter(account_id="alpha").history()
+    assert history, "Kill switch event was not published"
+    last_event = history[-1]
+    assert last_event["topic"] == "risk.events"
+    event_payload = last_event["payload"]
+    assert event_payload["event"] == "KILL_SWITCH_TRIGGERED"
+    assert event_payload["account_id"] == "alpha"
+    assert event_payload["actions"] == ["CANCEL_OPEN_ORDERS", "FLATTEN_POSITIONS"]
+
+    timescale = TimescaleAdapter(account_id="alpha")
+    config = timescale.load_risk_config()
+    assert config["kill_switch"] is True
+    events = timescale.events()["events"]
+    assert any(event["type"] == "kill_switch_engaged" for event in events)


### PR DESCRIPTION
## Summary
- add a dedicated FastAPI kill switch endpoint that enforces admin access, normalises account identifiers, and emits a risk event for downstream systems
- persist kill switch engagement in the shared Timescale adapter so the risk engine observes the disabled state
- cover the endpoint with a regression test that validates Kafka publication and state mutation

## Testing
- pytest tests/services/test_kill_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68dd633653108321b8ec48318c35ac56