### PR TITLE
Add trading sequencer enforcing risk and OMS loop

### DIFF
--- a/services/core/__init__.py
+++ b/services/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core service primitives shared across the control plane."""
+
+from .sequencer import SequencerResult, TradingSequencer
+
+__all__ = ["SequencerResult", "TradingSequencer"]


### PR DESCRIPTION
## Summary
- add a core TradingSequencer that sequences intents through risk validation, OMS placement, fill routing, and downstream updates while tagging every event with a correlation id
- persist round-trip latency samples to the per-account `latency_metrics` table and forward fills to risk and PnL sinks after publishing them to Kafka
- expose the sequencer primitives from the new `services.core` package for reuse across services

## Testing
- python -m compileall services/core/sequencer.py


------
https://chatgpt.com/codex/tasks/task_e_68dd9d2af8f0832190e76135f3e135bc