### PR TITLE
Add daily log export workflow and status endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from auth.routes import get_auth_service, router as auth_router
 from auth.service import AdminRepository, AuthService, SessionStore
 from services.alert_manager import setup_alerting
 from services.report_service import router as reports_router
+from services.logging_export import router as logging_export_router
 from exposure_forecast import router as exposure_router
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 from shared.correlation import CorrelationIdMiddleware
@@ -35,6 +36,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router)
     app.include_router(reports_router)
     app.include_router(exposure_router)
+    app.include_router(logging_export_router)
 
     app.state.audit_store = audit_store
     app.state.audit_logger = audit_logger

--- a/daily_export.py
+++ b/daily_export.py
@@ -1,0 +1,106 @@
+"""Daily export utility for audit and regulatory logs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import sys
+import time
+from typing import Callable
+
+from logging_export import ExportConfig, MissingDependencyError, run_export
+
+
+DEFAULT_SLEEP_INTERVAL = 5.0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit and reg-log export utility")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Start the export routine")
+    run_parser.add_argument(
+        "--date",
+        type=lambda value: dt.datetime.strptime(value, "%Y-%m-%d").date(),
+        help="Explicit date to export (defaults to yesterday in UTC)",
+    )
+    run_parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Continuously wait until midnight UTC and export for the previous day",
+    )
+
+    return parser.parse_args()
+
+
+def _resolve_export_date(explicit: dt.date | None = None) -> dt.date:
+    if explicit:
+        return explicit
+    now = dt.datetime.now(dt.timezone.utc)
+    return (now - dt.timedelta(days=1)).date()
+
+
+def _load_config() -> ExportConfig:
+    bucket = os.getenv("EXPORT_BUCKET")
+    if not bucket:
+        raise RuntimeError("EXPORT_BUCKET environment variable must be set")
+    prefix = os.getenv("EXPORT_PREFIX", "log-exports")
+    endpoint_url = os.getenv("EXPORT_S3_ENDPOINT_URL")
+    return ExportConfig(bucket=bucket, prefix=prefix, endpoint_url=endpoint_url)
+
+
+def _run_once(export_date: dt.date) -> None:
+    config = _load_config()
+    result = run_export(for_date=export_date, config=config)
+    sys.stdout.write(
+        "Exported logs for {date} to s3://{bucket}/{key} (sha256={digest})\n".format(
+            date=result.export_date.isoformat(),
+            bucket=result.s3_bucket,
+            key=result.s3_key,
+            digest=result.sha256,
+        )
+    )
+
+
+def _seconds_until_midnight_utc(now: dt.datetime | None = None) -> float:
+    now = now or dt.datetime.now(dt.timezone.utc)
+    tomorrow = (now + dt.timedelta(days=1)).date()
+    midnight = dt.datetime.combine(tomorrow, dt.time.min, tzinfo=dt.timezone.utc)
+    delta = midnight - now
+    return max(delta.total_seconds(), 0.0)
+
+
+def _daemon_loop(run_once: Callable[[dt.date], None]) -> None:
+    while True:
+        sleep_for = _seconds_until_midnight_utc()
+        time.sleep(sleep_for)
+        export_date = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=1)).date()
+        try:
+            run_once(export_date)
+        except Exception as exc:  # pragma: no cover - best effort logging for daemon mode
+            sys.stderr.write(f"log export failed for {export_date}: {exc}\n")
+        finally:
+            time.sleep(DEFAULT_SLEEP_INTERVAL)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    try:
+        export_date = _resolve_export_date(args.date if args.command == "run" else None)
+        if getattr(args, "daemon", False):
+            _daemon_loop(_run_once)
+        else:
+            _run_once(export_date)
+    except MissingDependencyError as exc:
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(2)
+    except Exception as exc:
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/logging_export.py
+++ b/logging_export.py
@@ -1,0 +1,269 @@
+"""Utilities for exporting audit and regulatory logs to external storage."""
+
+from __future__ import annotations
+
+import datetime as dt
+import gzip
+import io
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional
+
+try:  # pragma: no cover - boto3 is optional during unit tests.
+    import boto3
+except Exception:  # pragma: no cover
+    boto3 = None  # type: ignore
+
+try:  # pragma: no cover - psycopg might not be present in some test environments.
+    import psycopg
+    from psycopg.rows import dict_row
+except Exception:  # pragma: no cover
+    psycopg = None  # type: ignore
+    dict_row = None  # type: ignore
+
+
+DEFAULT_EXPORT_PREFIX = "log-exports"
+
+
+class MissingDependencyError(RuntimeError):
+    """Raised when an optional dependency required at runtime is missing."""
+
+
+@dataclass(frozen=True)
+class ExportConfig:
+    """Configuration required to ship the generated archive to object storage."""
+
+    bucket: str
+    prefix: str = DEFAULT_EXPORT_PREFIX
+    endpoint_url: str | None = None
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """Metadata captured once an export is successfully persisted."""
+
+    export_date: dt.date
+    exported_at: dt.datetime
+    s3_bucket: str
+    s3_key: str
+    sha256: str
+
+
+def _require_psycopg() -> None:
+    if psycopg is None:  # pragma: no cover - sanity guard for environments without psycopg.
+        raise MissingDependencyError("psycopg is required for log export functionality")
+
+
+def _database_dsn() -> str:
+    dsn = (
+        os.getenv("LOG_EXPORT_DATABASE_URL")
+        or os.getenv("AUDIT_DATABASE_URL")
+        or os.getenv("DATABASE_URL")
+    )
+    if not dsn:
+        raise RuntimeError(
+            "LOG_EXPORT_DATABASE_URL, AUDIT_DATABASE_URL, or DATABASE_URL must be set",
+        )
+    return dsn
+
+
+def ensure_export_table(conn: "psycopg.Connection[Any]") -> None:
+    """Ensure the metadata table for exports exists."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS log_export_status (
+                id BIGSERIAL PRIMARY KEY,
+                export_date DATE NOT NULL,
+                exported_at TIMESTAMPTZ NOT NULL,
+                s3_bucket TEXT NOT NULL,
+                s3_key TEXT NOT NULL,
+                sha256 TEXT NOT NULL UNIQUE
+            )
+            """.strip()
+        )
+    conn.commit()
+
+
+def _normalise_json(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+def _fetch_audit_logs(
+    conn: "psycopg.Connection[Any]",
+    start: dt.datetime,
+    end: dt.datetime,
+) -> List[dict[str, Any]]:
+    with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[arg-type]
+        cur.execute(
+            """
+            SELECT id, actor, action, entity, before_json, after_json, ts, ip_hash
+            FROM audit_log
+            WHERE ts >= %s AND ts < %s
+            ORDER BY ts ASC
+            """.strip(),
+            (start, end),
+        )
+        rows: Iterable[dict[str, Any]] = cur.fetchall()
+    records: List[dict[str, Any]] = []
+    for row in rows:
+        row = dict(row)
+        row["before_json"] = _normalise_json(row.get("before_json", "{}"))
+        row["after_json"] = _normalise_json(row.get("after_json", "{}"))
+        if isinstance(row.get("ts"), dt.datetime):
+            row["ts"] = row["ts"].astimezone(dt.timezone.utc).isoformat()
+        records.append(row)
+    return records
+
+
+def _fetch_reg_logs(
+    conn: "psycopg.Connection[Any]",
+    start: dt.datetime,
+    end: dt.datetime,
+) -> List[dict[str, Any]]:
+    with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[arg-type]
+        cur.execute(
+            """
+            SELECT id, ts, actor, action, payload, hash, prev_hash
+            FROM reg_log
+            WHERE ts >= %s AND ts < %s
+            ORDER BY ts ASC
+            """.strip(),
+            (start, end),
+        )
+        rows: Iterable[dict[str, Any]] = cur.fetchall()
+    records: List[dict[str, Any]] = []
+    for row in rows:
+        row = dict(row)
+        row["payload"] = _normalise_json(row.get("payload", "{}"))
+        if isinstance(row.get("ts"), dt.datetime):
+            row["ts"] = row["ts"].astimezone(dt.timezone.utc).isoformat()
+        records.append(row)
+    return records
+
+
+def _gzip_bytes(payload: Any) -> bytes:
+    buffer = io.BytesIO()
+    with gzip.GzipFile(mode="wb", fileobj=buffer) as gz:
+        gz.write(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    return buffer.getvalue()
+
+
+def _compute_sha256(blob: bytes) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    digest.update(blob)
+    return digest.hexdigest()
+
+
+def _s3_client(endpoint_url: str | None = None):
+    if boto3 is None:  # pragma: no cover - guard against optional dependency missing in tests.
+        raise MissingDependencyError("boto3 is required for log export uploads")
+    client_kwargs: dict[str, Any] = {}
+    if endpoint_url:
+        client_kwargs["endpoint_url"] = endpoint_url
+    return boto3.client("s3", **client_kwargs)  # type: ignore[return-value]
+
+
+def _build_s3_key(prefix: str, export_date: dt.date) -> str:
+    return f"{prefix.rstrip('/')}/audit-reg-log-{export_date.isoformat()}.json.gz"
+
+
+def run_export(
+    *,
+    for_date: dt.date,
+    config: ExportConfig,
+    dsn: str | None = None,
+) -> ExportResult:
+    """Export audit and regulatory logs for *for_date* and upload to object storage."""
+
+    _require_psycopg()
+    resolved_dsn = dsn or _database_dsn()
+    now = dt.datetime.now(dt.timezone.utc)
+    start = dt.datetime.combine(for_date, dt.time.min, tzinfo=dt.timezone.utc)
+    end = start + dt.timedelta(days=1)
+
+    with psycopg.connect(resolved_dsn) as conn:  # type: ignore[arg-type]
+        ensure_export_table(conn)
+        audit_records = _fetch_audit_logs(conn, start, end)
+        reg_records = _fetch_reg_logs(conn, start, end)
+
+        export_payload = {
+            "export_date": for_date.isoformat(),
+            "generated_at": now.isoformat(),
+            "audit_log": audit_records,
+            "reg_log": reg_records,
+        }
+
+        gz_blob = _gzip_bytes(export_payload)
+        digest = _compute_sha256(gz_blob)
+        key = _build_s3_key(config.prefix, for_date)
+
+        client = _s3_client(config.endpoint_url)
+        client.put_object(Bucket=config.bucket, Key=key, Body=gz_blob)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO log_export_status (export_date, exported_at, s3_bucket, s3_key, sha256)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (sha256) DO NOTHING
+                """.strip(),
+                (for_date, now, config.bucket, key, digest),
+            )
+        conn.commit()
+
+    return ExportResult(
+        export_date=for_date,
+        exported_at=now,
+        s3_bucket=config.bucket,
+        s3_key=key,
+        sha256=digest,
+    )
+
+
+def latest_export(dsn: str | None = None) -> Optional[ExportResult]:
+    """Return metadata for the most recent export if available."""
+
+    _require_psycopg()
+    resolved_dsn = dsn or _database_dsn()
+    with psycopg.connect(resolved_dsn) as conn:  # type: ignore[arg-type]
+        ensure_export_table(conn)
+        with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[arg-type]
+            cur.execute(
+                """
+                SELECT export_date, exported_at, s3_bucket, s3_key, sha256
+                FROM log_export_status
+                ORDER BY exported_at DESC
+                LIMIT 1
+                """.strip()
+            )
+            row = cur.fetchone()
+    if not row:
+        return None
+    exported_at = row["exported_at"]
+    if isinstance(exported_at, dt.datetime) and exported_at.tzinfo is None:
+        exported_at = exported_at.replace(tzinfo=dt.timezone.utc)
+    return ExportResult(
+        export_date=row["export_date"],
+        exported_at=exported_at,
+        s3_bucket=row["s3_bucket"],
+        s3_key=row["s3_key"],
+        sha256=row["sha256"],
+    )
+
+
+__all__ = [
+    "ExportConfig",
+    "ExportResult",
+    "MissingDependencyError",
+    "latest_export",
+    "run_export",
+]
+

--- a/services/logging_export.py
+++ b/services/logging_export.py
@@ -1,0 +1,34 @@
+"""API surface for log export status reporting."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from fastapi import APIRouter, HTTPException
+
+from logging_export import MissingDependencyError, latest_export
+
+
+router = APIRouter(prefix="/logging/export", tags=["logging"])
+
+
+@router.get("/status")
+def export_status() -> dict[str, dt.datetime | str | None]:
+    """Return metadata describing the most recent log export."""
+
+    try:
+        result = latest_export()
+    except MissingDependencyError as exc:  # pragma: no cover - exercised via HTTPException
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if result is None:
+        return {"last_export": None, "hash": None}
+
+    return {
+        "last_export": result.exported_at.astimezone(dt.timezone.utc).isoformat(),
+        "hash": result.sha256,
+    }
+
+
+__all__ = ["router", "export_status"]
+

--- a/tests/test_logging_export_status.py
+++ b/tests/test_logging_export_status.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from app import create_app
+from logging_export import ExportResult
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_export_status_returns_empty_payload(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr("services.logging_export.latest_export", lambda: None)
+
+    response = client.get("/logging/export/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"last_export": None, "hash": None}
+
+
+def test_export_status_returns_latest_metadata(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    export_date = dt.date(2024, 1, 1)
+    exported_at = dt.datetime(2024, 1, 2, 0, 5, tzinfo=dt.timezone.utc)
+    result = ExportResult(
+        export_date=export_date,
+        exported_at=exported_at,
+        s3_bucket="exports",
+        s3_key="log-exports/audit-reg-log-2024-01-01.json.gz",
+        sha256="abc123",
+    )
+    monkeypatch.setattr("services.logging_export.latest_export", lambda: result)
+
+    response = client.get("/logging/export/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "last_export": exported_at.isoformat(),
+        "hash": "abc123",
+    }
+
+
+def test_seconds_until_midnight(monkeypatch: pytest.MonkeyPatch) -> None:
+    from daily_export import _seconds_until_midnight_utc
+
+    now = dt.datetime(2024, 6, 1, 23, 30, tzinfo=dt.timezone.utc)
+    seconds = _seconds_until_midnight_utc(now)
+
+    assert pytest.approx(seconds, rel=1e-6) == 30 * 60
+
+
+def test_resolve_export_date_defaults_to_yesterday(monkeypatch: pytest.MonkeyPatch) -> None:
+    from daily_export import _resolve_export_date
+
+    today = dt.datetime(2024, 6, 2, 0, 5, tzinfo=dt.timezone.utc)
+    monkeypatch.setattr(dt, "datetime", type("_dt", (), {"now": staticmethod(lambda tz=None: today)}))
+
+    resolved = _resolve_export_date(None)
+
+    assert resolved == dt.date(2024, 6, 1)
+


### PR DESCRIPTION
## Summary
- add a shared log export utility that collects audit/regulatory logs, gzips them, uploads to object storage, and records metadata in Postgres
- introduce a daily_export CLI for running the export on demand or in a daemon loop
- expose `/logging/export/status` via FastAPI to report the latest export metadata and cover it with tests

## Testing
- pytest tests/test_logging_export_status.py

------
https://chatgpt.com/codex/tasks/task_e_68dd88da27648321aedbd05fff81e194