### PR TITLE
Add meta learner service

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from auth.service import AdminRepository, AuthService, SessionStore
 from services.alert_manager import setup_alerting
 from services.report_service import router as reports_router
 
+from services.models.meta_learner import router as meta_router
 from services.models.model_zoo import router as models_router
 
 from exposure_forecast import router as exposure_router
@@ -41,6 +42,7 @@ def create_app() -> FastAPI:
     app.include_router(exposure_router)
 
     app.include_router(models_router)
+    app.include_router(meta_router)
 
 
     app.state.audit_store = audit_store

--- a/services/models/__init__.py
+++ b/services/models/__init__.py
@@ -1,6 +1,15 @@
 """Model service exports used by API layers."""
 
+from .meta_learner import get_meta_learner, meta_governance_log, router as meta_router  # noqa: F401
 from .model_server import Intent, predict_intent  # noqa: F401
 from .model_zoo import router as model_router, get_model_zoo  # noqa: F401
 
-__all__ = ["Intent", "predict_intent", "model_router", "get_model_zoo"]
+__all__ = [
+    "Intent",
+    "predict_intent",
+    "model_router",
+    "get_model_zoo",
+    "meta_router",
+    "get_meta_learner",
+    "meta_governance_log",
+]

--- a/services/models/meta_learner.py
+++ b/services/models/meta_learner.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+"""Meta learner combining strategy models based on market regimes.
+
+This module maintains an in-memory history of model performance segmented by
+market regime and produces ensemble weights for the most likely winning model
+in the current environment.  The data structures deliberately mirror a
+Timescale-style table so the API can be exercised without a live database.
+"""
+
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import DefaultDict, Dict, Iterable, List, Mapping, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from policy_service import MODEL_VARIANTS, RegimeSnapshot, regime_classifier
+from services.common.security import require_admin_account
+
+
+_ALLOWED_REGIMES = {"trend", "range", "high_vol"}
+
+
+@dataclass(frozen=True)
+class PerformanceRecord:
+    """Point-in-time performance snapshot for a model."""
+
+    symbol: str
+    regime: str
+    model: str
+    score: float
+    ts: datetime
+
+
+@dataclass
+class MetaGovernanceLogEntry:
+    symbol: str
+    regime: str
+    weights_json: str
+    ts: datetime
+
+
+class MetaGovernanceLog:
+    """Lightweight in-memory journal for ensemble governance decisions."""
+
+    def __init__(self) -> None:
+        self._entries: List[MetaGovernanceLogEntry] = []
+        self._lock = Lock()
+
+    def append(self, symbol: str, regime: str, weights: Mapping[str, float], ts: datetime) -> None:
+        payload = json.dumps(dict(sorted(weights.items())), sort_keys=True)
+        entry = MetaGovernanceLogEntry(symbol=symbol, regime=regime, weights_json=payload, ts=ts)
+        with self._lock:
+            self._entries.append(entry)
+
+    def records(self, symbol: Optional[str] = None) -> List[MetaGovernanceLogEntry]:
+        with self._lock:
+            if symbol is None:
+                return list(self._entries)
+            norm = symbol.upper()
+            return [entry for entry in self._entries if entry.symbol == norm]
+
+    def reset(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+class MetaLearner:
+    """Simple meta-ensemble that favours the strongest regime-specific model."""
+
+    def __init__(self) -> None:
+        self._history: DefaultDict[str, DefaultDict[str, DefaultDict[str, List[PerformanceRecord]]]] = (
+            defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        )
+        self._lock = Lock()
+
+    def record_performance(
+        self,
+        *,
+        symbol: str,
+        regime: str,
+        model: str,
+        score: float,
+        ts: Optional[datetime] = None,
+    ) -> None:
+        """Record a new performance observation for ``model``."""
+
+        norm_symbol = symbol.upper()
+        norm_regime = regime.lower()
+        if norm_regime not in _ALLOWED_REGIMES:
+            raise ValueError(f"Unsupported regime '{regime}'")
+        if score is None or math.isnan(score):
+            raise ValueError("Score must be a finite value")
+        timestamp = ts or datetime.now(timezone.utc)
+        record = PerformanceRecord(
+            symbol=norm_symbol,
+            regime=norm_regime,
+            model=model,
+            score=float(score),
+            ts=timestamp,
+        )
+        with self._lock:
+            self._history[norm_symbol][norm_regime][model].append(record)
+
+    def _regime_similarity(self, regime: str) -> Dict[str, float]:
+        base = {
+            "trend": {"trend": 1.0, "range": 0.35, "high_vol": 0.15},
+            "range": {"range": 1.0, "trend": 0.4, "high_vol": 0.25},
+            "high_vol": {"high_vol": 1.0, "range": 0.45, "trend": 0.2},
+        }
+        return dict(base.get(regime, {"range": 1.0, "trend": 0.4, "high_vol": 0.3}))
+
+    def _aggregate_scores(
+        self, records: Iterable[PerformanceRecord]
+    ) -> float:
+        ordered = sorted(records, key=lambda item: item.ts)
+        if not ordered:
+            return 0.0
+        weights: List[float] = []
+        values: List[float] = []
+        for idx, record in enumerate(ordered):
+            # More recent observations receive exponentially more weight.
+            weight = 0.5 ** (len(ordered) - idx - 1)
+            weights.append(weight)
+            values.append(record.score)
+        numerator = sum(value * weight for value, weight in zip(values, weights))
+        denominator = sum(weights)
+        return numerator / denominator if denominator else 0.0
+
+    def _candidate_models(self, symbol: str) -> List[str]:
+        candidates = set(MODEL_VARIANTS)
+        history = self._history.get(symbol, {})
+        for regime_records in history.values():
+            candidates.update(regime_records.keys())
+        return sorted(candidates) if candidates else []
+
+    def train(self, symbol: str) -> Dict[str, Dict[str, float]]:
+        norm_symbol = symbol.upper()
+        with self._lock:
+            history = self._history.get(norm_symbol)
+            if not history:
+                return {}
+            stats: Dict[str, Dict[str, float]] = {}
+            for regime, regime_records in history.items():
+                aggregated: Dict[str, float] = {}
+                for model, records in regime_records.items():
+                    aggregated[model] = self._aggregate_scores(records)
+                stats[regime] = aggregated
+            return stats
+
+    def predict_weights(self, symbol: str, regime: str) -> Dict[str, float]:
+        norm_symbol = symbol.upper()
+        norm_regime = regime.lower()
+        candidates = self._candidate_models(norm_symbol)
+        if not candidates:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No models registered for symbol",
+            )
+        stats = self.train(norm_symbol)
+        similarity = self._regime_similarity(norm_regime)
+        scores: Dict[str, float] = {model: 0.0 for model in candidates}
+        for related_regime, weight in similarity.items():
+            regime_stats = stats.get(related_regime)
+            if not regime_stats:
+                continue
+            for model, value in regime_stats.items():
+                scores[model] = scores.get(model, 0.0) + max(value, 0.0) * weight
+        if not any(score > 0 for score in scores.values()):
+            uniform = 1.0 / float(len(candidates))
+            return {model: uniform for model in candidates}
+        max_score = max(scores.values())
+        exp_scores = {model: math.exp(score - max_score) for model, score in scores.items()}
+        total = sum(exp_scores.values())
+        if total <= 0:
+            uniform = 1.0 / float(len(candidates))
+            return {model: uniform for model in candidates}
+        return {model: exp_scores[model] / total for model in candidates}
+
+    def reset(self) -> None:
+        with self._lock:
+            self._history.clear()
+
+
+class MetaWeightsResponse(BaseModel):
+    symbol: str
+    regime: str
+    weights: Mapping[str, float] = Field(default_factory=dict)
+    generated_at: datetime
+
+
+router = APIRouter(prefix="/meta", tags=["meta"])
+_meta_learner: MetaLearner | None = None
+meta_governance_log = MetaGovernanceLog()
+
+
+def get_meta_learner() -> MetaLearner:
+    global _meta_learner
+    if _meta_learner is None:
+        _meta_learner = MetaLearner()
+    return _meta_learner
+
+
+@router.get("/weights", response_model=MetaWeightsResponse)
+def meta_weights(
+    symbol: str = Query(..., min_length=2),
+    _: str = Depends(require_admin_account),
+) -> MetaWeightsResponse:
+    learner = get_meta_learner()
+    snapshot: Optional[RegimeSnapshot] = regime_classifier.get_snapshot(symbol)
+    if snapshot is None:
+        regime = "range"
+    else:
+        regime = snapshot.regime
+    weights = learner.predict_weights(symbol, regime)
+    generated_at = datetime.now(timezone.utc)
+    meta_governance_log.append(symbol.upper(), regime, weights, generated_at)
+    return MetaWeightsResponse(symbol=symbol.upper(), regime=regime, weights=weights, generated_at=generated_at)
+
+
+__all__ = ["MetaLearner", "get_meta_learner", "meta_governance_log", "router"]

--- a/tests/models/test_meta_learner.py
+++ b/tests/models/test_meta_learner.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from app import create_app
+from policy_service import RegimeSnapshot, _reset_regime_state, regime_classifier
+from services.models.meta_learner import get_meta_learner, meta_governance_log
+
+
+def setup_function() -> None:
+    get_meta_learner().reset()
+    meta_governance_log.reset()
+    _reset_regime_state()
+
+
+def test_meta_learner_prefers_best_regime_model() -> None:
+    learner = get_meta_learner()
+    now = datetime.now(timezone.utc)
+    learner.record_performance(
+        symbol="BTC-USD",
+        regime="trend",
+        model="trend_model",
+        score=1.4,
+        ts=now - timedelta(minutes=10),
+    )
+    learner.record_performance(
+        symbol="BTC-USD",
+        regime="trend",
+        model="trend_model",
+        score=1.8,
+        ts=now - timedelta(minutes=1),
+    )
+    learner.record_performance(
+        symbol="BTC-USD",
+        regime="trend",
+        model="meanrev_model",
+        score=0.2,
+        ts=now - timedelta(minutes=5),
+    )
+
+    weights = learner.predict_weights("BTC-USD", "trend")
+
+    assert set(weights) == {"meanrev_model", "trend_model", "vol_breakout"}
+    assert weights["trend_model"] > weights["meanrev_model"]
+    assert math.isclose(sum(weights.values()), 1.0, rel_tol=1e-6)
+
+
+def test_meta_weights_endpoint_logs_governance_record() -> None:
+    learner = get_meta_learner()
+    now = datetime.now(timezone.utc)
+    learner.record_performance(
+        symbol="ETH-USD",
+        regime="range",
+        model="meanrev_model",
+        score=0.9,
+        ts=now - timedelta(minutes=15),
+    )
+    learner.record_performance(
+        symbol="ETH-USD",
+        regime="range",
+        model="trend_model",
+        score=0.4,
+        ts=now - timedelta(minutes=7),
+    )
+
+    snapshot = RegimeSnapshot(
+        symbol="ETH-USD",
+        regime="range",
+        volatility=0.01,
+        trend_strength=0.2,
+        feature_scale=1.0,
+        size_scale=0.85,
+        sample_count=30,
+        updated_at=now,
+    )
+    with regime_classifier._lock:  # type: ignore[attr-defined]
+        regime_classifier._snapshots["ETH-USD"] = snapshot  # type: ignore[attr-defined]
+
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.get(
+        "/meta/weights",
+        params={"symbol": "ETH-USD"},
+        headers={"X-Account-ID": "company"},
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["symbol"] == "ETH-USD"
+    assert payload["regime"] == "range"
+    weights = payload["weights"]
+    assert math.isclose(sum(weights.values()), 1.0, rel_tol=1e-6)
+    assert weights["meanrev_model"] > weights["trend_model"]
+
+    records = meta_governance_log.records("ETH-USD")
+    assert records, "expected governance entry to be recorded"
+    logged_weights = json.loads(records[-1].weights_json)
+    assert logged_weights.keys() == weights.keys()


### PR DESCRIPTION
## Summary
- add a meta learner service that tracks regime-conditioned model performance, generates ensemble weights, and records governance decisions
- expose the meta learner router through the main FastAPI app and service exports
- add unit coverage for weighting heuristics and governance logging (skipped when FastAPI is unavailable)

## Testing
- pytest tests/models/test_meta_learner.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8c677040832189626fe115e5bf9a