### PR TITLE
Add restrictive network policy for Aether services

### DIFF
--- a/deploy/k8s/base/networkpolicies/kustomization.yaml
+++ b/deploy/k8s/base/networkpolicies/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - egress-marketdata.yaml
   - ingress-risk.yaml
+  - restrictive-egress-ingress.yaml

--- a/deploy/k8s/base/networkpolicies/restrictive-egress-ingress.yaml
+++ b/deploy/k8s/base/networkpolicies/restrictive-egress-ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: aether-restrictive-egress
+  labels:
+    app.kubernetes.io/component: network
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - ipBlock:
+            cidr: 52.32.0.0/11
+      ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - ipBlock:
+            cidr: 104.16.0.0/13
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
## Summary
- add a namespace-wide network policy that restricts ingress to Aether pods and the NGINX ingress controller while limiting egress to Kraken and CoinGecko endpoints
- include the new policy in the networkpolicies kustomization manifest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd634aa4f88321937c9e984f284587