### PR TITLE
Add battle mode volatility safeguards to risk service

### DIFF
--- a/battle_mode.py
+++ b/battle_mode.py
@@ -1,0 +1,355 @@
+"""Battle mode controller coordinating volatility driven trading restrictions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Callable, ContextManager, Dict, Optional
+
+from sqlalchemy import Column, DateTime, String, select
+from sqlalchemy.orm import Session, declarative_base
+
+
+BattleModeBase = declarative_base()
+
+
+class BattleModeLog(BattleModeBase):
+    """SQLAlchemy table tracking battle mode state transitions."""
+
+    __tablename__ = "battle_mode_log"
+
+    account_id = Column(String, primary_key=True)
+    entered_at = Column(DateTime(timezone=True), primary_key=True)
+    exited_at = Column(DateTime(timezone=True), nullable=True)
+    reason = Column(String, nullable=False, default="")
+
+
+@dataclass
+class BattleModeStatus:
+    """Serializable representation of an account's battle mode status."""
+
+    account_id: str
+    engaged: bool
+    threshold: float
+    reason: Optional[str] = None
+    entered_at: Optional[datetime] = None
+    exited_at: Optional[datetime] = None
+    volatility: Optional[float] = None
+    metric: Optional[str] = None
+    automatic: bool = False
+    last_updated: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "account_id": self.account_id,
+            "engaged": self.engaged,
+            "threshold": self.threshold,
+            "reason": self.reason,
+            "entered_at": self.entered_at.isoformat() if self.entered_at else None,
+            "exited_at": self.exited_at.isoformat() if self.exited_at else None,
+            "volatility": self.volatility,
+            "metric": self.metric,
+            "automatic": self.automatic,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+        }
+
+
+@dataclass
+class _BattleModeState:
+    engaged: bool
+    reason: str
+    entered_at: datetime
+    automatic: bool
+    last_volatility: Optional[float] = None
+    metric: Optional[str] = None
+    last_updated: Optional[datetime] = None
+
+
+@dataclass
+class _MetricSnapshot:
+    value: float
+    metric: str
+    timestamp: datetime
+
+
+class BattleModeController:
+    """Coordinates battle mode state driven by realized market volatility."""
+
+    def __init__(
+        self,
+        session_factory: Callable[[], ContextManager[Session]],
+        *,
+        threshold: float,
+    ) -> None:
+        self._session_factory = session_factory
+        self._threshold = max(float(threshold), 0.0)
+        self._lock = Lock()
+        self._states: Dict[str, _BattleModeState] = {}
+        self._metrics: Dict[str, _MetricSnapshot] = {}
+        self._hydrate_active_states()
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    def _hydrate_active_states(self) -> None:
+        try:
+            with self._session_factory() as session:
+                records = (
+                    session.execute(
+                        select(BattleModeLog).where(BattleModeLog.exited_at.is_(None))
+                    )
+                    .scalars()
+                    .all()
+                )
+        except Exception:
+            # Database might not be initialised yet during bootstrap.
+            return
+
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            for record in records:
+                entered_at = record.entered_at
+                if entered_at is None:
+                    entered_at = now
+                self._states[self._normalize(record.account_id)] = _BattleModeState(
+                    engaged=True,
+                    reason=record.reason or "volatility_exceeded",
+                    entered_at=entered_at,
+                    automatic=False,
+                    last_updated=entered_at,
+                )
+
+    def status(self, account_id: str) -> BattleModeStatus:
+        normalized = self._normalize(account_id)
+        with self._lock:
+            state = self._states.get(normalized)
+            metric_snapshot = self._metrics.get(normalized)
+
+        if state and state.engaged:
+            volatility = state.last_volatility
+            metric_name = state.metric
+            updated = state.last_updated
+            if metric_snapshot:
+                volatility = metric_snapshot.value
+                metric_name = metric_snapshot.metric
+                updated = metric_snapshot.timestamp
+            return BattleModeStatus(
+                account_id=normalized,
+                engaged=True,
+                threshold=self._threshold,
+                reason=state.reason,
+                entered_at=state.entered_at,
+                volatility=volatility,
+                metric=metric_name,
+                automatic=state.automatic,
+                last_updated=updated,
+            )
+
+        record = self._load_last_record(normalized)
+        volatility = None
+        metric_name = None
+        updated = None
+        if metric_snapshot:
+            volatility = metric_snapshot.value
+            metric_name = metric_snapshot.metric
+            updated = metric_snapshot.timestamp
+        return BattleModeStatus(
+            account_id=normalized,
+            engaged=False,
+            threshold=self._threshold,
+            reason=record.reason if record else None,
+            entered_at=record.entered_at if record else None,
+            exited_at=record.exited_at if record else None,
+            volatility=volatility,
+            metric=metric_name,
+            automatic=False,
+            last_updated=updated,
+        )
+
+    def auto_update(
+        self,
+        account_id: str,
+        volatility: Optional[float],
+        *,
+        metric: str,
+        reason: Optional[str] = None,
+    ) -> None:
+        if volatility is None or metric.strip() == "":
+            return
+
+        normalized = self._normalize(account_id)
+        now = datetime.now(timezone.utc)
+        snapshot = _MetricSnapshot(value=float(volatility), metric=metric, timestamp=now)
+        with self._lock:
+            self._metrics[normalized] = snapshot
+            state = self._states.get(normalized)
+            if volatility > self._threshold:
+                if state and state.engaged:
+                    state.last_volatility = float(volatility)
+                    state.metric = metric
+                    state.last_updated = now
+                    return
+                entry_reason = reason or (
+                    f"{metric}={volatility:.6f} exceeded threshold {self._threshold:.6f}"
+                )
+                self._enter(normalized, entry_reason, automatic=True, volatility=float(volatility), metric=metric, updated=now)
+            elif state and state.engaged and volatility < self._threshold:
+                exit_reason = reason or (
+                    f"{metric}={volatility:.6f} fell below threshold {self._threshold:.6f}"
+                )
+                self._exit(normalized, exit_reason, automatic=True, updated=now)
+
+    def manual_toggle(
+        self,
+        account_id: str,
+        *,
+        engage: Optional[bool] = None,
+        reason: str,
+    ) -> BattleModeStatus:
+        normalized = self._normalize(account_id)
+        if not reason:
+            raise ValueError("A reason must be provided when toggling battle mode.")
+
+        with self._lock:
+            state = self._states.get(normalized)
+            target = engage if engage is not None else not (state and state.engaged)
+            if target:
+                self._enter(normalized, reason, automatic=False)
+            else:
+                self._exit(normalized, reason, automatic=False)
+
+        return self.status(normalized)
+
+    def is_engaged(self, account_id: str) -> bool:
+        normalized = self._normalize(account_id)
+        with self._lock:
+            state = self._states.get(normalized)
+            return bool(state and state.engaged)
+
+    def _enter(
+        self,
+        account_id: str,
+        reason: str,
+        *,
+        automatic: bool,
+        volatility: Optional[float] = None,
+        metric: Optional[str] = None,
+        updated: Optional[datetime] = None,
+    ) -> None:
+        ts = updated or datetime.now(timezone.utc)
+        reason_text = reason or "volatility_exceeded"
+        entered_at = ts
+        with self._session_factory() as session:
+            existing = (
+                session.execute(
+                    select(BattleModeLog)
+                    .where(
+                        BattleModeLog.account_id == account_id,
+                        BattleModeLog.exited_at.is_(None),
+                    )
+                    .order_by(BattleModeLog.entered_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+            if existing:
+                existing.reason = reason_text
+                entered_at = existing.entered_at or ts
+            else:
+                session.add(
+                    BattleModeLog(
+                        account_id=account_id,
+                        entered_at=ts,
+                        exited_at=None,
+                        reason=reason_text,
+                    )
+                )
+                entered_at = ts
+
+        self._states[account_id] = _BattleModeState(
+            engaged=True,
+            reason=reason_text,
+            entered_at=entered_at,
+            automatic=automatic,
+            last_volatility=volatility,
+            metric=metric,
+            last_updated=ts,
+        )
+        if volatility is not None and metric:
+            self._metrics[account_id] = _MetricSnapshot(value=float(volatility), metric=metric, timestamp=ts)
+
+    def _exit(
+        self,
+        account_id: str,
+        reason: str,
+        *,
+        automatic: bool,
+        updated: Optional[datetime] = None,
+    ) -> None:
+        ts = updated or datetime.now(timezone.utc)
+        reason_text = reason or "volatility_normalized"
+        with self._session_factory() as session:
+            active = (
+                session.execute(
+                    select(BattleModeLog)
+                    .where(
+                        BattleModeLog.account_id == account_id,
+                        BattleModeLog.exited_at.is_(None),
+                    )
+                    .order_by(BattleModeLog.entered_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+            if active:
+                active.exited_at = ts
+                if reason_text:
+                    if active.reason:
+                        active.reason = f"{active.reason} | exit: {reason_text}"
+                    else:
+                        active.reason = reason_text
+            else:
+                session.add(
+                    BattleModeLog(
+                        account_id=account_id,
+                        entered_at=ts,
+                        exited_at=ts,
+                        reason=reason_text,
+                    )
+                )
+
+        self._states.pop(account_id, None)
+        snapshot = self._metrics.get(account_id)
+        if snapshot:
+            self._metrics[account_id] = _MetricSnapshot(
+                value=snapshot.value,
+                metric=snapshot.metric,
+                timestamp=ts,
+            )
+
+    def _load_last_record(self, account_id: str) -> Optional[BattleModeLog]:
+        with self._session_factory() as session:
+            return (
+                session.execute(
+                    select(BattleModeLog)
+                    .where(BattleModeLog.account_id == account_id)
+                    .order_by(BattleModeLog.entered_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+
+    @staticmethod
+    def _normalize(account_id: str) -> str:
+        normalized = account_id.strip()
+        if not normalized:
+            raise ValueError("Account identifier must not be empty.")
+        return normalized
+
+
+def create_battle_mode_tables(engine) -> None:
+    """Initialise battle mode persistence layer."""
+
+    BattleModeBase.metadata.create_all(bind=engine)

--- a/risk_service.py
+++ b/risk_service.py
@@ -12,16 +12,17 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from typing import Callable, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
 
 
 import httpx
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_validator
 from sqlalchemy import Column, DateTime, Float, Integer, String, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import StaticPool
+from statistics import mean
 
 
 from metrics import (
@@ -30,6 +31,7 @@ from metrics import (
     setup_metrics,
 )
 from services.common.security import require_admin_account
+from battle_mode import BattleModeController, create_battle_mode_tables
 
 
 logger = logging.getLogger(__name__)
@@ -40,6 +42,7 @@ logging.basicConfig(level=logging.INFO)
 _CAPITAL_ALLOCATOR_URL = os.getenv("CAPITAL_ALLOCATOR_URL")
 _CAPITAL_ALLOCATOR_TIMEOUT = float(os.getenv("CAPITAL_ALLOCATOR_TIMEOUT", "1.5"))
 _CAPITAL_ALLOCATOR_TOLERANCE = float(os.getenv("CAPITAL_ALLOCATOR_NAV_TOLERANCE", "0.02"))
+_BATTLE_MODE_VOL_THRESHOLD = float(os.getenv("BATTLE_MODE_VOL_THRESHOLD", "1.0"))
 
 
 Base = declarative_base()
@@ -272,6 +275,7 @@ def _seed_default_limits(session: Session) -> None:
 
 def _bootstrap_storage() -> None:
     Base.metadata.create_all(bind=ENGINE)
+    create_battle_mode_tables(ENGINE)
     with get_session() as session:
         _seed_default_limits(session)
 
@@ -483,6 +487,15 @@ class RiskLimitsResponse(BaseModel):
     usage: AccountUsage
 
 
+class BattleModeToggleRequest(BaseModel):
+    account_id: str = Field(..., description="Account identifier to toggle battle mode for")
+    engage: Optional[bool] = Field(
+        None,
+        description="Explicit state to set. When omitted the state will be toggled.",
+    )
+    reason: str = Field(..., min_length=1, description="Audit reason for the toggle request")
+
+
 app = FastAPI(title="Risk Validation Service", version="1.0.0")
 setup_metrics(app)
 
@@ -494,6 +507,10 @@ def _on_startup() -> None:
 
 
 _bootstrap_storage()
+
+battle_mode_controller = BattleModeController(
+    session_factory=get_session, threshold=_BATTLE_MODE_VOL_THRESHOLD
+)
 
 
 @app.post("/risk/validate", response_model=RiskValidationResponse)
@@ -593,6 +610,40 @@ async def get_risk_limits(
     return response.dict()
 
 
+@app.get("/risk/battle_mode/status")
+async def get_battle_mode_status(
+    account_id: Optional[str] = Query(
+        None,
+        description="Account identifier to inspect. Defaults to the authenticated admin account.",
+    ),
+    admin_account: str = Depends(require_admin_account),
+) -> Dict[str, Any]:
+    target = account_id or admin_account
+    status_payload = battle_mode_controller.status(target)
+    logger.info("Retrieved battle mode status for account %s", target)
+    return status_payload.to_dict()
+
+
+@app.post("/risk/battle_mode/toggle")
+async def toggle_battle_mode(
+    request: BattleModeToggleRequest,
+    _: str = Depends(require_admin_account),
+) -> Dict[str, Any]:
+    try:
+        status_payload = battle_mode_controller.manual_toggle(
+            request.account_id,
+            engage=request.engage,
+            reason=request.reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.warning(
+        "Battle mode toggled for account %s -> engaged=%s", request.account_id, status_payload.engaged
+    )
+    return status_payload.to_dict()
+
+
 def _load_account_limits(account_id: str) -> AccountRiskLimit:
     with get_session() as session:
         limits = session.get(AccountRiskLimit, account_id)
@@ -685,6 +736,38 @@ def _evaluate(context: RiskEvaluationContext) -> RiskValidationResponse:
             scaled_notional_cap = base_size * float(target_vol) / current_vol
         elif nav_cap_for_trade:
             scaled_notional_cap = nav_cap_for_trade
+
+    volatility_metric: Optional[float] = None
+    volatility_source: Optional[str] = None
+    if atr_value is not None:
+        volatility_metric = atr_value
+        volatility_source = "atr"
+    else:
+        realized_vol = _compute_realized_volatility(state)
+        if realized_vol is not None:
+            volatility_metric = realized_vol
+            volatility_source = "realized_vol"
+
+    if volatility_metric is not None and volatility_source:
+        battle_mode_controller.auto_update(
+            context.request.account_id,
+            volatility_metric,
+            metric=volatility_source,
+            reason=f"{volatility_source}={volatility_metric:.6f}",
+        )
+
+    battle_status = battle_mode_controller.status(context.request.account_id)
+    if battle_status.engaged and not _is_position_reduction(intent, state, trade_notional):
+        _register_violation(
+            "Battle mode active: speculative trades are temporarily suspended",
+            cooldown=True,
+            details={
+                "threshold": battle_status.threshold,
+                "metric": battle_status.metric,
+                "volatility": battle_status.volatility,
+            },
+        )
+        suggested_quantities.append(0.0)
 
     # 3. Max NAV percentage per trade
     if trade_notional > nav_cap_for_trade:
@@ -1216,6 +1299,47 @@ def _compute_atr(instrument_id: str, window: int = 14) -> Optional[float]:
         return None
 
     return mean(true_ranges[-window:])
+
+
+def _compute_realized_volatility(state: AccountPortfolioState, window: int = 30) -> Optional[float]:
+    returns: List[float] = []
+    for series in (state.historical_returns or {}).values():
+        if not series:
+            continue
+        tail = series[-window:]
+        for value in tail:
+            if value is None:
+                continue
+            returns.append(float(value))
+
+    if len(returns) < 2:
+        return None
+
+    mean_return = sum(returns) / len(returns)
+    variance = sum((value - mean_return) ** 2 for value in returns) / (len(returns) - 1)
+    if variance < 0:
+        return 0.0
+    return math.sqrt(variance)
+
+
+def _is_position_reduction(
+    intent: TradeIntent, state: AccountPortfolioState, trade_notional: float
+) -> bool:
+    current_total = float(state.notional_exposure or 0.0)
+    tolerance = max(current_total * 1e-6, 1e-6)
+    if intent.side == "sell":
+        projected_total = max(current_total - trade_notional, 0.0)
+    else:
+        projected_total = current_total + trade_notional
+
+    if projected_total + tolerance < current_total:
+        return True
+
+    instrument_exposure = (state.instrument_exposure or {}).get(intent.instrument_id, 0.0)
+    if intent.side == "sell" and instrument_exposure > 0:
+        return True
+
+    return False
 
 
 def _compute_historical_var(account_id: str, nav: float, window: int = 250) -> Optional[float]:


### PR DESCRIPTION
## Summary
- add a battle mode controller with persistent logging to govern volatility-driven restrictions
- integrate the risk service with automatic battle mode toggling and speculative trade blocking
- expose administrative APIs to inspect and toggle battle mode status

## Testing
- pytest tests/risk/test_validate.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dd8c57924083218f76f80be59d7840