### PR TITLE
Add comprehensive test harness and CI support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e .[test]; fi
       - name: Run linters
         run: |
           if [ -f pyproject.toml ]; then poe lint || true; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,15 @@ dependencies = [
 test = [
     "pytest>=7.0",
     "httpx>=0.27",
+    "pytest-asyncio>=0.23",
 ]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra"
 testpaths = ["tests"]
+asyncio_mode = "auto"
+markers = [
+    "unit: unit test suite",
+    "integration: integration test suite",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,183 @@
 
+"""Shared pytest configuration for the Aether test suite."""
+
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
+
+
+pytest_plugins = ["tests.fixtures.backends"]
+
+
+def _install_sqlalchemy_stub() -> None:
+    if "sqlalchemy" in sys.modules:
+        return
+
+    sa = ModuleType("sqlalchemy")
+
+    class _Column:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    class _Type:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    def _select(*args: object, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(order_by=lambda *a, **k: SimpleNamespace(
+            where=lambda *a, **k: SimpleNamespace(
+                group_by=lambda *a, **k: SimpleNamespace(subquery=lambda *a, **k: SimpleNamespace())
+            )
+        ))
+
+    sa.Column = _Column
+    sa.Float = _Type
+    sa.Integer = _Type
+    sa.String = _Type
+    sa.Boolean = _Type
+    sa.DateTime = _Type
+    sa.Numeric = _Type
+    sa.func = SimpleNamespace(count=lambda *a, **k: 0)
+    sa.select = _select
+    sa.create_engine = lambda *a, **k: SimpleNamespace()
+
+    sys.modules["sqlalchemy"] = sa
+
+    orm = ModuleType("sqlalchemy.orm")
+
+    class Session(SimpleNamespace):
+        def execute(self, *args: object, **kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: []))
+
+        def get(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    orm.Session = Session
+    orm.sessionmaker = lambda *a, **k: lambda: Session()
+
+    class _BaseMeta(type):
+        def __new__(mcls, name, bases, attrs):
+            cls = super().__new__(mcls, name, bases, attrs)
+
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source_type, handler):  # type: ignore[override]
+                return handler.generate_schema(dict)
+
+            cls.__get_pydantic_core_schema__ = __get_pydantic_core_schema__  # type: ignore[attr-defined]
+            return cls
+
+    class DeclarativeBase(metaclass=_BaseMeta):
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def declarative_base(**kwargs: object):
+        return DeclarativeBase
+
+    orm.declarative_base = declarative_base
+    sys.modules["sqlalchemy.orm"] = orm
+
+    engine = ModuleType("sqlalchemy.engine")
+    engine.Engine = SimpleNamespace
+    sys.modules["sqlalchemy.engine"] = engine
+
+    dialects = ModuleType("sqlalchemy.dialects")
+    postgresql = ModuleType("sqlalchemy.dialects.postgresql")
+
+    class JSONB:  # pragma: no cover - simple placeholder
+        ...
+
+    class UUID:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    postgresql.JSONB = JSONB
+    postgresql.UUID = UUID
+    sys.modules["sqlalchemy.dialects"] = dialects
+    sys.modules["sqlalchemy.dialects.postgresql"] = postgresql
+
+
+def _install_prometheus_stub() -> None:
+    if "prometheus_client" in sys.modules:
+        return
+
+    prom = ModuleType("prometheus_client")
+
+    class _Metric:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def labels(self, **kwargs: object) -> "_Metric":
+            return self
+
+        def set(self, value: float) -> None:
+            self._value = value
+
+        def inc(self, value: float = 1.0) -> None:
+            self._value = getattr(self, "_value", 0.0) + value
+
+    prom.Counter = _Metric
+    prom.Gauge = _Metric
+    prom.Summary = _Metric
+    prom.Histogram = _Metric
+    prom.CollectorRegistry = SimpleNamespace
+    prom.CONTENT_TYPE_LATEST = "text/plain"
+    prom.generate_latest = lambda registry: b""
+    sys.modules["prometheus_client"] = prom
+
+
+_install_sqlalchemy_stub()
+_install_prometheus_stub()
+
+try:  # pragma: no cover - defensive in case pydantic is absent
+    import pydantic.fields as _pydantic_fields
+except Exception:  # pragma: no cover
+    _pydantic_fields = None
+
+if _pydantic_fields is not None:
+    _original_field = _pydantic_fields.Field
+
+    def _compat_field(*args: object, **kwargs: object):
+        if "regex" in kwargs and "pattern" not in kwargs:
+            kwargs["pattern"] = kwargs.pop("regex")
+        return _original_field(*args, **kwargs)
+
+    _pydantic_fields.Field = _compat_field  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional import guard
+    from pydantic.deprecated import class_validators as _class_validators
+except Exception:  # pragma: no cover
+    _class_validators = None
+
+if _class_validators is not None:
+    _original_root_validator = _class_validators.root_validator
+
+    def _compat_root_validator(*args: object, **kwargs: object):
+        kwargs.setdefault("skip_on_failure", True)
+        return _original_root_validator(*args, **kwargs)
+
+    _class_validators.root_validator = _compat_root_validator  # type: ignore[assignment]
+
+
+@pytest.fixture
+def fixtures_path() -> Path:
+    """Return the base path for test fixture assets."""
+
+    return Path(__file__).parent / "fixtures"
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,162 @@
+"""Factories for constructing representative domain payloads used in tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from services.common.schemas import (
+    ActionTemplate,
+    BookSnapshot,
+    ConfidenceMetrics,
+    FeeBreakdown,
+    FeeDetail,
+    PolicyDecisionRequest,
+    PolicyState,
+)
+from services.common.schemas import PolicyDecisionPayload as SchemaPolicyDecisionPayload
+from services.common.schemas import PolicyDecisionResponse
+from services.common.schemas import RiskIntentPayload
+from services.common.schemas import RiskIntentMetrics as SchemaRiskIntentMetrics
+
+
+def fee_detail(**overrides: Any) -> FeeDetail:
+    defaults = {
+        "bps": 10.0,
+        "usd": 1.0,
+        "tier_id": "tier_1",
+        "basis_ts": datetime(2024, 1, 1, tzinfo=timezone.utc),
+    }
+    defaults.update(overrides)
+    return FeeDetail(**defaults)
+
+
+def fee_breakdown(**overrides: Any) -> FeeBreakdown:
+    defaults = {
+        "currency": "USD",
+        "maker": 5.0,
+        "taker": 7.5,
+        "maker_detail": fee_detail(tier_id="maker"),
+        "taker_detail": fee_detail(tier_id="taker"),
+    }
+    defaults.update(overrides)
+    return FeeBreakdown(**defaults)
+
+
+def confidence(**overrides: Any) -> ConfidenceMetrics:
+    defaults = {
+        "model_confidence": 0.9,
+        "state_confidence": 0.85,
+        "execution_confidence": 0.8,
+        "overall_confidence": 0.85,
+    }
+    defaults.update(overrides)
+    return ConfidenceMetrics(**defaults)
+
+
+def book_snapshot(**overrides: Any) -> BookSnapshot:
+    defaults = {"mid_price": 25000.0, "spread_bps": 5.0, "imbalance": 0.1}
+    defaults.update(overrides)
+    return BookSnapshot(**defaults)
+
+
+def policy_state(**overrides: Any) -> PolicyState:
+    defaults = {
+        "regime": "bull",
+        "volatility": 0.2,
+        "liquidity_score": 0.7,
+        "conviction": 0.8,
+    }
+    defaults.update(overrides)
+    return PolicyState(**defaults)
+
+
+def action_templates() -> List[ActionTemplate]:
+    return [
+        ActionTemplate(name="maker", venue_type="maker", edge_bps=25.0, fee_bps=5.0, confidence=0.8),
+        ActionTemplate(name="taker", venue_type="taker", edge_bps=20.0, fee_bps=7.5, confidence=0.75),
+    ]
+
+
+def policy_decision_request(**overrides: Any) -> PolicyDecisionRequest:
+    defaults = {
+        "account_id": "company",
+        "order_id": "ORD-1",
+        "instrument": "BTC-USD",
+        "side": "BUY",
+        "quantity": 0.5,
+        "price": 25000.0,
+        "fee": fee_breakdown(),
+        "features": [0.1, 0.2, 0.3],
+        "book_snapshot": book_snapshot(),
+        "state": policy_state(),
+        "confidence": confidence(),
+        "take_profit_bps": 50.0,
+        "stop_loss_bps": 25.0,
+    }
+    defaults.update(overrides)
+    return PolicyDecisionRequest(**defaults)
+
+
+def policy_decision_response(
+    *,
+    approved: bool = True,
+    expected_edge_bps: float = 30.0,
+    fee_adjusted_edge_bps: float = 24.0,
+    selected_action: str = "maker",
+    templates: Optional[Iterable[ActionTemplate]] = None,
+    **overrides: Any,
+) -> PolicyDecisionResponse:
+    defaults: Dict[str, Any] = {
+        "approved": approved,
+        "reason": None,
+        "effective_fee": fee_breakdown(),
+        "expected_edge_bps": expected_edge_bps,
+        "fee_adjusted_edge_bps": fee_adjusted_edge_bps,
+        "selected_action": selected_action,
+        "action_templates": list(templates or action_templates()),
+        "confidence": confidence(),
+        "features": [0.1, 0.2, 0.3],
+        "book_snapshot": book_snapshot(),
+        "state": policy_state(),
+        "take_profit_bps": 50.0,
+        "stop_loss_bps": 25.0,
+    }
+    defaults.update(overrides)
+    return PolicyDecisionResponse(**defaults)
+
+
+def policy_decision_payload(**overrides: Any) -> SchemaPolicyDecisionPayload:
+    defaults = {
+        "request": policy_decision_request(),
+        "response": policy_decision_response(),
+    }
+    defaults.update(overrides)
+    return SchemaPolicyDecisionPayload(**defaults)
+
+
+def risk_metrics(**overrides: Any) -> SchemaRiskIntentMetrics:
+    defaults = {
+        "net_exposure": 100_000.0,
+        "gross_notional": 125_000.0,
+        "projected_loss": 500.0,
+        "projected_fee": 75.0,
+        "var_95": 2500.0,
+        "spread_bps": 8.0,
+        "latency_ms": 120.0,
+    }
+    defaults.update(overrides)
+    return SchemaRiskIntentMetrics(**defaults)
+
+
+def risk_intent_payload(**overrides: Any) -> RiskIntentPayload:
+    defaults = {
+        "policy_decision": policy_decision_payload(),
+        "metrics": risk_metrics(),
+        "book_snapshot": book_snapshot(),
+        "state": policy_state(),
+        "confidence": confidence(),
+    }
+    defaults.update(overrides)
+    return RiskIntentPayload(**defaults)
+

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,2 @@
+"""Shared pytest fixtures package."""
+

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -1,0 +1,134 @@
+"""Light-weight fakes for infrastructure dependencies used in tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+
+@dataclass(slots=True)
+class FakeTimescaleTable:
+    """In-memory representation of a TimescaleDB table."""
+
+    name: str
+    rows: List[Dict[str, Any]] = field(default_factory=list)
+
+    def insert(self, row: Dict[str, Any]) -> None:
+        self.rows.append(row)
+
+
+class FakeTimescaleDB:
+    """Very small shim that mimics the subset of SQLAlchemy we rely on in tests."""
+
+    def __init__(self) -> None:
+        self.tables: Dict[str, FakeTimescaleTable] = {}
+
+    def table(self, name: str) -> FakeTimescaleTable:
+        return self.tables.setdefault(name, FakeTimescaleTable(name=name))
+
+    async def begin(self) -> AsyncIterator["FakeTimescaleDB"]:
+        yield self
+
+    async def execute_batch(self, table: str, batch: Iterable[Dict[str, Any]]) -> None:
+        destination = self.table(table)
+        for row in batch:
+            destination.insert(dict(row))
+
+
+class FakeRedis:
+    """In-memory Redis replacement with dict semantics."""
+
+    def __init__(self) -> None:
+        self._values: Dict[str, Any] = {}
+
+    async def get(self, key: str) -> Any:
+        return self._values.get(key)
+
+    async def set(self, key: str, value: Any, *, expire: Optional[int] = None) -> None:
+        del expire  # Expirations are ignored for the fake.
+        self._values[key] = value
+
+    async def incr(self, key: str, amount: int = 1) -> int:
+        current = int(self._values.get(key, 0)) + amount
+        self._values[key] = current
+        return current
+
+
+class FakeKafkaProducer:
+    """Captures messages that would normally be published to Kafka."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.messages: List[tuple[str, Dict[str, Any]]] = []
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        async with self._lock:
+            self.started = True
+
+    async def stop(self) -> None:
+        async with self._lock:
+            self.stopped = True
+
+    async def send_and_wait(self, topic: str, payload: Dict[str, Any]) -> None:
+        async with self._lock:
+            self.messages.append((topic, dict(payload)))
+
+
+@dataclass
+class FakeAuditEvent:
+    action: str
+    actor_id: str
+    before: Dict[str, Any]
+    after: Dict[str, Any]
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class FakeSensitiveActionRecorder:
+    """Records sensitive audit operations for later verification."""
+
+    def __init__(self) -> None:
+        self.events: List[FakeAuditEvent] = []
+
+    def record(
+        self,
+        *,
+        action: str,
+        actor_id: str,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.events.append(
+            FakeAuditEvent(
+                action=action,
+                actor_id=actor_id,
+                before=before or {},
+                after=after or {},
+            )
+        )
+
+
+@pytest.fixture
+def fake_timescale() -> FakeTimescaleDB:
+    return FakeTimescaleDB()
+
+
+@pytest.fixture
+def fake_redis() -> FakeRedis:
+    return FakeRedis()
+
+
+@pytest.fixture
+def fake_kafka_producer() -> FakeKafkaProducer:
+    return FakeKafkaProducer()
+
+
+@pytest.fixture
+def fake_auditor() -> FakeSensitiveActionRecorder:
+    return FakeSensitiveActionRecorder()

--- a/tests/integration/test_data_pipelines.py
+++ b/tests/integration/test_data_pipelines.py
@@ -1,0 +1,173 @@
+"""Integration tests for ingestion and training pipelines using lightweight fakes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+import httpx
+
+from services import coingecko_ingest
+from services import kraken_ws_ingest
+from tests.fixtures.backends import FakeKafkaProducer
+
+
+@pytest.mark.asyncio
+async def test_coingecko_ingestion_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(days=1)
+    payload = {
+        "prices": [
+            [start.timestamp() * 1000, 10.0],
+            [(start + timedelta(hours=12)).timestamp() * 1000, 15.0],
+            [(start + timedelta(days=1)).timestamp() * 1000, 12.0],
+        ],
+        "total_volumes": [
+            [start.timestamp() * 1000, 1_000.0],
+            [(start + timedelta(days=1)).timestamp() * 1000, 1_200.0],
+        ],
+    }
+
+    async def handler(request):
+        assert request.url.path.endswith("/coins/bitcoin/market_chart/range")
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(base_url=coingecko_ingest.API_BASE_URL, transport=transport) as client:
+        data = await coingecko_ingest.fetch_market_chart(client, "bitcoin", "usd", start, end)
+
+    rows = coingecko_ingest.aggregate_daily_rows("bitcoin", data, start, end)
+    assert len(rows) == 2
+
+    captured: List[Dict[str, Any]] = []
+
+    async def fake_execute(connection, batch):
+        captured.extend(batch)
+
+    class FakeEngine:
+        def begin(self):
+            class _Ctx:
+                async def __aenter__(self_inner):
+                    return SimpleNamespace()
+
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _Ctx()
+
+    monkeypatch.setattr(coingecko_ingest, "_execute_upsert", fake_execute)
+    await coingecko_ingest.upsert_ohlcv_rows(FakeEngine(), rows, batch_size=1)
+    assert len(captured) == len(rows)
+
+
+@pytest.mark.asyncio
+async def test_kraken_ingestor_normalises_messages(fake_kafka_producer: FakeKafkaProducer) -> None:
+    config = kraken_ws_ingest.KrakenConfig(pairs=["BTC/USD"], kafka_bootstrap_servers="localhost:9092")
+    ingestor = kraken_ws_ingest.KrakenIngestor(config)
+    ingestor._producer = fake_kafka_producer
+
+    trades = [["50000.0", "0.1", "1700000000", "b"]]
+    await ingestor._handle_trade_message(trades, "BTC/USD")
+
+    book_payload = {"a": [["50010.0", "0.2", "1700000001"]]}
+    await ingestor._handle_book_message(book_payload, "BTC/USD")
+
+    topics = {topic for topic, _ in fake_kafka_producer.messages}
+    assert topics == {config.trade_topic, config.book_topic}
+
+
+def test_materialization_refresh_invokes_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    from data.feast import materialize
+
+    calls: List[str] = []
+
+    class FakeStore:
+        def materialize(self, start_date, end_date):
+            calls.append("daily")
+
+        def materialize_incremental(self, end_date):
+            calls.append("incremental")
+
+    materialize.refresh_online_store(FakeStore(), days=2)
+    assert calls == ["daily", "incremental"]
+
+
+def test_training_pipeline_generates_splits_and_trains(monkeypatch: pytest.MonkeyPatch) -> None:
+    from ml.data_loader import PurgedWalkForwardDataLoader, TimescaleFeastConfig
+    from ml.models import supervised
+
+    timestamps = pd.date_range("2024-01-01", periods=10, freq="D", tz="UTC")
+    base_frame = pd.DataFrame(
+        {
+            "event_ts": timestamps,
+            "asset": ["BTC"] * 10,
+            "label": np.linspace(0, 1, 10),
+            "turnover": np.linspace(10, 20, 10),
+        }
+    )
+    features_frame = pd.DataFrame(
+        {
+            "event_ts": timestamps,
+            "asset": ["BTC"] * 10,
+            "feature_a": np.linspace(1, 10, 10),
+        }
+    )
+
+    monkeypatch.setattr("ml.data_loader._create_engine", lambda uri: object())
+    monkeypatch.setattr("ml.data_loader._load_base_frame", lambda engine, query, time_column: base_frame)
+    monkeypatch.setattr(
+        "ml.data_loader._load_feast_features",
+        lambda feature_view, entities, feature_service, feature_store_repo: features_frame,
+    )
+
+    config = TimescaleFeastConfig(
+        timescale_uri="postgresql://",  # unused because of monkeypatch
+        base_query="select * from data",
+        time_column="event_ts",
+        entity_column="asset",
+        label_column="label",
+        transaction_fee_bps=5.0,
+        feature_view="features_view",
+    )
+
+    loader = PurgedWalkForwardDataLoader(
+        config=config,
+        turnover_column="turnover",
+        train_window=timedelta(days=3),
+        validation_window=timedelta(days=2),
+        test_window=timedelta(days=2),
+    )
+    splits = loader.load()
+    assert splits
+
+    dataset = supervised.SupervisedDataset(features=splits[0].train.drop(columns=["label"]), labels=splits[0].train["label"])
+
+    class DummyTrainer(supervised.SupervisedTrainer):
+        name = "dummy"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.fitted = False
+
+        def fit(self, dataset, **kwargs):  # type: ignore[override]
+            self.fitted = True
+            self._dataset = dataset
+            return "model"
+
+        def predict(self, features):  # type: ignore[override]
+            if not self.fitted:
+                raise RuntimeError("model not fitted")
+            return np.zeros(len(features))
+
+        def save(self, path):  # type: ignore[override]
+            return None
+
+    monkeypatch.setitem(supervised.TRAINER_REGISTRY, "dummy", DummyTrainer)
+    trainer = supervised.load_trainer("dummy")
+    trainer.fit(dataset)
+    preds = trainer.predict(dataset.features)
+    assert len(preds) == len(dataset.features)

--- a/tests/unit/services/test_fees_service.py
+++ b/tests/unit/services/test_fees_service.py
@@ -1,0 +1,90 @@
+"""Unit tests for the fee schedule service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.fees import fee_service
+
+
+@pytest.fixture
+def fees_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    tiers = [
+        SimpleNamespace(
+            tier_id="tier_0",
+            notional_threshold_usd=Decimal("0"),
+            maker_bps=Decimal("10"),
+            taker_bps=Decimal("20"),
+            effective_from=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ),
+        SimpleNamespace(
+            tier_id="tier_1",
+            notional_threshold_usd=Decimal("100000"),
+            maker_bps=Decimal("8"),
+            taker_bps=Decimal("18"),
+            effective_from=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ),
+    ]
+
+    monkeypatch.setattr(fee_service, "_ordered_tiers", lambda session: list(tiers))
+
+    volume = SimpleNamespace(
+        notional_usd_30d=Decimal("150000"),
+        updated_at=datetime(2024, 3, 1, tzinfo=timezone.utc),
+    )
+
+    class FakeSession:
+        def get(self, model, key):
+            if model is fee_service.AccountVolume30d and key == "company":
+                return volume
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def override_session():
+        session = FakeSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    fee_service.app.dependency_overrides[fee_service.get_session] = override_session
+    fee_service.app.dependency_overrides[fee_service.require_admin_account] = lambda: "company"
+    return TestClient(fee_service.app)
+
+
+def teardown_module(module) -> None:  # type: ignore[override]
+    fee_service.app.dependency_overrides.clear()
+
+
+def test_fee_service_requires_admin_header() -> None:
+    client = TestClient(fee_service.app)
+    response = client.get("/fees/tiers")
+    assert response.status_code == 403
+
+
+def test_effective_fee_uses_volume_and_tiers(fees_client: TestClient) -> None:
+    response = fees_client.get(
+        "/fees/effective",
+        params={"pair": "BTC/USD", "liquidity": "maker", "notional": 50_000},
+        headers={"X-Account-ID": "company"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["bps"] == pytest.approx(8.0)
+    assert body["tier_id"] == "tier_1"
+
+
+def test_fee_tiers_endpoint_returns_configured_schedule(fees_client: TestClient) -> None:
+    response = fees_client.get("/fees/tiers", headers={"X-Account-ID": "company"})
+    assert response.status_code == 200
+    tiers = response.json()
+    assert len(tiers) == 2
+    assert tiers[1]["tier_id"] == "tier_1"

--- a/tests/unit/services/test_oms_service.py
+++ b/tests/unit/services/test_oms_service.py
@@ -1,0 +1,134 @@
+"""Unit tests for the OMS FastAPI service."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.oms import oms_service
+
+
+class FakeAccount:
+    def __init__(self) -> None:
+        self.orders: Dict[str, SimpleNamespace] = {}
+
+    async def place_order(self, request: oms_service.OMSPlaceRequest) -> oms_service.OMSPlaceResponse:
+        response = oms_service.OMSPlaceResponse(
+            exchange_order_id="EX-1",
+            status="placed",
+            filled_qty=Decimal("0"),
+            avg_price=Decimal("0"),
+            errors=None,
+            transport="websocket",
+            reused=False,
+        )
+        self.orders[request.client_id] = SimpleNamespace(result=response)
+        return response
+
+    async def cancel_order(self, request: oms_service.OMSCancelRequest) -> oms_service.OMSOrderStatusResponse:
+        response = oms_service.OMSOrderStatusResponse(
+            exchange_order_id=request.exchange_order_id or "EX-1",
+            status="cancelled",
+            filled_qty=Decimal("0"),
+            avg_price=Decimal("0"),
+            errors=None,
+        )
+        self.orders[request.client_id] = SimpleNamespace(result=response)
+        return response
+
+    async def lookup(self, client_id: str) -> SimpleNamespace | None:
+        return self.orders.get(client_id)
+
+    async def start(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+    async def close(self) -> None:  # pragma: no cover
+        return None
+
+
+class FakeManager:
+    def __init__(self) -> None:
+        self.accounts: Dict[str, FakeAccount] = {}
+
+    async def get_account(self, account_id: str) -> FakeAccount:
+        return self.accounts.setdefault(account_id, FakeAccount())
+
+    async def shutdown(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
+@pytest.fixture
+def oms_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(oms_service, "manager", FakeManager())
+    return TestClient(oms_service.app)
+
+
+def test_place_order_requires_auth_header(oms_client: TestClient) -> None:
+    payload = {
+        "account_id": "ACC1",
+        "client_id": "CID-1",
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "qty": "1",
+        "limit_px": "50000",
+    }
+    response = oms_client.post("/oms/place", json=payload)
+    assert response.status_code == 401
+
+
+def test_place_order_succeeds_with_matching_account(oms_client: TestClient) -> None:
+    payload = {
+        "account_id": "ACC1",
+        "client_id": "CID-1",
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "qty": "1",
+        "limit_px": "50000",
+    }
+    headers = {"X-Account-ID": "ACC1"}
+    response = oms_client.post("/oms/place", json=payload, headers=headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "placed"
+    assert body["reused"] is False
+
+
+def test_status_requires_matching_account(oms_client: TestClient) -> None:
+    response = oms_client.get("/oms/status", params={"account_id": "ACC1", "client_id": "CID-1"})
+    assert response.status_code == 401
+
+    response = oms_client.get(
+        "/oms/status",
+        params={"account_id": "ACC1", "client_id": "CID-1"},
+        headers={"X-Account-ID": "ACC2"},
+    )
+    assert response.status_code == 403
+
+
+def test_status_returns_last_known_result(oms_client: TestClient) -> None:
+    headers = {"X-Account-ID": "ACC1"}
+    payload = {
+        "account_id": "ACC1",
+        "client_id": "CID-1",
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "qty": "1",
+        "limit_px": "50000",
+    }
+    place_response = oms_client.post("/oms/place", json=payload, headers=headers)
+    assert place_response.status_code == 200
+
+    status_response = oms_client.get(
+        "/oms/status",
+        params={"account_id": "ACC1", "client_id": "CID-1"},
+        headers=headers,
+    )
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "placed"

--- a/tests/unit/services/test_policy_service.py
+++ b/tests/unit/services/test_policy_service.py
@@ -1,0 +1,143 @@
+"""Unit tests for the policy decision services."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+import tests.factories as factories
+from policy_service import app as decision_app
+from services.policy import policy_service as intent_service
+
+
+class DummyIntent:
+    """Simple intent payload used to stub the model server."""
+
+    def __init__(self, *, approved: bool = True, edge: float = 30.0, reason: str | None = None):
+        self.confidence = factories.confidence(overall_confidence=0.9)
+        self.action_templates = factories.action_templates()
+        self.selected_action = "maker"
+        self.approved = approved
+        self.reason = reason
+        self.edge_bps = edge
+        self.take_profit_bps = 80.0
+        self.stop_loss_bps = 40.0
+
+
+@pytest.fixture
+def policy_test_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Create a test client with the model server stubbed out."""
+
+    stub_intent = DummyIntent()
+
+    def fake_predict_intent(**_: Any) -> DummyIntent:
+        return stub_intent
+
+    async def fake_fetch(*args: Any, **kwargs: Any) -> float:
+        del args, kwargs
+        return 5.0
+
+    monkeypatch.setattr("policy_service.predict_intent", fake_predict_intent)
+    monkeypatch.setattr("policy_service._fetch_effective_fee", fake_fetch)
+    return TestClient(decision_app)
+
+
+def test_policy_decision_approves_when_fee_adjusted_positive(policy_test_client: TestClient) -> None:
+    request = factories.policy_decision_request()
+    response = policy_test_client.post("/policy/decide", json=request.model_dump(mode="json"))
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["approved"] is True
+    assert pytest.approx(payload["effective_fee"]["maker"], rel=1e-3) == 5.0
+    assert pytest.approx(payload["fee_adjusted_edge_bps"], rel=1e-3) == 25.0
+
+
+def test_policy_decision_rejects_when_fee_erases_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = factories.policy_decision_request()
+
+    def fake_predict_intent(**_: Any) -> DummyIntent:
+        return DummyIntent(approved=True, edge=4.0)
+
+    fees: List[Dict[str, Any]] = []
+
+    async def fake_fetch(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
+        fees.append({
+            "account": account_id,
+            "symbol": symbol,
+            "liquidity": liquidity,
+            "notional": notional,
+        })
+        return 6.0 if liquidity == "maker" else 8.0
+
+    monkeypatch.setattr("policy_service.predict_intent", fake_predict_intent)
+    monkeypatch.setattr("policy_service._fetch_effective_fee", fake_fetch)
+
+    client = TestClient(decision_app)
+    response = client.post("/policy/decide", json=request.model_dump(mode="json"))
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["approved"] is False
+    assert payload["reason"] == "Fee-adjusted edge non-positive"
+    assert {entry["liquidity"] for entry in fees} == {"maker", "taker"}
+    assert fees[0]["symbol"] == request.instrument
+
+
+def test_policy_decision_requires_book_snapshot(policy_test_client: TestClient) -> None:
+    request = factories.policy_decision_request(book_snapshot=None)
+    response = policy_test_client.post("/policy/decide", json=request.model_dump(mode="json"))
+    assert response.status_code == 422
+
+
+def test_policy_intent_service_validates_admin_account() -> None:
+    client = TestClient(intent_service.app)
+
+    request = {
+        "account_id": "intruder",
+        "symbol": "BTC-USD",
+        "features": [1, 2, 3],
+        "book_snapshot": {},
+        "account_state": {},
+    }
+
+    response = client.post("/policy/decide", json=request)
+    assert response.status_code == 422
+
+
+def test_policy_intent_service_returns_model_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_intent = {
+        "action": "enter",
+        "side": "buy",
+        "qty": 1.0,
+        "preference": "maker",
+        "type": "limit",
+        "limit_px": 10.0,
+        "tif": "GTC",
+        "tp": None,
+        "sl": None,
+        "expected_edge_bps": 12.0,
+        "expected_cost_bps": 4.0,
+        "confidence": 0.9,
+    }
+
+    def fake_predict_intent(**_: Any) -> Dict[str, Any]:
+        return stub_intent
+
+    monkeypatch.setattr(intent_service, "models", SimpleNamespace(predict_intent=fake_predict_intent))
+
+    client = TestClient(intent_service.app)
+    request = {
+        "account_id": "company",
+        "symbol": "BTC-USD",
+        "features": [1, 2, 3],
+        "book_snapshot": {"mid": 1.0},
+        "account_state": {"drift_score": 0.1},
+    }
+
+    response = client.post("/policy/decide", json=request)
+    assert response.status_code == 200
+    assert response.json()["action"] == "enter"

--- a/tests/unit/services/test_risk_service.py
+++ b/tests/unit/services/test_risk_service.py
@@ -1,0 +1,73 @@
+"""Risk service unit tests covering schema validation and fee awareness."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from risk_service import RiskEvaluationContext, app as risk_app
+
+config = dict(getattr(RiskEvaluationContext, "model_config", {}))
+config["arbitrary_types_allowed"] = True
+config["from_attributes"] = True
+RiskEvaluationContext.model_config = config  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def risk_client() -> TestClient:
+    return TestClient(risk_app)
+
+
+def _base_request() -> Dict[str, object]:
+    return {
+        "account_id": "ACC-DEFAULT",
+        "intent": {
+            "policy_id": "policy-1",
+            "instrument_id": "AAPL",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 100.0,
+        },
+        "portfolio_state": {
+            "net_asset_value": 1_000_000.0,
+            "notional_exposure": 100_000.0,
+            "realized_daily_loss": 1_000.0,
+            "fees_paid": 1_000.0,
+        },
+    }
+
+
+def test_risk_validation_passes_under_fee_budget(risk_client: TestClient) -> None:
+    payload = _base_request()
+    response = risk_client.post("/risk/validate", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pass"] is True
+    assert body["reasons"] == []
+
+
+def test_risk_validation_rejects_when_fee_budget_exhausted(risk_client: TestClient) -> None:
+    payload = _base_request()
+    payload["portfolio_state"]["fees_paid"] = 12_000.0
+    response = risk_client.post("/risk/validate", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pass"] is False
+    assert any("Fee budget exhausted" in reason for reason in body["reasons"])
+
+
+def test_risk_validation_enforces_schema(risk_client: TestClient) -> None:
+    payload = _base_request()
+    payload["intent"]["side"] = "hold"
+    response = risk_client.post("/risk/validate", json=payload)
+    assert response.status_code == 422
+
+
+def test_risk_limits_endpoint_returns_configuration(risk_client: TestClient) -> None:
+    response = risk_client.get("/risk/limits", params={"account_id": "ACC-DEFAULT"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limits"]["account_id"] == "ACC-DEFAULT"
+    assert body["usage"]["account_id"] == "ACC-DEFAULT"

--- a/tests/unit/services/test_secrets_service.py
+++ b/tests/unit/services/test_secrets_service.py
@@ -1,0 +1,106 @@
+"""Unit tests for the secrets management service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.secrets import secrets_service
+
+
+class FakeCoreV1Api:
+    def __init__(self) -> None:
+        self.patched: Dict[str, Dict[str, object]] = {}
+        self.created: Dict[str, Dict[str, object]] = {}
+        self._secret = SimpleNamespace(
+            metadata=SimpleNamespace(
+                annotations={
+                    secrets_service.ANNOTATION_CREATED_AT: datetime(2023, 1, 1, tzinfo=timezone.utc).isoformat(),
+                    secrets_service.ANNOTATION_ROTATED_AT: datetime(2023, 1, 2, tzinfo=timezone.utc).isoformat(),
+                },
+                name="kraken-keys-company",
+            )
+        )
+
+    def read_namespaced_secret(self, name: str, namespace: str):
+        return self._secret
+
+    def patch_namespaced_secret(self, name: str, namespace: str, body: Dict[str, object]):
+        self.patched[f"{namespace}/{name}"] = body
+
+    def create_namespaced_secret(self, namespace: str, body: Dict[str, object]):
+        self.created[f"{namespace}/{body['metadata']['name']}"] = body
+
+
+@pytest.fixture
+def secrets_client(monkeypatch: pytest.MonkeyPatch, fake_auditor) -> TestClient:
+    fake_api = FakeCoreV1Api()
+
+    secrets_service.app.dependency_overrides[secrets_service.ensure_secure_transport] = lambda: None
+    secrets_service.app.dependency_overrides[secrets_service.require_admin_account] = lambda: "company"
+    secrets_service.app.dependency_overrides[secrets_service.require_mfa_context] = lambda: "verified"
+    secrets_service.app.dependency_overrides[secrets_service.get_core_v1_api] = lambda: fake_api
+    monkeypatch.setattr(secrets_service, "validate_kraken_credentials", lambda *_, **__: True)
+    monkeypatch.setattr(secrets_service, "_auditor", fake_auditor)
+
+    client = TestClient(secrets_service.app)
+    client._fake_api = fake_api  # type: ignore[attr-defined]
+    return client
+
+
+def teardown_module(module) -> None:  # type: ignore[override]
+    secrets_service.app.dependency_overrides.clear()
+
+
+def test_rotate_secret_requires_tls_guard() -> None:
+    client = TestClient(secrets_service.app)
+    payload = {
+        "account_id": "company",
+        "api_key": "abcdef",
+        "api_secret": "abcdefghijkl",
+    }
+    response = client.post("/secrets/kraken", json=payload)
+    assert response.status_code == 400
+
+
+def test_rotate_secret_enforces_account_match(secrets_client: TestClient) -> None:
+    payload = {
+        "account_id": "other",
+        "api_key": "abcdef",
+        "api_secret": "abcdefghijkl",
+    }
+    response = secrets_client.post("/secrets/kraken", json=payload, headers={"X-Account-ID": "company", "X-MFA-Context": "verified"})
+    assert response.status_code == 403
+
+
+def test_rotate_secret_updates_kubernetes(secrets_client: TestClient, fake_auditor) -> None:
+    payload = {
+        "account_id": "company",
+        "api_key": "abcdef",
+        "api_secret": "abcdefghijkl",
+    }
+    response = secrets_client.post(
+        "/secrets/kraken",
+        json=payload,
+        headers={"X-Account-ID": "company", "X-MFA-Context": "verified"},
+    )
+    assert response.status_code == 204
+
+    fake_api: FakeCoreV1Api = secrets_client._fake_api  # type: ignore[attr-defined]
+    assert fake_api.patched
+    assert fake_auditor.events
+
+
+def test_secret_status_returns_metadata(secrets_client: TestClient) -> None:
+    response = secrets_client.get(
+        "/secrets/kraken/status",
+        params={"account_id": "company"},
+        headers={"X-Account-ID": "company", "X-MFA-Context": "verified"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["secret_name"] == "kraken-keys-company"

--- a/tests/unit/services/test_universe_service.py
+++ b/tests/unit/services/test_universe_service.py
@@ -1,0 +1,98 @@
+"""Unit tests for the universe service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.universe import universe_service
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+        self.committed = False
+        self.flushed = False
+
+    def add(self, record) -> None:
+        self.added.append(record)
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def flush(self) -> None:
+        self.flushed = True
+
+
+@pytest.fixture
+def universe_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    session = FakeSession()
+
+    def override_session():
+        try:
+            yield session
+        finally:
+            session.committed = True
+
+    caps = {
+        "BTC/USD": SimpleNamespace(value=1_500_000_000.0, entity_id="BTC/USD"),
+        "ETH/USD": SimpleNamespace(value=2_000_000_000.0, entity_id="ETH/USD"),
+    }
+    vols = {
+        "BTC/USD": SimpleNamespace(value=0.5, entity_id="BTC/USD"),
+        "ETH/USD": SimpleNamespace(value=0.3, entity_id="ETH/USD"),
+    }
+    volumes = {"BTC-USD": 150_000_000.0, "ETH-USD": 50_000_000.0}
+    overrides = {"ETH-USD": SimpleNamespace(approved=False)}
+
+    def fake_feature_map(_session, feature_names):
+        if "volatility" in feature_names[0]:
+            return vols
+        return caps
+
+    monkeypatch.setattr(universe_service, "_latest_feature_map", fake_feature_map)
+    monkeypatch.setattr(universe_service, "_kraken_volume_24h", lambda session: volumes)
+    monkeypatch.setattr(universe_service, "_latest_manual_overrides", lambda session, migrate=False: overrides)
+    universe_service.app.dependency_overrides[universe_service.get_session] = override_session
+    return TestClient(universe_service.app)
+
+
+def teardown_module(module) -> None:  # type: ignore[override]
+    universe_service.app.dependency_overrides.clear()
+
+
+def test_universe_approved_filters_thresholds(universe_client: TestClient) -> None:
+    response = universe_client.get("/universe/approved")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["symbols"] == ["BTC-USD"]
+
+
+def test_override_symbol_validates_reason(universe_client: TestClient) -> None:
+    response = universe_client.post(
+        "/universe/override",
+        json={"symbol": " BTC/USD ", "enabled": True, "reason": "  ", "actor": "ops"},
+    )
+    assert response.status_code == 400
+
+
+def test_override_symbol_creates_entry(universe_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: Dict[str, object] = {}
+
+    def fake_latest_overrides(session, migrate=False):
+        recorded["session"] = session
+        return {}
+
+    monkeypatch.setattr(universe_service, "_latest_manual_overrides", fake_latest_overrides)
+    response = universe_client.post(
+        "/universe/override",
+        json={"symbol": "ETH/USD", "enabled": True, "reason": "Listing", "actor": "ops"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["symbol"] == "ETH-USD"
+    assert recorded


### PR DESCRIPTION
## Summary
- add reusable fixtures and factories to simplify constructing domain payloads in tests
- introduce unit tests for the policy, risk, fees, OMS, universe, and secrets FastAPI services to validate schema, auth, and fee-aware behaviours
- add integration coverage for CoinGecko/Kraken ingestion, feature materialisation, and model training flows while updating CI to install test extras

## Testing
- pytest tests/unit/services -q *(fails in this environment due to legacy pydantic validators and SQLAlchemy requirements that are stubbed for test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68dd65038db48321a02ff482d381db09