### PR TITLE
Add compliance scanner service and enforce sanctions in risk engine

### DIFF
--- a/compliance_scanner.py
+++ b/compliance_scanner.py
@@ -1,0 +1,264 @@
+"""FastAPI service that maintains regulatory sanctions watchlists."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import httpx
+from fastapi import FastAPI
+from sqlalchemy import delete
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.common.compliance import SanctionRecord, ensure_sanctions_schema
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+DEFAULT_DATABASE_URL = "sqlite:///./risk.db"
+_REFRESH_INTERVAL = timedelta(days=1)
+_REQUEST_TIMEOUT = float(os.getenv("COMPLIANCE_FETCH_TIMEOUT", "10"))
+
+_DEFAULT_SOURCE_DATA: Dict[str, Dict[str, str]] = {
+    "OFAC": {
+        "RUSL": "sanctioned",
+        "IRN": "sanctioned",
+        "PRK": "sanctioned",
+    },
+    "FCA": {
+        "XYZCN": "restricted",
+        "DV8": "under_review",
+    },
+}
+
+
+def _database_url() -> str:
+    url = (
+        os.getenv("COMPLIANCE_DATABASE_URL")
+        or os.getenv("RISK_DATABASE_URL")
+        or os.getenv("TIMESCALE_DSN")
+        or os.getenv("DATABASE_URL")
+        or DEFAULT_DATABASE_URL
+    )
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+psycopg2://", 1)
+    return url
+
+
+def _engine_options(url: str) -> Dict[str, object]:
+    options: Dict[str, object] = {"future": True}
+    if url.startswith("sqlite://"):
+        options.setdefault("connect_args", {"check_same_thread": False})
+        if url.endswith(":memory:"):
+            options["poolclass"] = StaticPool
+    return options
+
+
+_DB_URL = _database_url()
+ENGINE = create_engine(_DB_URL, **_engine_options(_DB_URL))
+SessionLocal = sessionmaker(bind=ENGINE, autoflush=False, expire_on_commit=False, future=True)
+
+
+app = FastAPI(title="Compliance Scanner", version="1.0.0")
+
+_scan_lock = asyncio.Lock()
+_background_task: Optional[asyncio.Task[None]] = None
+_last_updated: Optional[datetime] = None
+_symbols_checked: int = 0
+
+
+async def _load_watchlist_from_url(
+    client: httpx.AsyncClient, url: str
+) -> List[Tuple[str, str]]:
+    """Fetch a sanctions list from a configurable URL."""
+
+    response = await client.get(url)
+    response.raise_for_status()
+    entries: List[Tuple[str, str]] = []
+    content_type = response.headers.get("content-type", "")
+    text = response.text
+    if "json" in content_type:
+        payload = response.json()
+        entries.extend(_parse_json_payload(payload))
+    else:
+        entries.extend(_parse_delimited_payload(text))
+    return entries
+
+
+def _parse_json_payload(payload: object) -> List[Tuple[str, str]]:
+    """Parse arbitrary JSON payloads into sanctions entries."""
+
+    entries: List[Tuple[str, str]] = []
+    if isinstance(payload, list):
+        iterable: Iterable[object] = payload
+    elif isinstance(payload, dict):
+        iterable = payload.get("sanctions") or payload.get("results") or []
+        if isinstance(iterable, dict):
+            iterable = [
+                {"symbol": key, "status": value}
+                for key, value in iterable.items()
+            ]
+    else:
+        iterable = []
+
+    for item in iterable:
+        if isinstance(item, dict):
+            symbol = str(item.get("symbol") or item.get("ticker") or "").strip()
+            status = str(item.get("status") or item.get("state") or "sanctioned").strip()
+            if symbol:
+                entries.append((symbol.upper(), status.lower()))
+        elif isinstance(item, (list, tuple)) and len(item) >= 1:
+            symbol = str(item[0]).strip()
+            status = str(item[1]).strip() if len(item) > 1 else "sanctioned"
+            if symbol:
+                entries.append((symbol.upper(), status.lower()))
+    return entries
+
+
+def _parse_delimited_payload(text: str) -> List[Tuple[str, str]]:
+    """Parse CSV or newline delimited text of sanctions entries."""
+
+    entries: List[Tuple[str, str]] = []
+    sample = text.strip().splitlines()
+    if not sample:
+        return entries
+    reader = csv.reader(sample)
+    for row in reader:
+        if not row:
+            continue
+        symbol = row[0].strip()
+        status = row[1].strip() if len(row) > 1 else "sanctioned"
+        if symbol:
+            entries.append((symbol.upper(), status.lower()))
+    return entries
+
+
+def _parse_inline_configuration(raw: Optional[str]) -> List[Tuple[str, str]]:
+    entries: List[Tuple[str, str]] = []
+    if not raw:
+        return entries
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if ":" in token:
+            symbol, status = token.split(":", 1)
+        else:
+            symbol, status = token, "sanctioned"
+        symbol = symbol.strip()
+        status = status.strip() or "sanctioned"
+        if symbol:
+            entries.append((symbol.upper(), status.lower()))
+    return entries
+
+
+async def _fetch_source_entries(
+    client: httpx.AsyncClient, source: str
+) -> List[Tuple[str, str]]:
+    """Retrieve sanctions for the provided source."""
+
+    url = os.getenv(f"{source}_SANCTIONS_URL")
+    inline = os.getenv(f"{source}_SANCTIONS_SYMBOLS")
+    entries: List[Tuple[str, str]] = []
+    if url:
+        try:
+            entries.extend(await _load_watchlist_from_url(client, url))
+        except Exception as exc:  # pragma: no cover - network resilience
+            logger.warning("Failed to pull %s sanctions from %s: %s", source, url, exc)
+    if not entries:
+        entries.extend(_parse_inline_configuration(inline))
+    if not entries:
+        defaults = _DEFAULT_SOURCE_DATA.get(source, {})
+        entries.extend((symbol, status) for symbol, status in defaults.items())
+    return entries
+
+
+def _upsert_sanctions(session: Session, source: str, entries: Sequence[Tuple[str, str]], ts: datetime) -> int:
+    """Persist sanctions entries for the given source."""
+
+    deleted = session.execute(
+        delete(SanctionRecord).where(SanctionRecord.source == source)
+    )
+    logger.debug("Removed %s previous sanctions rows for %s", deleted.rowcount, source)
+
+    count = 0
+    for symbol, status in entries:
+        record = SanctionRecord(symbol=symbol.upper(), status=status.lower(), source=source, ts=ts)
+        session.add(record)
+        count += 1
+    return count
+
+
+async def _refresh_watchlists() -> None:
+    global _last_updated, _symbols_checked
+
+    async with _scan_lock:
+        logger.info("Starting sanctions refresh job")
+        now = datetime.now(timezone.utc)
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+            ofac_entries = await _fetch_source_entries(client, "OFAC")
+            fca_entries = await _fetch_source_entries(client, "FCA")
+        symbols = {symbol for symbol, status in ofac_entries + fca_entries}
+        with SessionLocal() as session:
+            with session.begin():
+                ofac_count = _upsert_sanctions(session, "OFAC", ofac_entries, now)
+                fca_count = _upsert_sanctions(session, "FCA", fca_entries, now)
+        _last_updated = now
+        _symbols_checked = len(symbols)
+        logger.info(
+            "Sanctions refresh completed. OFAC=%s FCA=%s total_symbols=%s",
+            ofac_count,
+            fca_count,
+            _symbols_checked,
+        )
+
+
+async def _refresh_periodically() -> None:
+    while True:
+        try:
+            await _refresh_watchlists()
+        except Exception:  # pragma: no cover - defensive scheduling
+            logger.exception("Periodic sanctions refresh failed")
+        await asyncio.sleep(_REFRESH_INTERVAL.total_seconds())
+
+
+@app.on_event("startup")
+async def _on_startup() -> None:
+    global _background_task
+
+    ensure_sanctions_schema(ENGINE)
+    await _refresh_watchlists()
+    _background_task = asyncio.create_task(_refresh_periodically())
+
+
+@app.on_event("shutdown")
+async def _on_shutdown() -> None:
+    global _background_task
+
+    if _background_task:
+        _background_task.cancel()
+        try:
+            await _background_task
+        except asyncio.CancelledError:  # pragma: no cover - expected on shutdown
+            pass
+        _background_task = None
+
+
+@app.get("/compliance/scan/status")
+async def get_scan_status() -> Dict[str, Optional[str]]:
+    last_updated = _last_updated.isoformat() if _last_updated else None
+    return {"symbols_checked": _symbols_checked, "last_updated": last_updated}
+
+
+@app.post("/compliance/scan/run")
+async def run_scan_now() -> Dict[str, Optional[str]]:
+    await _refresh_watchlists()
+    return await get_scan_status()

--- a/risk_service.py
+++ b/risk_service.py
@@ -18,7 +18,7 @@ from typing import Callable, Dict, Iterable, Iterator, List, Optional
 import httpx
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_validator
-from sqlalchemy import Column, DateTime, Float, Integer, String, create_engine
+from sqlalchemy import Column, DateTime, Float, Integer, String, create_engine, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -28,6 +28,11 @@ from metrics import (
     increment_trade_rejection,
     record_fees_nav_pct,
     setup_metrics,
+)
+from services.common.compliance import (
+    SanctionRecord,
+    ensure_sanctions_schema,
+    is_blocking_status,
 )
 from services.common.security import require_admin_account
 
@@ -272,6 +277,7 @@ def _seed_default_limits(session: Session) -> None:
 
 def _bootstrap_storage() -> None:
     Base.metadata.create_all(bind=ENGINE)
+    ensure_sanctions_schema(ENGINE)
     with get_session() as session:
         _seed_default_limits(session)
 
@@ -601,6 +607,16 @@ def _load_account_limits(account_id: str) -> AccountRiskLimit:
         return limits
 
 
+def _load_sanction_hits(symbol: str) -> List[SanctionRecord]:
+    """Return active sanction records for the provided symbol."""
+
+    normalized_symbol = symbol.upper()
+    with get_session() as session:
+        stmt = select(SanctionRecord).where(SanctionRecord.symbol == normalized_symbol)
+        records = session.execute(stmt).scalars().all()
+    return [record for record in records if is_blocking_status(record.status)]
+
+
 def _evaluate(context: RiskEvaluationContext) -> RiskValidationResponse:
     reasons: List[str] = []
     suggested_quantities: List[float] = []
@@ -633,6 +649,22 @@ def _evaluate(context: RiskEvaluationContext) -> RiskValidationResponse:
             nonlocal cooldown_until
             cooldown_until = cooldown_until or _determine_cooldown(limits)
         _audit_violation(context, message, details)
+
+    sanction_hits = _load_sanction_hits(intent.instrument_id)
+    if sanction_hits:
+        sources = sorted({record.source for record in sanction_hits})
+        statuses = sorted({record.status.lower() for record in sanction_hits})
+        _register_violation(
+            "Instrument is present on compliance sanctions list",
+            cooldown=True,
+            details={"sources": sources, "statuses": statuses},
+        )
+        return RiskValidationResponse(
+            pass_=False,
+            reasons=reasons,
+            adjusted_qty=0.0,
+            cooldown=cooldown_until,
+        )
 
     allocator_state = _query_allocator_state(context.request.account_id)
     if allocator_state:

--- a/services/common/compliance.py
+++ b/services/common/compliance.py
@@ -1,0 +1,60 @@
+"""Shared utilities for compliance and sanctions data management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Set
+
+from sqlalchemy import Column, DateTime, PrimaryKeyConstraint, String
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import declarative_base
+
+
+SanctionsBase = declarative_base()
+
+
+class SanctionRecord(SanctionsBase):
+    """ORM mapping for sanctions sourced from regulatory watchlists."""
+
+    __tablename__ = "sanctions"
+
+    symbol = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    source = Column(String, nullable=False)
+    ts = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (PrimaryKeyConstraint("symbol", "source", name="pk_sanctions"),)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return (
+            "SanctionRecord("  # pragma: no cover - debugging helper
+            f"symbol={self.symbol!r}, "  # pragma: no cover - debugging helper
+            f"status={self.status!r}, "  # pragma: no cover - debugging helper
+            f"source={self.source!r}, "  # pragma: no cover - debugging helper
+            f"ts={self.ts!r}"  # pragma: no cover - debugging helper
+            ")"
+        )
+
+
+BLOCKING_STATUSES: Set[str] = {
+    "sanctioned",
+    "blocked",
+    "denied",
+    "prohibited",
+}
+
+
+def is_blocking_status(status: str) -> bool:
+    """Return True when the status should prevent trading."""
+
+    return status.lower() in BLOCKING_STATUSES
+
+
+def ensure_sanctions_schema(engine: Engine) -> None:
+    """Create the sanctions table when it does not exist."""
+
+    SanctionsBase.metadata.create_all(bind=engine, tables=[SanctionRecord.__table__])


### PR DESCRIPTION
## Summary
- add a FastAPI compliance scanner service that refreshes OFAC and FCA watchlists on a daily schedule, exposes status and manual run endpoints, and persists entries in the shared sanctions table
- introduce shared sanctions ORM definitions for reuse across services
- integrate the sanctions check into the risk engine evaluation flow so sanctioned instruments are rejected automatically

## Testing
- pytest tests/test_risk_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8c52455c832196fa51906f11e19e