### PR TITLE
Add Linode deployment workflow with testing and security checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,174 @@
+name: Deploy to Linode Kubernetes
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  quality-checks:
+    name: Lint, Type Check, and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install ruff black mypy pytest pytest-cov
+
+      - name: Run Ruff
+        run: ruff check .
+
+      - name: Run Black
+        run: black --check .
+
+      - name: Run Mypy
+        run: mypy .
+
+      - name: Run Pytest
+        run: pytest --maxfail=1 --disable-warnings --cov=. --cov-report=xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+
+  build-and-publish:
+    name: Build, Sign, and Publish Images
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    env:
+      REGISTRY: ghcr.io
+    strategy:
+      matrix:
+        build:
+          - name: kraken-ws-ingest
+            context: deploy/docker/kraken-ws-ingest
+            dockerfile: deploy/docker/kraken-ws-ingest/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine image coordinates
+        id: image_meta
+        run: |
+          OWNER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE_ID="${REGISTRY}/${OWNER}/${{ matrix.build.name }}"
+          echo "image_id=${IMAGE_ID}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${IMAGE_ID}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${IMAGE_ID}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image with Kaniko
+        uses: int128/kaniko-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          image: ${{ steps.image_meta.outputs.image_id }}
+          tags: |
+            latest
+            ${{ github.sha }}
+          context: ${{ matrix.build.context }}
+          dockerfile: ${{ matrix.build.dockerfile }}
+          push: true
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM with Syft
+        id: sbom
+        uses: anchore/syft-action@v1
+        with:
+          image: ${{ steps.image_meta.outputs.sha_tag }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.build.name }}.spdx.json
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.build.name }}
+          path: sbom-${{ matrix.build.name }}.spdx.json
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.21.0
+        with:
+          image-ref: ${{ steps.image_meta.outputs.sha_tag }}
+          severity: CRITICAL,HIGH
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign images with Cosign
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY "${{ steps.image_meta.outputs.sha_tag }}"
+          cosign sign --key env://COSIGN_PRIVATE_KEY "${{ steps.image_meta.outputs.latest_tag }}"
+
+  deploy:
+    name: Deploy with ArgoCD
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ArgoCD CLI
+        run: |
+          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/download/v2.9.3/argocd-linux-amd64
+          chmod +x argocd
+          sudo mv argocd /usr/local/bin/
+
+      - name: Login to ArgoCD
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          argocd login "$ARGOCD_SERVER" --auth-token "$ARGOCD_AUTH_TOKEN" --insecure
+
+      - name: Sync Linode Kubernetes applications
+        env:
+          STAGING_APP: ${{ secrets.ARGOCD_STAGING_APP }}
+          PRODUCTION_APP: ${{ secrets.ARGOCD_PRODUCTION_APP }}
+        run: |
+          if [ -z "$STAGING_APP" ] && [ -z "$PRODUCTION_APP" ]; then
+            echo "No ArgoCD applications configured" >&2
+            exit 1
+          fi
+          if [ -n "$STAGING_APP" ]; then
+            argocd app sync "$STAGING_APP"
+            argocd app wait "$STAGING_APP" --health --timeout 600
+          fi
+          if [ -n "$PRODUCTION_APP" ]; then
+            argocd app sync "$PRODUCTION_APP"
+            argocd app wait "$PRODUCTION_APP" --health --timeout 600
+          fi


### PR DESCRIPTION
## Summary
- add deploy workflow that runs linting, type checks, and tests before building container images
- build and push images with Kaniko, signing them with Cosign and generating SBOMs via Syft
- deploy to Linode Kubernetes through ArgoCD after vulnerability scans pass

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68dd9e00e1008321966619b89893b166