### PR TITLE
Enhance Kraken API key management UI

### DIFF
--- a/frontend/components/ApiKeyManager.tsx
+++ b/frontend/components/ApiKeyManager.tsx
@@ -2,7 +2,14 @@ import React, { FormEvent, useCallback, useEffect, useState } from "react";
 
 type SecretsStatusResponse = {
   last_rotated_at?: string | null;
+  last_rotated_by?: string | null;
   status?: string | null;
+};
+
+type SecretsAuditEvent = {
+  actor: string;
+  rotated_at: string;
+  notes?: string | null;
 };
 
 type RotateSecretsPayload = {
@@ -31,9 +38,17 @@ const ApiKeyManager: React.FC = () => {
   const [statusLoading, setStatusLoading] = useState(true);
   const [statusError, setStatusError] = useState<string | null>(null);
   const [lastRotatedAt, setLastRotatedAt] = useState<string | null>(null);
+  const [lastRotatedBy, setLastRotatedBy] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [auditEvents, setAuditEvents] = useState<SecretsAuditEvent[]>([]);
+  const [auditLoading, setAuditLoading] = useState<boolean>(true);
+  const [auditError, setAuditError] = useState<string | null>(null);
+  const [confirmationStage, setConfirmationStage] = useState<"idle" | "confirm">(
+    "idle"
+  );
+  const [confirmationInput, setConfirmationInput] = useState("");
 
   const loadStatus = useCallback(
     async (signal: AbortSignal) => {
@@ -53,6 +68,7 @@ const ApiKeyManager: React.FC = () => {
 
         const data = (await response.json()) as SecretsStatusResponse;
         setLastRotatedAt(data.last_rotated_at ?? null);
+        setLastRotatedBy(data.last_rotated_by ?? null);
         setStatusMessage(data.status ?? null);
         setStatusError(null);
       } catch (error) {
@@ -80,6 +96,50 @@ const ApiKeyManager: React.FC = () => {
     }
   }, [loadStatus]);
 
+  const loadAudit = useCallback(
+    async (signal: AbortSignal) => {
+      try {
+        setAuditLoading(true);
+        const response = await fetch("/secrets/audit", {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+          },
+          signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to load audit history: ${response.status}`);
+        }
+
+        const data = (await response.json()) as SecretsAuditEvent[];
+        setAuditEvents(data);
+        setAuditError(null);
+      } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
+
+        console.error("Failed to fetch Kraken secret audit history", error);
+        setAuditError("Unable to load the rotation history.");
+      } finally {
+        if (!signal.aborted) {
+          setAuditLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  const refreshAudit = useCallback(async () => {
+    const controller = new AbortController();
+    try {
+      await loadAudit(controller.signal);
+    } finally {
+      controller.abort();
+    }
+  }, [loadAudit]);
+
   useEffect(() => {
     const controller = new AbortController();
 
@@ -94,13 +154,37 @@ const ApiKeyManager: React.FC = () => {
     };
   }, [loadStatus]);
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    loadAudit(controller.signal).catch((error) => {
+      if (!controller.signal.aborted) {
+        console.error("Failed to initialize secrets audit", error);
+      }
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [loadAudit]);
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    setIsSubmitting(true);
     setSubmitError(null);
     setSuccessMessage(null);
 
+    if (confirmationStage === "idle") {
+      setConfirmationStage("confirm");
+      return;
+    }
+
+    if (confirmationInput.trim().toUpperCase() !== "ROTATE") {
+      setSubmitError('Please type "ROTATE" to confirm credential rotation.');
+      return;
+    }
+
+    setIsSubmitting(true);
     const payload: RotateSecretsPayload = {
       api_key: apiKey.trim(),
       api_secret: apiSecret.trim(),
@@ -129,7 +213,10 @@ const ApiKeyManager: React.FC = () => {
       setSuccessMessage("Kraken API credentials rotated successfully.");
       setApiKey("");
       setApiSecret("");
+      setConfirmationStage("idle");
+      setConfirmationInput("");
       await refreshStatus();
+      await refreshAudit();
     } catch (error) {
       console.error("Failed to rotate Kraken API credentials", error);
       setSubmitError(
@@ -157,6 +244,9 @@ const ApiKeyManager: React.FC = () => {
         ) : (
           <>
             <p className="text-sm text-gray-900">{formatTimestamp(lastRotatedAt)}</p>
+            {lastRotatedBy && (
+              <p className="text-sm text-gray-500">Rotated by: {lastRotatedBy}</p>
+            )}
             {statusMessage && (
               <p className="text-sm text-gray-500" role="status">
                 Current status: {statusMessage}
@@ -201,6 +291,36 @@ const ApiKeyManager: React.FC = () => {
           />
         </div>
 
+        {confirmationStage === "confirm" && (
+          <div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+            <p className="text-sm text-yellow-800 mb-2">
+              Rotating the Kraken API credentials will immediately revoke access for the current key pair. Please confirm that
+              you intend to proceed by typing <span className="font-semibold">ROTATE</span> below.
+            </p>
+            <input
+              type="text"
+              value={confirmationInput}
+              onChange={(event) => setConfirmationInput(event.target.value)}
+              className="w-full rounded-md border border-yellow-300 px-3 py-2 focus:border-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-200"
+              placeholder="Type ROTATE to confirm"
+              autoComplete="off"
+            />
+            <div className="mt-3 flex items-center justify-between">
+              <button
+                type="button"
+                className="text-sm font-medium text-gray-600 hover:text-gray-800"
+                onClick={() => {
+                  setConfirmationStage("idle");
+                  setConfirmationInput("");
+                }}
+              >
+                Cancel rotation
+              </button>
+              <p className="text-xs text-gray-500">Confirmation required before submission</p>
+            </div>
+          </div>
+        )}
+
         {submitError && (
           <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
             {submitError}
@@ -219,10 +339,37 @@ const ApiKeyManager: React.FC = () => {
             disabled={isSubmitting}
             className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-75"
           >
-            {isSubmitting ? "Rotating…" : "Rotate Keys"}
+            {isSubmitting ? "Rotating…" : confirmationStage === "confirm" ? "Confirm Rotation" : "Rotate Keys"}
           </button>
         </div>
       </form>
+
+      <div className="mt-8">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">Rotation History</h3>
+        {auditLoading ? (
+          <p className="text-sm text-gray-500">Loading rotation history…</p>
+        ) : auditError ? (
+          <p className="text-sm text-red-600" role="alert">
+            {auditError}
+          </p>
+        ) : auditEvents.length === 0 ? (
+          <p className="text-sm text-gray-500">No rotation events recorded.</p>
+        ) : (
+          <ul className="space-y-3">
+            {auditEvents.map((event, index) => (
+              <li key={`${event.rotated_at}-${index}`} className="rounded-md border border-gray-200 p-3">
+                <p className="text-sm font-medium text-gray-900">
+                  {formatTimestamp(event.rotated_at)}
+                </p>
+                <p className="text-sm text-gray-600">Rotated by {event.actor}</p>
+                {event.notes && (
+                  <p className="text-xs text-gray-500 mt-1">Notes: {event.notes}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add dual-stage confirmation flow requiring directors to type ROTATE before rotating Kraken API credentials
- show the actor and timestamp of the last rotation and surface backend status messaging
- fetch and render the rotation audit history so directors can review prior changes

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ddac3476848321be2f0129efe34d70