### PR TITLE
Add trade explanation endpoint with SHAP output

### DIFF
--- a/services/models/model_server.py
+++ b/services/models/model_server.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-from services.policy.model_server import Intent, predict_intent
+from services.policy.model_server import Intent, get_active_model, predict_intent
 
-__all__ = ["Intent", "predict_intent"]
+__all__ = ["Intent", "predict_intent", "get_active_model"]
 
 

--- a/services/policy/model_server.py
+++ b/services/policy/model_server.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
 from services.common.schemas import ActionTemplate, BookSnapshot, ConfidenceMetrics
 
@@ -148,6 +148,28 @@ class DummyPolicyModel:
             return 0.0
         return total / float(count)
 
+    def explain(
+        self, feature_values: Mapping[str, float] | Sequence[float]
+    ) -> Dict[str, float]:
+        """Return a deterministic attribution for the supplied features."""
+
+        if isinstance(feature_values, Mapping):
+            items: Iterable[Tuple[str, float]] = (
+                (str(key), float(value)) for key, value in feature_values.items()
+            )
+        else:
+            items = ((f"feature_{idx}", float(value)) for idx, value in enumerate(feature_values))
+
+        values = list(items)
+        if not values:
+            return {}
+
+        normalizer = float(len(values))
+        if normalizer == 0:
+            return {}
+
+        return {name: contribution / normalizer for name, contribution in values}
+
 
 class MLflowClientStub:
     """Very small stand-in for the MLflow client used in production."""
@@ -195,3 +217,10 @@ def predict_intent(
     except Exception:  # pragma: no cover - defensive safety net
         logger.exception("Failed to generate intent for account=%s symbol=%s", account_id, symbol)
         return Intent.null()
+
+
+def get_active_model(account_id: str, symbol: str) -> DummyPolicyModel:
+    """Return the latest model instance for ``account_id`` and ``symbol``."""
+
+    model_key = _model_name(account_id, symbol)
+    return _client.load_latest_model(model_key)

--- a/tests/reports/test_trade_explain.py
+++ b/tests/reports/test_trade_explain.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi.testclient import TestClient
+import pytest
+
+
+pytest.importorskip("pandas", exc_type=ImportError)
+
+import report_service
+
+
+class StubModel:
+    def __init__(self, shap_values: Dict[str, float]) -> None:
+        self._shap_values = shap_values
+
+    def explain(self, features: Dict[str, float]) -> Dict[str, float]:
+        # ignore provided features and return the predetermined attributions
+        return self._shap_values
+
+
+def test_trade_explain_returns_sorted_top_features(monkeypatch) -> None:
+    trade_record = {
+        "fill_id": "fill-123",
+        "account_id": "alpha",
+        "instrument": "BTC-USD",
+        "order_metadata": {
+            "features": {
+                "alpha": 1.0,
+                "beta": 2.0,
+                "gamma": 3.0,
+                "delta": 4.0,
+                "epsilon": 5.0,
+                "zeta": 6.0,
+            },
+            "model_version": "2024.06.01",
+        },
+    }
+
+    shap_values = {
+        "alpha": 0.1,
+        "beta": -0.2,
+        "gamma": 0.05,
+        "delta": -0.6,
+        "epsilon": 0.3,
+        "zeta": -0.4,
+    }
+
+    monkeypatch.setattr(report_service, "_load_trade_record", lambda trade_id: trade_record)
+    monkeypatch.setattr(report_service, "get_active_model", lambda account_id, instrument: StubModel(shap_values))
+
+    client = TestClient(report_service.app)
+    response = client.get("/reports/trade_explain", params={"trade_id": "fill-123"})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["trade_id"] == "fill-123"
+    assert payload["account_id"] == "alpha"
+    assert payload["instrument"] == "BTC-USD"
+    assert payload["model_version"] == "2024.06.01"
+
+    feature_importance = payload["feature_importance"]
+    assert len(feature_importance) == 6
+    assert feature_importance[0]["feature"] == "delta"
+    assert feature_importance[0]["importance"] == -0.6
+    assert feature_importance[-1]["feature"] == "gamma"
+
+    top_features = payload["top_features"]
+    assert len(top_features) == 5
+    assert [entry["feature"] for entry in top_features] == [
+        "delta",
+        "zeta",
+        "epsilon",
+        "beta",
+        "alpha",
+    ]
+
+
+def test_trade_explain_missing_features_returns_422(monkeypatch) -> None:
+    trade_record = {"fill_id": "fill-404", "account_id": "beta", "instrument": "ETH-USD"}
+
+    monkeypatch.setattr(report_service, "_load_trade_record", lambda trade_id: trade_record)
+
+    client = TestClient(report_service.app)
+    response = client.get("/reports/trade_explain", params={"trade_id": "fill-404"})
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Trade is missing feature metadata"


### PR DESCRIPTION
## Summary
- add utilities in the report service to normalise trade features and load trade metadata
- expose a /reports/trade_explain endpoint that returns model-based SHAP feature importance per trade and trim HTML reports to the top features
- extend the dummy policy model with an explain helper, re-export the loader, and cover the behaviour with tests

## Testing
- pytest tests/reports/test_trade_explain.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d6e1a083219574d39294b1ea59