### PR TITLE
Add OMS impact analytics storage and endpoint

### DIFF
--- a/services/oms/impact_store.py
+++ b/services/oms/impact_store.py
@@ -1,0 +1,306 @@
+"""Persistent storage for realized impact analytics.
+
+This module provides a small abstraction over TimescaleDB for recording
+historical fills alongside the pre-trade mid price and computing realized
+slippage curves.  The implementation gracefully degrades to an in-memory
+store when TimescaleDB is unavailable so unit tests and local development
+environments without the database continue to function.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from threading import Lock
+from typing import Any, DefaultDict, Dict, Iterable, List, Tuple
+
+from services.common.config import get_timescale_session
+
+try:  # pragma: no cover - optional dependency in CI
+    import psycopg
+    from psycopg import sql
+except Exception:  # pragma: no cover - fallback when psycopg is unavailable
+    psycopg = None
+    sql = None  # type: ignore
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ImpactFill:
+    """Structured representation of a recorded fill."""
+
+    account_id: str
+    client_order_id: str
+    symbol: str
+    side: str
+    filled_qty: float
+    avg_price: float
+    pre_trade_mid: float
+    impact_bps: float
+    recorded_at: datetime
+
+
+class ImpactAnalyticsStore:
+    """Timescale-backed persistence layer for trade impact analytics."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._initialized_accounts: set[str] = set()
+        self._memory: DefaultDict[Tuple[str, str], List[ImpactFill]] = defaultdict(list)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def record_fill(
+        self,
+        *,
+        account_id: str,
+        client_order_id: str,
+        symbol: str,
+        side: str,
+        filled_qty: float,
+        avg_price: float,
+        pre_trade_mid: float,
+        impact_bps: float,
+        recorded_at: datetime,
+    ) -> None:
+        fill = ImpactFill(
+            account_id=account_id,
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=side,
+            filled_qty=filled_qty,
+            avg_price=avg_price,
+            pre_trade_mid=pre_trade_mid,
+            impact_bps=impact_bps,
+            recorded_at=recorded_at,
+        )
+
+        if psycopg is None:
+            self._append_memory(fill)
+            return
+
+        from asyncio import to_thread
+
+        await to_thread(self._record_fill_sync, fill)
+
+    async def impact_curve(
+        self,
+        *,
+        account_id: str,
+        symbol: str,
+        limit: int = 500,
+        bucket_count: int = 10,
+    ) -> List[Dict[str, float]]:
+        if psycopg is None:
+            rows = [
+                (fill.filled_qty, fill.impact_bps)
+                for fill in self._memory.get((account_id, symbol), [])
+            ]
+            return self._build_curve(rows, bucket_count=bucket_count)
+
+        from asyncio import to_thread
+
+        return await to_thread(
+            self._impact_curve_sync,
+            account_id,
+            symbol,
+            limit,
+            bucket_count,
+        )
+
+    # ------------------------------------------------------------------
+    # Synchronous helpers executed in a threadpool
+    # ------------------------------------------------------------------
+    def _record_fill_sync(self, fill: ImpactFill) -> None:
+        assert psycopg is not None and sql is not None  # nosec - guarded by caller
+
+        session = get_timescale_session(fill.account_id)
+        try:
+            with psycopg.connect(session.dsn, autocommit=True) as conn:
+                self._ensure_schema(conn, session.account_schema)
+                insert_sql = sql.SQL(
+                    """
+                    INSERT INTO {}.{} (
+                        recorded_at,
+                        account_id,
+                        client_order_id,
+                        symbol,
+                        side,
+                        filled_qty,
+                        avg_price,
+                        pre_trade_mid,
+                        impact_bps
+                    )
+                    VALUES (
+                        %(recorded_at)s,
+                        %(account_id)s,
+                        %(client_order_id)s,
+                        %(symbol)s,
+                        %(side)s,
+                        %(filled_qty)s,
+                        %(avg_price)s,
+                        %(pre_trade_mid)s,
+                        %(impact_bps)s
+                    )
+                    ON CONFLICT DO NOTHING
+                """
+                ).format(
+                    sql.Identifier(session.account_schema),
+                    sql.Identifier("oms_fill_impact"),
+                )
+                params = {
+                    "recorded_at": fill.recorded_at,
+                    "account_id": fill.account_id,
+                    "client_order_id": fill.client_order_id,
+                    "symbol": fill.symbol,
+                    "side": fill.side,
+                    "filled_qty": fill.filled_qty,
+                    "avg_price": fill.avg_price,
+                    "pre_trade_mid": fill.pre_trade_mid,
+                    "impact_bps": fill.impact_bps,
+                }
+                with conn.cursor() as cursor:
+                    cursor.execute(insert_sql, params)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning(
+                "Failed to persist impact analytics for %s: %s. Falling back to in-memory store.",
+                fill.account_id,
+                exc,
+            )
+            self._append_memory(fill)
+
+    def _impact_curve_sync(
+        self,
+        account_id: str,
+        symbol: str,
+        limit: int,
+        bucket_count: int,
+    ) -> List[Dict[str, float]]:
+        assert psycopg is not None and sql is not None  # nosec - guarded by caller
+
+        session = get_timescale_session(account_id)
+        try:
+            with psycopg.connect(session.dsn, autocommit=True) as conn:
+                self._ensure_schema(conn, session.account_schema)
+                query = sql.SQL(
+                    """
+                    SELECT filled_qty::float8, impact_bps::float8
+                    FROM {}.{}
+                    WHERE symbol = %(symbol)s
+                    ORDER BY recorded_at DESC
+                    LIMIT %(limit)s
+                """
+                ).format(
+                    sql.Identifier(session.account_schema),
+                    sql.Identifier("oms_fill_impact"),
+                )
+                params = {"symbol": symbol, "limit": limit}
+                with conn.cursor() as cursor:
+                    cursor.execute(query, params)
+                    rows = cursor.fetchall()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning(
+                "Failed to query impact analytics for %s: %s. Falling back to in-memory data.",
+                account_id,
+                exc,
+            )
+            rows = [
+                (fill.filled_qty, fill.impact_bps)
+                for fill in self._memory.get((account_id, symbol), [])
+            ]
+
+        return self._build_curve(rows, bucket_count=bucket_count)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_schema(self, conn: "psycopg.Connection[Any]", schema: str) -> None:
+        if schema in self._initialized_accounts:
+            return
+
+        assert psycopg is not None and sql is not None  # nosec - guarded by caller
+
+        with self._lock:
+            if schema in self._initialized_accounts:
+                return
+
+            create_schema = sql.SQL("CREATE SCHEMA IF NOT EXISTS {}" ).format(
+                sql.Identifier(schema)
+            )
+            create_table = sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {}.{} (
+                    recorded_at TIMESTAMPTZ NOT NULL,
+                    account_id TEXT NOT NULL,
+                    client_order_id TEXT,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    filled_qty NUMERIC NOT NULL,
+                    avg_price NUMERIC NOT NULL,
+                    pre_trade_mid NUMERIC NOT NULL,
+                    impact_bps DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (recorded_at, account_id, symbol, client_order_id)
+                )
+                """
+            ).format(
+                sql.Identifier(schema),
+                sql.Identifier("oms_fill_impact"),
+            )
+            create_index = sql.SQL(
+                """
+                CREATE INDEX IF NOT EXISTS {} ON {}.{} (symbol, recorded_at DESC)
+                """
+            ).format(
+                sql.Identifier(f"{schema}_impact_symbol_recorded_at"),
+                sql.Identifier(schema),
+                sql.Identifier("oms_fill_impact"),
+            )
+            with conn.cursor() as cursor:
+                cursor.execute(create_schema)
+                cursor.execute(create_table)
+                cursor.execute(create_index)
+
+            self._initialized_accounts.add(schema)
+
+    @staticmethod
+    def _build_curve(
+        rows: Iterable[Tuple[float, float]],
+        *,
+        bucket_count: int,
+    ) -> List[Dict[str, float]]:
+        data = [row for row in rows if row[0] is not None and row[1] is not None]
+        if not data:
+            return []
+
+        ordered = sorted(data, key=lambda item: abs(item[0]))
+        buckets = max(1, min(bucket_count, len(ordered)))
+        chunk_size = max(1, math.ceil(len(ordered) / buckets))
+
+        points: List[Dict[str, float]] = []
+        for index in range(0, len(ordered), chunk_size):
+            chunk = ordered[index : index + chunk_size]
+            if not chunk:
+                continue
+            avg_size = sum(abs(entry[0]) for entry in chunk) / len(chunk)
+            avg_impact = sum(entry[1] for entry in chunk) / len(chunk)
+            points.append({"size": avg_size, "impact_bps": avg_impact})
+
+        return points
+
+    def _append_memory(self, fill: ImpactFill) -> None:
+        key = (fill.account_id, fill.symbol)
+        with self._lock:
+            self._memory[key].append(fill)
+
+
+impact_store = ImpactAnalyticsStore()
+
+
+__all__ = ["ImpactAnalyticsStore", "ImpactFill", "impact_store"]
+

--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_EVEN
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, Tuple
@@ -14,6 +15,7 @@ from typing import Any, Awaitable, Dict, Iterable, List, Optional, Tuple
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
 
+from services.oms.impact_store import ImpactAnalyticsStore, impact_store
 from services.oms.kraken_rest import KrakenRESTClient, KrakenRESTError
 from services.oms.kraken_ws import (
     KrakenWSError,
@@ -64,6 +66,11 @@ class OMSPlaceRequest(BaseModel):
         default=None,
         gt=Decimal("0"),
         description="Trailing stop offset",
+    )
+    pre_trade_mid_px: Optional[Decimal] = Field(
+        default=None,
+        gt=Decimal("0"),
+        description="Observed mid price immediately before order placement",
     )
 
     @field_validator("side")
@@ -120,6 +127,17 @@ class OMSPlaceResponse(OMSOrderStatusResponse):
     )
 
 
+class ImpactCurvePoint(BaseModel):
+    size: float
+    impact_bps: float
+
+
+class ImpactCurveResponse(BaseModel):
+    symbol: str
+    points: List[ImpactCurvePoint]
+    as_of: datetime
+
+
 class _IdempotencyStore:
     """Cooperative idempotency cache used per-account."""
 
@@ -158,6 +176,10 @@ class OrderRecord:
     client_id: str
     result: OMSOrderStatusResponse
     transport: str
+    symbol: str
+    side: str
+    pre_trade_mid: Optional[Decimal]
+    recorded_qty: Decimal = Decimal("0")
 
 
 class _PrecisionValidator:
@@ -357,6 +379,7 @@ class AccountContext:
         self._orders_lock = asyncio.Lock()
         self._startup_lock = asyncio.Lock()
         self._stream_task: Optional[asyncio.Task[None]] = None
+        self._impact_store: ImpactAnalyticsStore = impact_store
 
     async def start(self) -> None:
         async with self._startup_lock:
@@ -395,9 +418,29 @@ class AccountContext:
             avg_price=Decimal(str(state.avg_price or 0)),
             errors=state.errors or None,
         )
-        record = OrderRecord(client_id=key, result=result, transport=state.transport)
         async with self._orders_lock:
+            existing = self._orders.get(key)
+            if existing:
+                record = OrderRecord(
+                    client_id=key,
+                    result=result,
+                    transport=existing.transport,
+                    symbol=existing.symbol,
+                    side=existing.side,
+                    pre_trade_mid=existing.pre_trade_mid,
+                    recorded_qty=existing.recorded_qty,
+                )
+            else:
+                record = OrderRecord(
+                    client_id=key,
+                    result=result,
+                    transport=state.transport,
+                    symbol="",
+                    side="",
+                    pre_trade_mid=None,
+                )
             self._orders[key] = record
+        await self._record_trade_impact(record)
 
     async def place_order(self, request: OMSPlaceRequest) -> OMSPlaceResponse:
         await self.start()
@@ -434,7 +477,12 @@ class AccountContext:
             result = self._order_result_from_ack(request, ack)
             async with self._orders_lock:
                 self._orders[request.client_id] = OrderRecord(
-                    client_id=request.client_id, result=result, transport=transport
+                    client_id=request.client_id,
+                    result=result,
+                    transport=transport,
+                    symbol=request.symbol,
+                    side=request.side,
+                    pre_trade_mid=request.pre_trade_mid_px,
                 )
             return result
 
@@ -443,6 +491,8 @@ class AccountContext:
         async with self._orders_lock:
             record = self._orders.get(request.client_id)
         transport = record.transport if record else "websocket"
+        if record is not None:
+            await self._record_trade_impact(record)
         return OMSPlaceResponse(
             exchange_order_id=result.exchange_order_id,
             status=result.status,
@@ -496,8 +546,15 @@ class AccountContext:
                 errors=ack.errors or None,
             )
             async with self._orders_lock:
+                existing = self._orders.get(request.client_id)
                 self._orders[request.client_id] = OrderRecord(
-                    client_id=request.client_id, result=result, transport=transport
+                    client_id=request.client_id,
+                    result=result,
+                    transport=transport,
+                    symbol=existing.symbol if existing else "",
+                    side=existing.side if existing else "",
+                    pre_trade_mid=existing.pre_trade_mid if existing else None,
+                    recorded_qty=existing.recorded_qty if existing else Decimal("0"),
                 )
             return result
 
@@ -559,6 +616,49 @@ class AccountContext:
     async def lookup(self, client_id: str) -> OrderRecord | None:
         async with self._orders_lock:
             return self._orders.get(client_id)
+
+    async def _record_trade_impact(self, record: OrderRecord) -> None:
+        if record.pre_trade_mid is None:
+            return
+        if record.result.filled_qty <= 0:
+            return
+        if record.result.avg_price <= 0:
+            return
+        if record.recorded_qty >= record.result.filled_qty:
+            return
+        if not record.symbol:
+            return
+
+        filled_qty = record.result.filled_qty
+        avg_price = record.result.avg_price
+        mid_px = record.pre_trade_mid
+        if mid_px is None or mid_px <= 0:
+            return
+
+        normalized_side = record.side.lower()
+        if normalized_side not in {"buy", "sell"}:
+            return
+
+        direction = Decimal("1") if normalized_side == "buy" else Decimal("-1")
+        impact_ratio = (avg_price - mid_px) / mid_px
+        impact_bps = float((impact_ratio * direction * Decimal("10000")))
+
+        await self._impact_store.record_fill(
+            account_id=self.account_id,
+            client_order_id=record.client_id,
+            symbol=record.symbol,
+            side=record.side,
+            filled_qty=float(filled_qty),
+            avg_price=float(avg_price),
+            pre_trade_mid=float(mid_px),
+            impact_bps=impact_bps,
+            recorded_at=datetime.now(timezone.utc),
+        )
+
+        async with self._orders_lock:
+            current = self._orders.get(record.client_id)
+            if current:
+                current.recorded_qty = filled_qty
 
 
 class OMSManager:
@@ -641,5 +741,18 @@ async def get_status(
     if not record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown order")
     return record.result
+
+
+@app.get("/oms/impact_curve", response_model=ImpactCurveResponse)
+async def get_impact_curve(
+    symbol: str,
+    account_id: str = Depends(require_account_id),
+) -> ImpactCurveResponse:
+    points_raw = await impact_store.impact_curve(account_id=account_id, symbol=symbol)
+    points = [
+        ImpactCurvePoint(size=point["size"], impact_bps=point["impact_bps"])
+        for point in points_raw
+    ]
+    return ImpactCurveResponse(symbol=symbol, points=points, as_of=datetime.now(timezone.utc))
 
 


### PR DESCRIPTION
## Summary
- record pre-trade mid prices on OMS orders and compute realized trade impact
- persist impact analytics to TimescaleDB with an in-memory fallback and derive symbol impact curves
- expose a new `/oms/impact_curve` endpoint for retrieving size-vs-slippage data

## Testing
- pytest tests/services -k oms --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68dd66c4cd74832187facf33252deb42