### PR TITLE
Implement OMS warm start resync and replay

### DIFF
--- a/services/oms/kraken_rest.py
+++ b/services/oms/kraken_rest.py
@@ -57,6 +57,21 @@ class KrakenRESTClient:
         response = await self._request("/private/CancelOrder", payload)
         return self._parse_response(response)
 
+    async def open_orders(self) -> Dict[str, Any]:
+        return await self._request("/private/OpenOrders", {})
+
+    async def own_trades(self, *, start: Optional[int] = None, end: Optional[int] = None) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"trades": True}
+        if start is not None:
+            payload["start"] = int(start)
+        if end is not None:
+            payload["end"] = int(end)
+        return await self._request("/private/TradesHistory", payload)
+
+    async def open_positions(self, *, docalcs: bool = True) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"docalcs": bool(docalcs)}
+        return await self._request("/private/OpenPositions", payload)
+
     async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         credentials = await self._credential_getter()
         session = await self._session_or_create()


### PR DESCRIPTION
## Summary
- add REST helpers to load open orders, trades, and positions from Kraken
- extend the OMS account context to resync open orders, active positions, and trade history on startup
- expand the warm start coordinator to resync positions, apply trade snapshots, and replay missed Kafka fills

## Testing
- `pytest tests/unit/services/test_oms_service.py -k warm_start` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68dd998688208321b3a2f0e0d16bb55b