### PR TITLE
Add PR security and test workflow

### DIFF
--- a/.github/workflows/pr-security-tests.yml
+++ b/.github/workflows/pr-security-tests.yml
@@ -1,0 +1,216 @@
+name: PR Security and Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  security-and-tests:
+    name: Security Scans and Tests
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.11"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]"
+          pip install bandit ruff mypy pytest-cov
+
+      - name: Run Bandit
+        id: bandit
+        run: bandit -r .
+        continue-on-error: true
+
+      - name: Run Ruff
+        id: ruff
+        run: ruff check .
+        continue-on-error: true
+
+      - name: Run MyPy
+        id: mypy
+        run: mypy .
+        continue-on-error: true
+
+      - name: Run Pytest with coverage
+        id: pytest
+        run: pytest --cov=. --cov-report=term --cov-report=xml
+        continue-on-error: true
+
+      - name: Extract coverage percentage
+        id: coverage
+        if: always()
+        run: |
+          if [ -f coverage.xml ]; then
+            total=$(python - <<'PY'
+import xml.etree.ElementTree as ET
+from decimal import Decimal, ROUND_HALF_UP
+root = ET.parse("coverage.xml").getroot()
+rate = Decimal(root.get('line-rate', '0')) * Decimal(100)
+print(rate.quantize(Decimal('0.1'), rounding=ROUND_HALF_UP))
+PY
+)
+          else
+            total="N/A"
+          fi
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+
+      - name: Download Syft
+        uses: anchore/sbom-action/download-syft@v0.15.4
+        with:
+          syft-version: v1.17.0
+
+      - name: Generate SBOM
+        run: syft dir:. -o json > sbom.json
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-json
+          path: sbom.json
+          if-no-files-found: error
+
+      - name: Run Trivy filesystem scan
+        id: trivy_scan
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          format: json
+          output: trivy-results.json
+          severity: CRITICAL
+          exit-code: 1
+          ignore-unfixed: true
+        continue-on-error: true
+
+      - name: Summarize Trivy findings
+        id: trivy_summary
+        if: always()
+        run: |
+          if [ -f trivy-results.json ]; then
+            critical=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json)
+            total=$(jq '[.Results[].Vulnerabilities[]?] | length' trivy-results.json)
+          else
+            critical=0
+            total=0
+          fi
+          echo "critical_count=$critical" >> "$GITHUB_OUTPUT"
+          echo "total_count=$total" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare PR comment
+        id: prepare_comment
+        if: always()
+        run: |
+          bandit_outcome="${{ steps.bandit.outcome }}"
+          ruff_outcome="${{ steps.ruff.outcome }}"
+          mypy_outcome="${{ steps.mypy.outcome }}"
+          pytest_outcome="${{ steps.pytest.outcome }}"
+
+          to_status() {
+            if [ "$1" = "success" ]; then
+              echo "✅ Passed"
+            else
+              echo "❌ Failed"
+            fi
+          }
+
+          bandit_status=$(to_status "$bandit_outcome")
+          ruff_status=$(to_status "$ruff_outcome")
+          mypy_status=$(to_status "$mypy_outcome")
+          pytest_status=$(to_status "$pytest_outcome")
+          coverage="${{ steps.coverage.outputs.total }}"
+          total_vulns="${{ steps.trivy_summary.outputs.total_count }}"
+          critical_vulns="${{ steps.trivy_summary.outputs.critical_count }}"
+
+          if [ "$coverage" = "" ]; then
+            coverage="N/A"
+          fi
+
+          cat <<'COMMENT' > pr-comment.md
+### Automated Security & Test Summary
+
+| Check | Result |
+| --- | --- |
+| Bandit | BANDIT_STATUS |
+| Ruff | RUFF_STATUS |
+| MyPy | MYPY_STATUS |
+| Pytest (coverage) | PYTEST_STATUS (Coverage: COVERAGE%) |
+
+**Vulnerabilities**
+- Total: TOTAL_VULNS
+- Critical: CRITICAL_VULNS
+COMMENT
+
+          sed -i "s/BANDIT_STATUS/$bandit_status/" pr-comment.md
+          sed -i "s/RUFF_STATUS/$ruff_status/" pr-comment.md
+          sed -i "s/MYPY_STATUS/$mypy_status/" pr-comment.md
+          sed -i "s/PYTEST_STATUS/$pytest_status/" pr-comment.md
+          sed -i "s/COVERAGE/$coverage/" pr-comment.md
+          sed -i "s/TOTAL_VULNS/$total_vulns/" pr-comment.md
+          sed -i "s/CRITICAL_VULNS/$critical_vulns/" pr-comment.md
+
+          {
+            echo "body<<'EOF'"
+            cat pr-comment.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment on pull request
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PR_COMMENT: ${{ steps.prepare_comment.outputs.body }}
+        with:
+          script: |
+            if (!process.env.PR_COMMENT) {
+              core.warning('No PR comment body provided');
+              return;
+            }
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.PR_COMMENT
+            });
+
+      - name: Fail if checks failed or critical vulnerabilities found
+        if: always()
+        run: |
+          status=0
+          if [ "${{ steps.bandit.outcome }}" != "success" ]; then
+            echo "Bandit failed"
+            status=1
+          fi
+          if [ "${{ steps.ruff.outcome }}" != "success" ]; then
+            echo "Ruff failed"
+            status=1
+          fi
+          if [ "${{ steps.mypy.outcome }}" != "success" ]; then
+            echo "MyPy failed"
+            status=1
+          fi
+          if [ "${{ steps.pytest.outcome }}" != "success" ]; then
+            echo "Pytest failed"
+            status=1
+          fi
+          critical="${{ steps.trivy_summary.outputs.critical_count }}"
+          if [ -z "$critical" ]; then
+            critical=0
+          fi
+          if [ "$critical" != "0" ]; then
+            echo "Critical vulnerabilities detected"
+            status=1
+          fi
+          exit $status


### PR DESCRIPTION
## Summary
- add a pull_request workflow that runs bandit, ruff, mypy, and pytest with coverage
- integrate trivy scanning and syft SBOM generation with artifact upload
- post a PR comment summarizing results and fail the run when critical vulnerabilities are detected

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd6353becc83219fceae3f1c361efc