### PR TITLE
Add Kraken OMS order book management and latency metrics

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -29,6 +29,27 @@ _oms_submit_ack_ms = Gauge(
     registry=_REGISTRY,
 )
 
+_oms_latency_ms = Gauge(
+    "oms_latency_ms",
+    "Latency of OMS order placement by transport in milliseconds.",
+    labelnames=("account_id", "symbol", "transport"),
+    registry=_REGISTRY,
+)
+
+_oms_error_count = Counter(
+    "oms_error_count",
+    "Count of OMS transport errors by account, symbol and transport.",
+    labelnames=("account_id", "symbol", "transport"),
+    registry=_REGISTRY,
+)
+
+_oms_child_orders_total = Counter(
+    "oms_child_orders_total",
+    "Number of OMS child orders created per account and symbol.",
+    labelnames=("account_id", "symbol"),
+    registry=_REGISTRY,
+)
+
 _trade_rejections_total = Counter(
     "trade_rejections_total",
     "Count of rejected trades by account and symbol.",
@@ -60,6 +81,9 @@ _abstention_rate = Gauge(
 _METRICS: Dict[str, Gauge | Counter] = {
     "ws_latency_ms": _ws_latency_ms,
     "oms_submit_ack_ms": _oms_submit_ack_ms,
+    "oms_latency_ms": _oms_latency_ms,
+    "oms_error_count": _oms_error_count,
+    "oms_child_orders_total": _oms_child_orders_total,
     "trade_rejections_total": _trade_rejections_total,
     "fees_nav_pct": _fees_nav_pct,
     "drift_score": _drift_score,
@@ -103,6 +127,25 @@ def record_ws_latency(account_id: str, symbol: str, latency_ms: float) -> None:
 def record_oms_submit_ack(account_id: str, symbol: str, latency_ms: float) -> None:
     init_metrics()
     _oms_submit_ack_ms.labels(account_id=account_id, symbol=symbol).set(latency_ms)
+
+
+def record_oms_latency(account_id: str, symbol: str, transport: str, latency_ms: float) -> None:
+    init_metrics()
+    _oms_latency_ms.labels(
+        account_id=account_id, symbol=symbol, transport=transport
+    ).set(latency_ms)
+
+
+def increment_oms_error_count(account_id: str, symbol: str, transport: str) -> None:
+    init_metrics()
+    _oms_error_count.labels(
+        account_id=account_id, symbol=symbol, transport=transport
+    ).inc()
+
+
+def increment_oms_child_orders_total(account_id: str, symbol: str, count: int) -> None:
+    init_metrics()
+    _oms_child_orders_total.labels(account_id=account_id, symbol=symbol).inc(count)
 
 
 def increment_trade_rejection(account_id: str, symbol: str) -> None:

--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -6,10 +6,13 @@ import contextlib
 import json
 import logging
 import os
+import time
+import uuid
+from collections import deque
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_EVEN
+from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_EVEN, ROUND_UP
 from pathlib import Path
-from typing import Any, Awaitable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Awaitable, Deque, Dict, Iterable, List, Optional, Set, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
@@ -23,12 +26,22 @@ from services.oms.kraken_ws import (
     OrderState,
 )
 
+import websockets
+
+from metrics import (
+    increment_oms_child_orders_total,
+    increment_oms_error_count,
+    record_oms_latency,
+    setup_metrics,
+)
+
 
 
 logger = logging.getLogger(__name__)
 
 
 app = FastAPI(title="Kraken OMS Async Service")
+setup_metrics(app)
 
 
 class OMSPlaceRequest(BaseModel):
@@ -158,6 +171,14 @@ class OrderRecord:
     client_id: str
     result: OMSOrderStatusResponse
     transport: str
+    children: List["ChildOrderRecord"] | None = None
+
+
+@dataclass
+class ChildOrderRecord:
+    client_id: str
+    exchange_order_id: str
+    transport: str
 
 
 class _PrecisionValidator:
@@ -242,6 +263,297 @@ class _PrecisionValidator:
             except Exception:  # pragma: no cover - defensive
                 continue
         return None
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.replace("-", "/").replace("_", "/").upper()
+
+
+def _resolve_pair_metadata(symbol: str, metadata: Dict[str, Any] | None) -> Dict[str, Any] | None:
+    if not metadata:
+        return None
+
+    normalized = _normalize_symbol(symbol)
+    candidates = [symbol, normalized, normalized.replace("/", ""), symbol.replace("/", "")]
+    for candidate in candidates:
+        value = metadata.get(candidate)
+        if isinstance(value, dict):
+            return value
+
+    for value in metadata.values():
+        if isinstance(value, dict):
+            wsname = str(value.get("wsname") or "")
+            altname = str(value.get("altname") or "")
+            if wsname == normalized or altname == normalized.replace("/", ""):
+                return value
+    return None
+
+
+def _resolve_book_symbol(symbol: str, metadata: Dict[str, Any] | None) -> str:
+    pair_meta = _resolve_pair_metadata(symbol, metadata)
+    if pair_meta:
+        for key in ("wsname", "altname"):
+            value = pair_meta.get(key)
+            if value:
+                return str(value)
+    return _normalize_symbol(symbol)
+
+
+class _PublicOrderBookState:
+    def __init__(self, symbol: str, depth: int = 10) -> None:
+        self.symbol = symbol
+        self._depth = depth
+        self._bids: Dict[Decimal, Decimal] = {}
+        self._asks: Dict[Decimal, Decimal] = {}
+        self._ordered_bids: List[Tuple[Decimal, Decimal]] = []
+        self._ordered_asks: List[Tuple[Decimal, Decimal]] = []
+        self._lock = asyncio.Lock()
+        self._ready = asyncio.Event()
+        self._last_ts: float | None = None
+
+    async def apply(self, payload: Dict[str, Any]) -> None:
+        bids_snapshot = payload.get("bs") or payload.get("bids")
+        asks_snapshot = payload.get("as") or payload.get("asks")
+        bids_update = payload.get("b") or []
+        asks_update = payload.get("a") or []
+
+        async with self._lock:
+            if bids_snapshot or asks_snapshot:
+                if isinstance(bids_snapshot, list):
+                    self._update_side(self._bids, bids_snapshot, is_bid=True, replace=True)
+                if isinstance(asks_snapshot, list):
+                    self._update_side(self._asks, asks_snapshot, is_bid=False, replace=True)
+            if bids_update:
+                self._update_side(self._bids, bids_update, is_bid=True)
+            if asks_update:
+                self._update_side(self._asks, asks_update, is_bid=False)
+            self._ordered_bids = self._sorted_levels(self._bids, is_bid=True)
+            self._ordered_asks = self._sorted_levels(self._asks, is_bid=False)
+            self._last_ts = time.time()
+            if self._ordered_bids or self._ordered_asks:
+                self._ready.set()
+
+    def _update_side(
+        self,
+        book: Dict[Decimal, Decimal],
+        updates: Iterable[Iterable[Any]],
+        *,
+        is_bid: bool,
+        replace: bool = False,
+    ) -> None:
+        if replace:
+            book.clear()
+        for level in updates:
+            try:
+                price_value = level[0]
+                size_value = level[1]
+            except IndexError:
+                continue
+            try:
+                price = Decimal(str(price_value))
+                size = Decimal(str(size_value))
+            except Exception:
+                continue
+            if size <= 0:
+                book.pop(price, None)
+            else:
+                book[price] = size
+
+    def _sorted_levels(
+        self, book: Dict[Decimal, Decimal], *, is_bid: bool
+    ) -> List[Tuple[Decimal, Decimal]]:
+        ordered = sorted(book.items(), key=lambda item: item[0], reverse=is_bid)
+        return ordered[: self._depth]
+
+    async def depth(self, side: str, levels: int = 10) -> Optional[Decimal]:
+        if not self._ready.is_set():
+            return None
+        async with self._lock:
+            if side.lower() == "buy":
+                book = self._ordered_asks
+            else:
+                book = self._ordered_bids
+            relevant = book[:levels]
+            depth = sum(size for _, size in relevant)
+        return depth if depth > 0 else None
+
+    async def last_update(self) -> Optional[float]:
+        async with self._lock:
+            return self._last_ts
+
+
+class KrakenOrderBookStore:
+    def __init__(self, depth: int = 10) -> None:
+        self._depth = depth
+        self._books: Dict[str, _PublicOrderBookState] = {}
+        self._tasks: Dict[str, asyncio.Task[None]] = {}
+        self._lock = asyncio.Lock()
+        self._url = os.environ.get("KRAKEN_PUBLIC_WS_URL", "wss://ws.kraken.com")
+
+    async def ensure_book(self, symbol: str) -> _PublicOrderBookState:
+        normalized = _normalize_symbol(symbol)
+        async with self._lock:
+            book = self._books.get(normalized)
+            if book is None:
+                book = _PublicOrderBookState(normalized, depth=self._depth)
+                self._books[normalized] = book
+                task = asyncio.create_task(
+                    self._run_stream(book), name=f"kraken-public-{normalized}"
+                )
+                self._tasks[normalized] = task
+        return book
+
+    async def _run_stream(self, book: _PublicOrderBookState) -> None:
+        subscription = {
+            "event": "subscribe",
+            "pair": [book.symbol],
+            "subscription": {"name": "book", "depth": max(self._depth, 10)},
+        }
+        while True:
+            try:
+                async with websockets.connect(self._url, ping_interval=None) as ws:
+                    await ws.send(json.dumps(subscription))
+                    while True:
+                        raw = await ws.recv()
+                        if isinstance(raw, bytes):
+                            raw = raw.decode()
+                        try:
+                            message = json.loads(raw)
+                        except json.JSONDecodeError:
+                            logger.debug("Invalid public WS payload: %s", raw)
+                            continue
+                        if isinstance(message, dict):
+                            event = message.get("event")
+                            if event == "subscriptionStatus" and message.get("status") != "subscribed":
+                                logger.warning(
+                                    "Order book subscription failed for %s: %s",
+                                    book.symbol,
+                                    message,
+                                )
+                            continue
+                        if isinstance(message, list) and len(message) >= 2:
+                            data = message[1]
+                            if isinstance(data, dict):
+                                await book.apply(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Public order book stream error for %s: %s", book.symbol, exc
+                )
+                await asyncio.sleep(1.0)
+
+    async def stop(self) -> None:
+        async with self._lock:
+            tasks = list(self._tasks.values())
+            self._tasks.clear()
+        for task in tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+class _TransportLatencyTracker:
+    def __init__(self, window: int = 50) -> None:
+        self._window = window
+        self._samples: Dict[str, Deque[float]] = {
+            "websocket": deque(maxlen=window),
+            "rest": deque(maxlen=window),
+        }
+
+    def record(self, transport: str, latency_ms: float) -> None:
+        if transport not in self._samples:
+            self._samples[transport] = deque(maxlen=self._window)
+        self._samples[transport].append(latency_ms)
+
+    def preferred(self) -> str:
+        ws_avg = self._average("websocket")
+        rest_avg = self._average("rest")
+        if ws_avg is None and rest_avg is None:
+            return "websocket"
+        if rest_avg is None:
+            return "websocket"
+        if ws_avg is None:
+            return "rest"
+        return "websocket" if ws_avg <= rest_avg else "rest"
+
+    def _average(self, key: str) -> Optional[float]:
+        samples = self._samples.get(key)
+        if not samples:
+            return None
+        return sum(samples) / len(samples)
+
+
+order_book_store = KrakenOrderBookStore()
+
+AGGREGATE_PRICE_PRECISION = Decimal("0.00000001")
+
+
+def _split_quantities(
+    total: Decimal,
+    max_child: Decimal,
+    qty_step: Optional[Decimal],
+    min_qty: Optional[Decimal],
+) -> List[Decimal]:
+    if max_child <= 0 or total <= 0:
+        return [total]
+    if total <= max_child:
+        return [total]
+
+    quantities: List[Decimal] = []
+
+    if qty_step and qty_step > 0:
+        step = qty_step
+        total_units = int((total / step).to_integral_value(rounding=ROUND_HALF_EVEN))
+        max_units = int((max_child / step).to_integral_value(rounding=ROUND_FLOOR))
+        if max_units <= 0:
+            max_units = 1
+        if min_qty and min_qty > 0:
+            min_units = int((min_qty / step).to_integral_value(rounding=ROUND_UP))
+            if min_units <= 0:
+                min_units = 1
+            max_units = max(max_units, min_units)
+        else:
+            min_units = 1
+
+        units_remaining = total_units
+        while units_remaining > 0:
+            units = min(units_remaining, max_units)
+            if units < min_units and quantities:
+                quantities[-1] += Decimal(units_remaining) * step
+                units_remaining = 0
+                break
+            if units < min_units:
+                units = min_units
+            quantity = Decimal(units) * step
+            if quantity > total:
+                quantity = total
+            quantities.append(quantity)
+            units_remaining -= units
+
+        allocated = sum(quantities)
+        if allocated < total and quantities:
+            quantities[-1] += total - allocated
+        elif allocated > total and quantities:
+            quantities[-1] -= allocated - total
+        return [qty for qty in quantities if qty > 0]
+
+    remaining = total
+    while remaining > 0:
+        child = min(remaining, max_child)
+        if min_qty and min_qty > 0 and child < min_qty:
+            if quantities:
+                quantities[-1] += remaining
+                remaining = Decimal("0")
+                break
+            child = min_qty
+        quantities.append(child)
+        remaining -= child
+
+    if remaining > 0 and quantities:
+        quantities[-1] += remaining
+
+    return [qty for qty in quantities if qty > 0]
 
 
 class CredentialWatcher:
@@ -357,6 +669,8 @@ class AccountContext:
         self._orders_lock = asyncio.Lock()
         self._startup_lock = asyncio.Lock()
         self._stream_task: Optional[asyncio.Task[None]] = None
+        self._child_parent: Dict[str, str] = {}
+        self._latency_tracker = _TransportLatencyTracker()
 
     async def start(self) -> None:
         async with self._startup_lock:
@@ -383,11 +697,13 @@ class AccountContext:
             self._stream_task = None
         if self.rest_client is not None:
             await self.rest_client.close()
+        self._child_parent.clear()
 
     async def _apply_stream_state(self, state: OrderState) -> None:
         if not state.client_order_id:
             return
         key = state.client_order_id
+        parent_key = self._child_parent.get(key, key)
         result = OMSOrderStatusResponse(
             exchange_order_id=state.exchange_order_id or state.client_order_id,
             status=state.status,
@@ -395,9 +711,26 @@ class AccountContext:
             avg_price=Decimal(str(state.avg_price or 0)),
             errors=state.errors or None,
         )
-        record = OrderRecord(client_id=key, result=result, transport=state.transport)
         async with self._orders_lock:
-            self._orders[key] = record
+            existing = self._orders.get(parent_key)
+            children = list(existing.children) if existing and existing.children else None
+            if children:
+                for idx, child in enumerate(children):
+                    if child.client_id == key:
+                        children[idx] = ChildOrderRecord(
+                            client_id=child.client_id,
+                            exchange_order_id=result.exchange_order_id,
+                            transport=state.transport,
+                        )
+                        break
+            transport = existing.transport if existing else state.transport
+            aggregate_result = result if parent_key == key else (existing.result if existing else result)
+            self._orders[parent_key] = OrderRecord(
+                client_id=parent_key,
+                result=aggregate_result,
+                transport=transport,
+                children=children,
+            )
 
     async def place_order(self, request: OMSPlaceRequest) -> OMSPlaceResponse:
         await self.start()
@@ -413,30 +746,75 @@ class AccountContext:
                 request.limit_px,
                 metadata,
             )
-
-            payload = self._build_payload(request, qty, px)
+            book_symbol = _resolve_book_symbol(request.symbol, metadata)
+            depth: Optional[Decimal] = None
             try:
-                ack = await self.ws_client.add_order(payload)
-                transport = "websocket"
-            except (KrakenWSTimeout, KrakenWSError) as exc:
-                logger.warning(
-                    "Websocket add_order failed for account %s: %s", self.account_id, exc
+                book = await order_book_store.ensure_book(book_symbol)
+                depth = await book.depth(request.side, levels=10)
+            except Exception as exc:
+                logger.debug(
+                    "Unable to fetch order book depth for %s on account %s: %s",
+                    book_symbol,
+                    self.account_id,
+                    exc,
                 )
-                try:
-                    ack = await self.rest_client.add_order(payload)
-                except KrakenRESTError as rest_exc:
-                    raise HTTPException(
-                        status_code=status.HTTP_502_BAD_GATEWAY,
-                        detail=str(rest_exc),
-                    ) from rest_exc
-                transport = "rest"
 
-            result = self._order_result_from_ack(request, ack)
+            child_quantities = self._plan_child_quantities(request, qty, metadata, depth)
+            if not child_quantities:
+                child_quantities = [qty]
+            increment_oms_child_orders_total(
+                self.account_id, request.symbol, len(child_quantities)
+            )
+            if len(child_quantities) > 1:
+                logger.info(
+                    "Slicing order for account %s symbol %s into %d child orders (depth=%s)",
+                    self.account_id,
+                    request.symbol,
+                    len(child_quantities),
+                    depth,
+                )
+
+            child_results: List[OMSOrderStatusResponse] = []
+            child_records: List[ChildOrderRecord] = []
+            transports_used: Set[str] = set()
+
+            for child_id, parent_id in list(self._child_parent.items()):
+                if parent_id == request.client_id:
+                    self._child_parent.pop(child_id, None)
+
+            for index, child_qty in enumerate(child_quantities):
+                child_client_base = self._child_client_id(request.client_id, index)
+                payload = self._build_payload(
+                    request, child_qty, px, client_id=child_client_base
+                )
+                ack, transport, client_id_used, _ = await self._submit_order_with_preference(
+                    payload, request.symbol, child_client_base
+                )
+                transports_used.add(transport)
+                child_result = self._order_result_from_ack(client_id_used, ack)
+                child_results.append(child_result)
+                child_records.append(
+                    ChildOrderRecord(
+                        client_id=client_id_used,
+                        exchange_order_id=child_result.exchange_order_id,
+                        transport=transport,
+                    )
+                )
+
+            aggregated_result = self._aggregate_child_results(
+                request.client_id, child_results, child_records
+            )
+            aggregate_transport = self._aggregate_transport(transports_used)
+
             async with self._orders_lock:
                 self._orders[request.client_id] = OrderRecord(
-                    client_id=request.client_id, result=result, transport=transport
+                    client_id=request.client_id,
+                    result=aggregated_result,
+                    transport=aggregate_transport,
+                    children=child_records,
                 )
-            return result
+                self._update_child_mapping(request.client_id, child_records)
+            return aggregated_result
 
         cache_key = f"place:{request.client_id}"
         result, reused = await self.idempotency.get_or_create(cache_key, _execute())
@@ -460,46 +838,81 @@ class AccountContext:
             assert self.ws_client is not None
             assert self.rest_client is not None
 
-            txid = request.exchange_order_id
-            if txid is None:
-                async with self._orders_lock:
-                    record = self._orders.get(request.client_id)
+            async with self._orders_lock:
+                record = self._orders.get(request.client_id)
+
+            target_txids: List[str] = []
+            if request.exchange_order_id is not None:
+                target_txids = [request.exchange_order_id]
+            else:
                 if record is None:
                     raise HTTPException(
                         status_code=status.HTTP_404_NOT_FOUND,
                         detail="Unknown order for cancellation",
                     )
-                txid = record.result.exchange_order_id
-
-            try:
-                ack = await self.ws_client.cancel_order({"txid": txid})
-                transport = "websocket"
-            except (KrakenWSTimeout, KrakenWSError) as exc:
-                logger.warning(
-                    "Websocket cancel failed for account %s: %s", self.account_id, exc
-                )
-                try:
-                    ack = await self.rest_client.cancel_order({"txid": txid})
-                except KrakenRESTError as rest_exc:
+                if record.children:
+                    target_txids = [
+                        child.exchange_order_id
+                        for child in record.children
+                        if child.exchange_order_id
+                    ]
+                if not target_txids and record.result.exchange_order_id:
+                    target_txids = [record.result.exchange_order_id]
+                if not target_txids:
                     raise HTTPException(
-                        status_code=status.HTTP_502_BAD_GATEWAY,
-                        detail=str(rest_exc),
-                    ) from rest_exc
-                transport = "rest"
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="No exchange order id available for cancellation",
+                    )
 
-            status_value = ack.status or ("rejected" if ack.errors else "canceled")
-            result = OMSOrderStatusResponse(
-                exchange_order_id=ack.exchange_order_id or txid,
-                status=status_value,
-                filled_qty=Decimal(str(ack.filled_qty or 0)),
-                avg_price=Decimal(str(ack.avg_price or 0)),
-                errors=ack.errors or None,
+            cancel_results: List[OMSOrderStatusResponse] = []
+            transports_used: List[str] = []
+            for txid in target_txids:
+                ack, transport = await self._cancel_single_txid(txid)
+                transports_used.append(transport)
+                status_value = ack.status or ("rejected" if ack.errors else "canceled")
+                cancel_results.append(
+                    OMSOrderStatusResponse(
+                        exchange_order_id=ack.exchange_order_id or txid,
+                        status=status_value,
+                        filled_qty=Decimal(str(ack.filled_qty or 0)),
+                        avg_price=Decimal(str(ack.avg_price or 0)),
+                        errors=ack.errors or None,
+                    )
+                )
+
+            child_records: List[ChildOrderRecord] = []
+            client_lookup = {}
+            if record and record.children:
+                client_lookup = {
+                    child.exchange_order_id: child.client_id for child in record.children
+                }
+            for result, transport in zip(cancel_results, transports_used):
+                child_client_id = client_lookup.get(result.exchange_order_id, request.client_id)
+                child_records.append(
+                    ChildOrderRecord(
+                        client_id=child_client_id,
+                        exchange_order_id=result.exchange_order_id,
+                        transport=transport,
+                    )
+                )
+
+            aggregated = self._aggregate_child_results(
+                request.client_id, cancel_results, child_records
             )
+            aggregate_transport = self._aggregate_transport(set(transports_used))
+
             async with self._orders_lock:
                 self._orders[request.client_id] = OrderRecord(
-                    client_id=request.client_id, result=result, transport=transport
+                    client_id=request.client_id,
+                    result=aggregated,
+                    transport=aggregate_transport,
+                    children=(record.children if record and record.children else child_records),
                 )
-            return result
+                if record and record.children:
+                    self._update_child_mapping(request.client_id, record.children)
+                else:
+                    self._update_child_mapping(request.client_id, child_records)
+            return aggregated
 
         cache_key = f"cancel:{request.client_id}"
         result, _ = await self.idempotency.get_or_create(cache_key, _execute_cancel())
@@ -510,10 +923,11 @@ class AccountContext:
         request: OMSPlaceRequest,
         qty: Decimal,
         price: Optional[Decimal],
+        client_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
-            "clientOrderId": request.client_id,
-            "pair": request.symbol.replace("-", "/").replace("_", "/"),
+            "clientOrderId": client_id or request.client_id,
+            "pair": _normalize_symbol(request.symbol),
             "type": request.side,
             "ordertype": request.order_type.lower(),
             "volume": str(qty),
@@ -540,16 +954,263 @@ class AccountContext:
 
         return payload
 
-    def _order_result_from_ack(
+    def _plan_child_quantities(
         self,
         request: OMSPlaceRequest,
+        qty: Decimal,
+        metadata: Dict[str, Any] | None,
+        depth: Optional[Decimal],
+    ) -> List[Decimal]:
+        if depth is None or depth <= 0:
+            return [qty]
+        max_child_qty = depth * Decimal("0.1")
+        if max_child_qty <= 0 or qty <= max_child_qty:
+            return [qty]
+
+        pair_meta = _resolve_pair_metadata(request.symbol, metadata)
+        min_qty = (
+            _PrecisionValidator._maybe_decimal(
+                pair_meta.get("ordermin"), pair_meta.get("min_qty")
+            )
+            if pair_meta
+            else None
+        )
+        qty_step = (
+            _PrecisionValidator._step(
+                pair_meta,
+                ["lot_step", "lot_decimals", "step_size"],
+            )
+            if pair_meta
+            else None
+        )
+
+        if min_qty is not None and max_child_qty < min_qty:
+            max_child_qty = min_qty
+
+        child_quantities = _split_quantities(qty, max_child_qty, qty_step, min_qty)
+        if not child_quantities:
+            child_quantities = [qty]
+
+        total_allocated = sum(child_quantities)
+        if total_allocated != qty and child_quantities:
+            difference = qty - total_allocated
+            child_quantities[-1] += difference
+        return [child for child in child_quantities if child > 0]
+
+    def _child_client_id(self, base: str, index: int) -> str:
+        return base if index == 0 else f"{base}-{index + 1}"
+
+    def _derive_retry_client_id(self, base: str) -> str:
+        return f"{base}-{uuid.uuid4().hex[:8]}"
+
+    def _update_child_mapping(self, parent: str, children: List[ChildOrderRecord]) -> None:
+        for key, value in list(self._child_parent.items()):
+            if value == parent:
+                self._child_parent.pop(key, None)
+        for child in children:
+            self._child_parent[child.client_id] = parent
+
+    def _aggregate_child_results(
+        self,
+        parent_client_id: str,
+        child_results: List[OMSOrderStatusResponse],
+        child_records: List[ChildOrderRecord],
+    ) -> OMSOrderStatusResponse:
+        if not child_results:
+            return OMSOrderStatusResponse(
+                exchange_order_id=parent_client_id,
+                status="accepted",
+                filled_qty=Decimal("0"),
+                avg_price=Decimal("0"),
+                errors=None,
+            )
+
+        total_filled = sum(result.filled_qty for result in child_results)
+        notional = Decimal("0")
+        errors: List[str] = []
+        statuses: List[str] = []
+        for result in child_results:
+            statuses.append(str(result.status))
+            if result.avg_price and result.filled_qty:
+                notional += result.avg_price * result.filled_qty
+            if result.errors:
+                for err in result.errors:
+                    if err not in errors:
+                        errors.append(err)
+
+        avg_price = Decimal("0")
+        if total_filled > 0 and notional > 0:
+            avg_price = (notional / total_filled).quantize(
+                AGGREGATE_PRICE_PRECISION, rounding=ROUND_HALF_EVEN
+            )
+
+        lowered = [status.lower() for status in statuses]
+        status_value = child_results[-1].status
+        if any(status.startswith("reject") for status in lowered):
+            status_value = "rejected"
+        elif any(status.startswith("cancel") for status in lowered):
+            status_value = "canceled"
+
+        exchange_ids = [child.exchange_order_id for child in child_records if child.exchange_order_id]
+        exchange_value = ",".join(exchange_ids) if exchange_ids else parent_client_id
+
+        return OMSOrderStatusResponse(
+            exchange_order_id=exchange_value,
+            status=status_value,
+            filled_qty=total_filled,
+            avg_price=avg_price,
+            errors=errors or None,
+        )
+
+    def _aggregate_transport(self, transports: Set[str]) -> str:
+        if not transports:
+            return "websocket"
+        if len(transports) == 1:
+            return next(iter(transports))
+        return "mixed"
+
+    async def _submit_order_with_preference(
+        self,
+        payload: Dict[str, Any],
+        symbol: str,
+        base_client_id: str,
+    ) -> Tuple[OrderAck, str, str, float]:
+        assert self.ws_client is not None
+        assert self.rest_client is not None
+
+        base_payload = dict(payload)
+        preferred = self._latency_tracker.preferred()
+        transports = [preferred]
+        fallback = "rest" if preferred == "websocket" else "websocket"
+        if fallback not in transports:
+            transports.append(fallback)
+
+        ws_failed = False
+        rest_after_ws_attempted = False
+        last_ws_error: Exception | None = None
+        last_rest_error: Exception | None = None
+
+        for transport in transports:
+            attempt_payload = dict(base_payload)
+            if transport == "rest" and ws_failed:
+                rest_after_ws_attempted = True
+                attempt_payload["clientOrderId"] = self._derive_retry_client_id(base_client_id)
+
+            start = time.perf_counter()
+            try:
+                if transport == "websocket":
+                    ack = await self.ws_client.add_order(attempt_payload)
+                else:
+                    ack = await self.rest_client.add_order(attempt_payload)
+            except (KrakenWSTimeout, KrakenWSError) as exc:
+                increment_oms_error_count(self.account_id, symbol, "websocket")
+                logger.warning(
+                    "Websocket add_order failed for account %s (%s): %s",
+                    self.account_id,
+                    symbol,
+                    exc,
+                )
+                ws_failed = True
+                last_ws_error = exc
+                continue
+            except KrakenRESTError as rest_exc:
+                increment_oms_error_count(self.account_id, symbol, "rest")
+                logger.warning(
+                    "REST add_order failed for account %s (%s): %s",
+                    self.account_id,
+                    symbol,
+                    rest_exc,
+                )
+                last_rest_error = rest_exc
+                continue
+
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            self._latency_tracker.record(transport, latency_ms)
+            record_oms_latency(self.account_id, symbol, transport, latency_ms)
+            logger.info(
+                "Order latency account=%s symbol=%s transport=%s latency=%.2fms",
+                self.account_id,
+                symbol,
+                transport,
+                latency_ms,
+            )
+            client_id_used = str(attempt_payload.get("clientOrderId", base_client_id))
+            return ack, transport, client_id_used, latency_ms
+
+        if ws_failed and not rest_after_ws_attempted:
+            rest_payload = dict(base_payload)
+            rest_payload["clientOrderId"] = self._derive_retry_client_id(base_client_id)
+            start = time.perf_counter()
+            try:
+                ack = await self.rest_client.add_order(rest_payload)
+            except KrakenRESTError as rest_exc:
+                increment_oms_error_count(self.account_id, symbol, "rest")
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=str(rest_exc),
+                ) from rest_exc
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            self._latency_tracker.record("rest", latency_ms)
+            record_oms_latency(self.account_id, symbol, "rest", latency_ms)
+            logger.info(
+                "Order latency account=%s symbol=%s transport=rest latency=%.2fms",
+                self.account_id,
+                symbol,
+                latency_ms,
+            )
+            client_id_used = str(rest_payload["clientOrderId"])
+            return ack, "rest", client_id_used, latency_ms
+
+        if last_rest_error is not None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=str(last_rest_error),
+            ) from last_rest_error
+
+        if last_ws_error is not None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=str(last_ws_error),
+            ) from last_ws_error
+
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Order submission failed: no transport available",
+        )
+
+    async def _cancel_single_txid(self, txid: str) -> Tuple[OrderAck, str]:
+        assert self.ws_client is not None
+        assert self.rest_client is not None
+
+        try:
+            ack = await self.ws_client.cancel_order({"txid": txid})
+            return ack, "websocket"
+        except (KrakenWSTimeout, KrakenWSError) as exc:
+            logger.warning(
+                "Websocket cancel failed for account %s (txid=%s): %s",
+                self.account_id,
+                txid,
+                exc,
+            )
+            try:
+                ack = await self.rest_client.cancel_order({"txid": txid})
+            except KrakenRESTError as rest_exc:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=str(rest_exc),
+                ) from rest_exc
+            return ack, "rest"
+
+    def _order_result_from_ack(
+        self,
+        client_id: str,
         ack: OrderAck,
     ) -> OMSOrderStatusResponse:
         status_value = ack.status or ("rejected" if ack.errors else "accepted")
         filled = Decimal(str(ack.filled_qty or 0))
         avg_price = Decimal(str(ack.avg_price or 0))
         return OMSOrderStatusResponse(
-            exchange_order_id=ack.exchange_order_id or request.client_id,
+            exchange_order_id=ack.exchange_order_id or client_id,
             status=status_value,
             filled_qty=filled,
             avg_price=avg_price,
@@ -594,6 +1255,7 @@ async def require_account_id(request: Request) -> str:
 @app.on_event("shutdown")
 async def _shutdown() -> None:
     await manager.shutdown()
+    await order_book_store.stop()
 
 
 @app.post("/oms/place", response_model=OMSPlaceResponse)


### PR DESCRIPTION
## Summary
- maintain an in-memory Kraken order book via public websocket subscriptions and use depth-aware slicing to break large orders into child submissions with parent/child tracking
- prefer the lowest-latency transport when placing orders, retry transient websocket failures via REST with a fresh client id, and expose new Prometheus counters/gauges for latency, errors, and child orders

## Testing
- pytest tests/services/oms/test_kraken_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dd6599ca5c8321be47c22ab2f858b9