### PR TITLE
feat: add SQLAlchemy config service endpoints

### DIFF
--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -2,95 +2,126 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from config_service import ConfigChangeStore, app
+from config_service import app, reset_state, set_guarded_keys
 
 
 def setup_function() -> None:
-    ConfigChangeStore.reset()
+    reset_state()
+    set_guarded_keys(set())
 
 
-def test_non_guarded_change_applies_immediately() -> None:
-    ConfigChangeStore.set_guarded_keys({"risk.limits"})
+def test_update_and_history_for_account() -> None:
     client = TestClient(app)
 
     response = client.post(
         "/config/update",
-        json={"key": "features.toggle_x", "new_value": True, "author": "alice"},
+        params={"account_id": "acct-1"},
+        json={"key": "features.toggle_x", "value": True, "author": "alice"},
     )
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "applied"
-    assert body["requires_second_approval"] is False
     assert body["version"] == 1
-    assert body["approvals"] == ["alice"]
+    assert body["approvers"] == ["alice"]
+    assert body["required_approvals"] == 1
 
-    assert ConfigChangeStore.pending_changes() == ()
-    versions = ConfigChangeStore.config_versions()
-    assert len(versions) == 1
-    latest = versions[0]
-    assert latest.config_key == "features.toggle_x"
-    assert latest.value is True
-    assert latest.approvals == ("alice",)
+    current = client.get("/config/current", params={"account_id": "acct-1"})
+    assert current.status_code == 200
+    current_body = current.json()
+    assert set(current_body.keys()) == {"features.toggle_x"}
+    current_entry = current_body["features.toggle_x"]
+    assert current_entry["account_id"] == "acct-1"
+    assert current_entry["key"] == "features.toggle_x"
+    assert current_entry["value"] is True
+    assert current_entry["version"] == 1
+    assert current_entry["approvers"] == ["alice"]
+    assert "id" in current_entry
+    assert "ts" in current_entry
 
-    audit_actions = [entry.action for entry in ConfigChangeStore.audit_entries()]
-    assert audit_actions == ["config_update_requested", "config_update_applied"]
+    history = client.get(
+        "/config/history",
+        params={"account_id": "acct-1", "key": "features.toggle_x"},
+    )
+    assert history.status_code == 200
+    history_body = history.json()
+    assert len(history_body) == 1
+    assert history_body[0]["version"] == 1
+    assert history_body[0]["approvers"] == ["alice"]
+
+    second_response = client.post(
+        "/config/update",
+        params={"account_id": "acct-1"},
+        json={"key": "features.toggle_x", "value": False, "author": "bob"},
+    )
+    assert second_response.status_code == 200
+    second_body = second_response.json()
+    assert second_body["version"] == 2
+    assert second_body["approvers"] == ["bob"]
+
+    history_body = client.get(
+        "/config/history",
+        params={"account_id": "acct-1", "key": "features.toggle_x"},
+    ).json()
+    assert [entry["version"] for entry in history_body] == [1, 2]
 
 
-def test_guarded_change_requires_two_distinct_authors() -> None:
-    ConfigChangeStore.set_guarded_keys({"risk.max_notional"})
+def test_guarded_key_requires_two_authors() -> None:
+    set_guarded_keys({"risk.max_notional"})
     client = TestClient(app)
 
-    response = client.post(
+    first = client.post(
         "/config/update",
-        json={
-            "key": "risk.max_notional",
-            "new_value": {"notional": 1_000_000},
-            "author": "alice",
-        },
+        params={"account_id": "acct-77"},
+        json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "alice"},
     )
-    assert response.status_code == 200
-    body = response.json()
-    assert body["status"] == "pending"
-    assert body["version"] is None
-    assert body["approvals"] == ["alice"]
-    assert body["requires_second_approval"] is True
+    assert first.status_code == 202
+    first_body = first.json()
+    assert first_body["status"] == "pending"
+    assert first_body["approvers"] == ["alice"]
+    assert first_body["version"] is None
+    assert first_body["required_approvals"] == 2
 
-    pending_response = client.get("/config/pending")
-    assert pending_response.status_code == 200
-    pending = pending_response.json()
-    assert len(pending) == 1
-    assert pending[0]["request_id"] == body["request_id"]
+    current = client.get("/config/current", params={"account_id": "acct-77"})
+    assert current.status_code == 200
+    assert current.json() == {}
 
-    duplicate = client.post(
-        "/config/approve",
-        json={"request_id": body["request_id"], "author": "alice"},
+    duplicate_author = client.post(
+        "/config/update",
+        params={"account_id": "acct-77"},
+        json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "alice"},
     )
-    assert duplicate.status_code == 400
-    assert duplicate.json()["detail"] == "duplicate_approval"
+    assert duplicate_author.status_code == 400
+    assert duplicate_author.json()["detail"] == "second_author_required"
 
-    approval = client.post(
-        "/config/approve",
-        json={"request_id": body["request_id"], "author": "bob"},
+    mismatched_value = client.post(
+        "/config/update",
+        params={"account_id": "acct-77"},
+        json={"key": "risk.max_notional", "value": {"notional": 2000}, "author": "bob"},
     )
-    assert approval.status_code == 200
-    approval_body = approval.json()
-    assert approval_body["status"] == "applied"
-    assert approval_body["version"] == 1
-    assert approval_body["approvals"] == ["alice", "bob"]
+    assert mismatched_value.status_code == 400
+    assert mismatched_value.json()["detail"] == "value_mismatch"
 
-    assert client.get("/config/pending").json() == []
+    second = client.post(
+        "/config/update",
+        params={"account_id": "acct-77"},
+        json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "bob"},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["status"] == "applied"
+    assert second_body["version"] == 1
+    assert second_body["approvers"] == ["alice", "bob"]
 
-    versions = ConfigChangeStore.config_versions()
-    assert len(versions) == 1
-    latest = versions[0]
-    assert latest.config_key == "risk.max_notional"
-    assert latest.value == {"notional": 1_000_000}
-    assert latest.approvals == ("alice", "bob")
+    final_current = client.get("/config/current", params={"account_id": "acct-77"}).json()
+    assert final_current["risk.max_notional"]["value"] == {"notional": 1000}
+    assert final_current["risk.max_notional"]["approvers"] == ["alice", "bob"]
 
-    audit_actions = [entry.action for entry in ConfigChangeStore.audit_entries()]
-    assert audit_actions == [
-        "config_update_requested",
-        "config_update_approved",
-        "config_update_applied",
-    ]
+    history = client.get(
+        "/config/history",
+        params={"account_id": "acct-77", "key": "risk.max_notional"},
+    )
+    assert history.status_code == 200
+    history_body = history.json()
+    assert len(history_body) == 1
+    assert history_body[0]["approvers"] == ["alice", "bob"]
 


### PR DESCRIPTION
## Summary
- replace the previous in-memory config change helper with a FastAPI service backed by a SQLAlchemy `config_versions` table
- add endpoints for fetching current configs, updating values with optional dual sign-off, and retrieving audit history
- cover the new behaviour with focused FastAPI client tests for guarded and unguarded updates

## Testing
- pytest tests/test_config_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd632f08a48321928f896f83e271cd