### PR TITLE
Enhance OMS warm start recovery

### DIFF
--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -1835,8 +1835,8 @@ async def get_routing_status(
     return account.routing_status()
 
 
-@app.get("/oms/warm_start/status")
-async def get_warm_start_status() -> Dict[str, int]:
+@app.get("/oms/warm_start/report")
+async def get_warm_start_report(_: str = Depends(require_account_id)) -> Dict[str, int]:
     return await warm_start.status()
 
 


### PR DESCRIPTION
## Summary
- add Kafka offset log support, retry orchestration, and balance resync to the warm start coordinator
- expose a secured /oms/warm_start/report endpoint that surfaces warm start metrics including latency

## Testing
- python -m compileall services/oms/warm_start.py services/oms/oms_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9d76ce408321b36f89a224c74ca6