### PR TITLE
Add Azure AD OIDC FastAPI auth service with TOTP MFA

### DIFF
--- a/services/auth/auth_service.py
+++ b/services/auth/auth_service.py
@@ -1,120 +1,133 @@
-"""FastAPI authentication service supporting OIDC, MFA, and JWT issuance.
+"""FastAPI authentication service integrating Azure AD OIDC with TOTP MFA.
 
-This module exposes a small FastAPI application that can be embedded inside
-other services or launched standalone.  It provides helper classes to interact
-with OIDC providers (e.g. Microsoft and Google), enforces multi-factor
-authentication (either TOTP or SMS based) before granting access, and issues
-JWT tokens that include an ``admin`` role claim.  It also exposes a
-``/auth/status`` endpoint that can be used by the UI to check whether a user is
-currently authenticated.
+This module exposes a small FastAPI application capable of handling an
+enterprise-grade authentication flow backed by Azure Active Directory
+(Azure AD / Microsoft 365).  The login process relies on OIDC for the
+initial identity verification and then enforces a time-based one-time
+password (TOTP) challenge.  Successful MFA verification results in a
+short-lived admin JWT (15 minutes) and an accompanying refresh token
+which can be traded in for new access tokens when the old one expires.
+
+The service exposes a handful of endpoints:
+
+* ``GET /auth/login`` - returns the Azure authorization URL to redirect users.
+* ``POST /auth/callback`` - processes the authorization code and starts MFA.
+* ``POST /auth/mfa/totp`` - verifies the TOTP code and issues tokens.
+* ``POST /auth/refresh`` - exchanges a refresh token for a new access token.
+* ``GET /auth/status`` - reports whether the caller holds a valid admin JWT.
+* ``POST /auth/logout`` - revokes refresh tokens and ends the session.
+
+The implementation intentionally keeps state in-memory for simplicity.  In a
+real deployment a persistent cache (Redis, SQL, etc.) should be used.
 """
 from __future__ import annotations
 
 import base64
-import dataclasses
 import hashlib
 import hmac
 import json
-import secrets
 import time
-from typing import Any, Dict, Literal, Optional
-from urllib.parse import urlencode
+import os
+import secrets
+from typing import Any, Dict, Optional
 
 import httpx
 import pyotp
 from fastapi import Depends, FastAPI, Header, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
-MFAMethod = Literal["totp", "sms"]
+class AzureOIDCSettings(BaseModel):
+    """Azure Active Directory specific OIDC configuration."""
 
+    tenant_id: str = Field(..., description="Azure AD tenant identifier")
+    client_id: str = Field(..., description="Azure AD application (client) ID")
+    client_secret: SecretStr = Field(..., description="Azure AD client secret")
+    redirect_uri: str = Field(..., description="Redirect URI registered with Azure")
+    scope: str = Field(
+        default="openid profile email offline_access",
+        description="OIDC scopes requested from Azure AD",
+    )
 
-class OIDCProviderConfig(BaseModel):
-    """Configuration for a single OIDC provider."""
+    @property
+    def authorization_endpoint(self) -> str:
+        return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/authorize"
 
-    name: str
-    authorization_endpoint: str
-    token_endpoint: str
-    userinfo_endpoint: str
-    client_id: str
-    client_secret: str
-    redirect_uri: str
-    scope: str = "openid profile email"
+    @property
+    def token_endpoint(self) -> str:
+        return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
+
+    @property
+    def userinfo_endpoint(self) -> str:
+        return "https://graph.microsoft.com/oidc/userinfo"
 
 
 class AuthSettings(BaseModel):
-    """Runtime settings for the authentication service."""
+    """Runtime configuration for token issuance and MFA."""
 
-    jwt_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
-    jwt_issuer: str = "aether/auth-service"
-    token_ttl_seconds: int = 3600
+    jwt_secret: SecretStr = Field(..., description="HS256 secret used for signing access tokens")
+    jwt_issuer: str = Field(default="aether/auth", description="JWT issuer claim")
+    access_token_ttl_seconds: int = Field(default=900, description="Access token lifetime (15 minutes)")
+    refresh_token_ttl_seconds: int = Field(default=86400, description="Refresh token lifetime (1 day)")
+
+
+class AuthorizationURLResponse(BaseModel):
+    authorization_url: str
 
 
 class OIDCCallbackRequest(BaseModel):
-    """Payload expected from the OIDC redirect handler."""
-
     code: str
     state: Optional[str] = None
     nonce: Optional[str] = None
-    mfa_method: MFAMethod = Field(default="totp")
-
-
-class MFAVerificationRequest(BaseModel):
-    """Payload for verifying a MFA challenge."""
-
-    session_id: str
-    method: MFAMethod
-    code: str
-
-
-class AuthorizationResponse(BaseModel):
-    """Response object for initiating an OIDC authorization request."""
-
-    authorization_url: str
-    provider: str
 
 
 class OIDCCallbackResponse(BaseModel):
-    """Response returned when an OIDC callback succeeds but needs MFA."""
-
     session_id: str
-    mfa_required: bool
-    mfa_method: MFAMethod
-    mfa_provisioning_uri: Optional[str] = None
+    mfa_required: bool = True
+    totp_provisioning_uri: str
 
 
-class TokenResponse(BaseModel):
-    """Response returned once MFA succeeds and a JWT is issued."""
+class MFAVerificationRequest(BaseModel):
+    session_id: str
+    totp_code: str
 
+
+class TokenPair(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str = "bearer"
     expires_in: int
 
 
-class AuthStatusResponse(BaseModel):
-    """Response for the ``/auth/status`` endpoint."""
+class RefreshRequest(BaseModel):
+    refresh_token: str
 
+
+class AuthStatusResponse(BaseModel):
     authenticated: bool
     claims: Optional[Dict[str, Any]] = None
 
 
-@dataclasses.dataclass
-class PendingSession:
-    """Holds data between the OIDC callback and MFA verification."""
+class LogoutRequest(BaseModel):
+    refresh_token: Optional[str] = None
 
+
+class _PendingSession(BaseModel):
     user_info: Dict[str, Any]
-    method: MFAMethod
-    totp_secret: Optional[str]
-    sms_code: Optional[str]
+    totp_secret: str
+    expires_at: float
+
+
+class _RefreshTokenState(BaseModel):
+    user_id: str
     expires_at: float
 
 
 class MFAService:
-    """Handles TOTP and SMS MFA challenges."""
+    """Handles storage and verification of per-user TOTP secrets."""
 
     def __init__(self) -> None:
         self._totp_secrets: Dict[str, str] = {}
-        self._sms_codes: Dict[str, tuple[str, float]] = {}
 
     def ensure_totp_secret(self, user_id: str) -> str:
         secret = self._totp_secrets.get(user_id)
@@ -125,182 +138,106 @@ class MFAService:
 
     def provisioning_uri(self, user_id: str, issuer: str) -> str:
         secret = self.ensure_totp_secret(user_id)
-        return pyotp.TOTP(secret).provisioning_uri(name=user_id, issuer_name=issuer)
+        totp = pyotp.TOTP(secret)
+        return totp.provisioning_uri(name=user_id, issuer_name=issuer)
 
-    def verify_totp(self, user_id: str, code: str) -> bool:
+    def verify(self, user_id: str, code: str) -> bool:
         secret = self._totp_secrets.get(user_id)
         if not secret:
             return False
         totp = pyotp.TOTP(secret)
         return totp.verify(code, valid_window=1)
 
-    def generate_sms_code(self, user_id: str) -> str:
-        code = f"{secrets.randbelow(1_000_000):06d}"
-        self._sms_codes[user_id] = (code, time.time() + 300)
-        # In a production system this is where we would integrate with an SMS
-        # provider to deliver the message.  For now we simply store the code.
-        return code
-
-    def verify_sms(self, user_id: str, code: str) -> bool:
-        entry = self._sms_codes.get(user_id)
-        if not entry:
-            return False
-        stored_code, expires_at = entry
-        if expires_at < time.time():
-            del self._sms_codes[user_id]
-            return False
-        if secrets.compare_digest(stored_code, code):
-            del self._sms_codes[user_id]
-            return True
-        return False
-
 
 class AuthService:
-    """Encapsulates core authentication logic."""
+    """Encapsulates Azure AD OIDC authentication and token issuance."""
 
-    def __init__(self, providers: Dict[str, OIDCProviderConfig], settings: AuthSettings) -> None:
-        self.providers = providers
+    def __init__(self, oidc: AzureOIDCSettings, settings: AuthSettings) -> None:
+        self.oidc = oidc
         self.settings = settings
-        self._sessions: Dict[str, PendingSession] = {}
         self._mfa = MFAService()
+        self._sessions: Dict[str, _PendingSession] = {}
+        self._refresh_tokens: Dict[str, _RefreshTokenState] = {}
         self._http_client = httpx.AsyncClient(timeout=10.0)
 
     async def close(self) -> None:
         await self._http_client.aclose()
 
-    def _get_provider(self, name: str) -> OIDCProviderConfig:
-        try:
-            return self.providers[name.lower()]
-        except KeyError as exc:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown provider") from exc
-
-    async def build_authorization_url(self, provider_name: str, state: Optional[str] = None, nonce: Optional[str] = None) -> str:
-        provider = self._get_provider(provider_name)
-        query = {
-            "client_id": provider.client_id,
+    async def build_authorization_url(self, state: Optional[str] = None, nonce: Optional[str] = None) -> str:
+        query: Dict[str, str] = {
+            "client_id": self.oidc.client_id,
             "response_type": "code",
-            "scope": provider.scope,
-            "redirect_uri": provider.redirect_uri,
+            "redirect_uri": self.oidc.redirect_uri,
+            "scope": self.oidc.scope,
         }
         if state:
             query["state"] = state
         if nonce:
             query["nonce"] = nonce
-        return f"{provider.authorization_endpoint}?{urlencode(query)}"
+        encoded = str(httpx.QueryParams(query))
+        return f"{self.oidc.authorization_endpoint}?{encoded}"
 
-    async def exchange_code_for_tokens(self, provider_name: str, code: str) -> Dict[str, Any]:
-        provider = self._get_provider(provider_name)
-        payload = {
+    async def exchange_code_for_tokens(self, code: str) -> Dict[str, Any]:
+        data = {
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": provider.redirect_uri,
-            "client_id": provider.client_id,
-            "client_secret": provider.client_secret,
+            "redirect_uri": self.oidc.redirect_uri,
+            "client_id": self.oidc.client_id,
+            "client_secret": self.oidc.client_secret.get_secret_value(),
         }
-        response = await self._http_client.post(provider.token_endpoint, data=payload)
+        response = await self._http_client.post(self.oidc.token_endpoint, data=data)
         if response.status_code >= 400:
-            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="OIDC token exchange failed")
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to exchange authorization code")
         return response.json()
 
-    async def fetch_user_info(self, provider_name: str, access_token: str) -> Dict[str, Any]:
-        provider = self._get_provider(provider_name)
+    async def fetch_user_info(self, access_token: str) -> Dict[str, Any]:
         headers = {"Authorization": f"Bearer {access_token}"}
-        response = await self._http_client.get(provider.userinfo_endpoint, headers=headers)
+        response = await self._http_client.get(self.oidc.userinfo_endpoint, headers=headers)
         if response.status_code >= 400:
-            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to retrieve user info")
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to fetch user info")
         return response.json()
 
-    def _create_pending_session(self, user_info: Dict[str, Any], method: MFAMethod) -> tuple[PendingSession, Optional[str]]:
-        user_id = user_info.get("email") or user_info.get("sub")
+    def start_mfa_session(self, user_info: Dict[str, Any]) -> OIDCCallbackResponse:
+        user_id = user_info.get("email") or user_info.get("preferred_username") or user_info.get("sub")
         if not user_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User info missing identifier")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OIDC user info missing identifier")
 
-        if method == "totp":
-            secret = self._mfa.ensure_totp_secret(user_id)
-            provisioning_uri = self._mfa.provisioning_uri(user_id, self.settings.jwt_issuer)
-            session = PendingSession(
-                user_info=user_info,
-                method=method,
-                totp_secret=secret,
-                sms_code=None,
-                expires_at=time.time() + 600,
-            )
-            return session, provisioning_uri
-        if method == "sms":
-            code = self._mfa.generate_sms_code(user_id)
-            session = PendingSession(
-                user_info=user_info,
-                method=method,
-                totp_secret=None,
-                sms_code=code,
-                expires_at=time.time() + 600,
-            )
-            return session, None
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported MFA method")
+        secret = self._mfa.ensure_totp_secret(user_id)
+        provisioning_uri = self._mfa.provisioning_uri(user_id, self.settings.jwt_issuer)
+        session_id = secrets.token_urlsafe(32)
+        expires_at = time.time() + 600  # 10 minutes window to finish MFA
+        self._sessions[session_id] = _PendingSession(user_info=user_info, totp_secret=secret, expires_at=expires_at)
+        return OIDCCallbackResponse(session_id=session_id, totp_provisioning_uri=provisioning_uri)
 
-    def create_pending_session(self, user_info: Dict[str, Any], method: MFAMethod) -> OIDCCallbackResponse:
-        session, provisioning_uri = self._create_pending_session(user_info, method)
-        session_id = secrets.token_urlsafe(24)
-        self._sessions[session_id] = session
-        return OIDCCallbackResponse(
-            session_id=session_id,
-            mfa_required=True,
-            mfa_method=method,
-            mfa_provisioning_uri=provisioning_uri,
-        )
-
-    def verify_mfa_and_issue_token(self, session_id: str, method: MFAMethod, code: str) -> TokenResponse:
-        session = self._sessions.get(session_id)
-        if not session or session.expires_at < time.time():
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session expired or not found")
-
-        user_id = session.user_info.get("email") or session.user_info.get("sub")
-        if not user_id:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Session missing user identifier")
-
-        if method != session.method:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="MFA method mismatch")
-
-        if method == "totp":
-            if not self._mfa.verify_totp(user_id, code):
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
-        elif method == "sms":
-            if not self._mfa.verify_sms(user_id, code):
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid SMS code")
-        else:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported MFA method")
-
-        token = self._issue_admin_token(session.user_info)
-        del self._sessions[session_id]
-        return TokenResponse(access_token=token, expires_in=self.settings.token_ttl_seconds)
-
-    def _issue_admin_token(self, user_info: Dict[str, Any]) -> str:
+    def _issue_tokens(self, user_info: Dict[str, Any]) -> TokenPair:
         now = int(time.time())
+        expires_at = now + self.settings.access_token_ttl_seconds
         payload = {
+            "iss": self.settings.jwt_issuer,
+            "iat": now,
+            "exp": expires_at,
             "sub": user_info.get("sub") or user_info.get("email"),
             "email": user_info.get("email"),
-            "name": user_info.get("name"),
+            "name": user_info.get("name") or user_info.get("given_name"),
             "role": "admin",
-            "iat": now,
-            "exp": now + self.settings.token_ttl_seconds,
-            "iss": self.settings.jwt_issuer,
         }
-        return self._encode_jwt(payload)
-
-    def _encode_segment(self, data: Any) -> str:
-        if isinstance(data, bytes):
-            raw = data
-        else:
-            raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
-        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+        access_token = self._encode_jwt(payload)
+        refresh_token = secrets.token_urlsafe(48)
+        refresh_expires = now + self.settings.refresh_token_ttl_seconds
+        self._refresh_tokens[refresh_token] = _RefreshTokenState(user_id=payload["sub"], expires_at=refresh_expires)
+        return TokenPair(access_token=access_token, refresh_token=refresh_token, expires_in=self.settings.access_token_ttl_seconds)
 
     def _encode_jwt(self, payload: Dict[str, Any]) -> str:
         header = {"alg": "HS256", "typ": "JWT"}
-        header_b64 = self._encode_segment(header)
-        payload_b64 = self._encode_segment(payload)
-        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
-        signature = hmac.new(self.settings.jwt_secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
-        signature_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+        header_b64 = self._b64encode(header)
+        payload_b64 = self._b64encode(payload)
+        signing_input = f"{header_b64}.{payload_b64}".encode()
+        signature = hmac.new(
+            self.settings.jwt_secret.get_secret_value().encode(),
+            signing_input,
+            hashlib.sha256,
+        ).digest()
+        signature_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode()
         return f"{header_b64}.{payload_b64}.{signature_b64}"
 
     def decode_jwt(self, token: str) -> Dict[str, Any]:
@@ -309,88 +246,132 @@ class AuthService:
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token format") from exc
 
-        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
-        expected_sig = hmac.new(self.settings.jwt_secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
-        actual_sig = self._decode_segment(signature_b64)
-        if not hmac.compare_digest(expected_sig, actual_sig):
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token signature invalid")
+        signing_input = f"{header_b64}.{payload_b64}".encode()
+        expected_signature = hmac.new(
+            self.settings.jwt_secret.get_secret_value().encode(),
+            signing_input,
+            hashlib.sha256,
+        ).digest()
+        actual_signature = self._b64decode(signature_b64)
+        if not hmac.compare_digest(expected_signature, actual_signature):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token signature")
 
-        payload = json.loads(self._decode_segment(payload_b64))
-        exp = payload.get("exp")
-        if exp is not None and int(exp) < int(time.time()):
+        payload = json.loads(self._b64decode(payload_b64))
+        if payload.get("exp") and int(payload["exp"]) < int(time.time()):
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired")
+        if payload.get("role") != "admin":
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
         return payload
 
+    def verify_totp_and_issue_tokens(self, session_id: str, totp_code: str) -> TokenPair:
+        session = self._sessions.get(session_id)
+        if not session or session.expires_at < time.time():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session expired or not found")
+
+        user_id = session.user_info.get("email") or session.user_info.get("preferred_username") or session.user_info.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Session missing user identifier")
+
+        if not self._mfa.verify(user_id, totp_code):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
+
+        del self._sessions[session_id]
+        return self._issue_tokens(session.user_info)
+
+    def refresh_access_token(self, refresh_token: str) -> TokenPair:
+        state = self._refresh_tokens.get(refresh_token)
+        if not state or state.expires_at < time.time():
+            self._refresh_tokens.pop(refresh_token, None)
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+
+        # Keep the refresh token one-time use by rotating it
+        self._refresh_tokens.pop(refresh_token, None)
+        user_info = {"sub": state.user_id, "email": state.user_id}
+        return self._issue_tokens(user_info)
+
+    def logout(self, refresh_token: Optional[str], token: Optional[str]) -> None:
+        if refresh_token:
+            self._refresh_tokens.pop(refresh_token, None)
+
+        if token:
+            try:
+                payload = self.decode_jwt(token)
+            except HTTPException:
+                return
+            user_id = payload.get("sub")
+            if user_id:
+                for rt, rt_state in list(self._refresh_tokens.items()):
+                    if rt_state.user_id == user_id:
+                        self._refresh_tokens.pop(rt, None)
+
     @staticmethod
-    def _decode_segment(segment: str) -> bytes:
+    def _b64encode(data: Any) -> str:
+        if isinstance(data, bytes):
+            raw = data
+        else:
+            raw = json.dumps(data, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    @staticmethod
+    def _b64decode(segment: str) -> bytes:
         padding = "=" * (-len(segment) % 4)
         return base64.urlsafe_b64decode(segment + padding)
 
 
-# Default provider configuration placeholders.  In production these values should
-# come from environment variables or a secure configuration service.
-default_providers = {
-    "google": OIDCProviderConfig(
-        name="google",
-        authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
-        token_endpoint="https://oauth2.googleapis.com/token",
-        userinfo_endpoint="https://openidconnect.googleapis.com/v1/userinfo",
-        client_id="GOOGLE_CLIENT_ID",
-        client_secret="GOOGLE_CLIENT_SECRET",
-        redirect_uri="https://localhost/auth/google/callback",
-    ),
-    "microsoft": OIDCProviderConfig(
-        name="microsoft",
-        authorization_endpoint="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-        token_endpoint="https://login.microsoftonline.com/common/oauth2/v2.0/token",
-        userinfo_endpoint="https://graph.microsoft.com/oidc/userinfo",
-        client_id="MICROSOFT_CLIENT_ID",
-        client_secret="MICROSOFT_CLIENT_SECRET",
-        redirect_uri="https://localhost/auth/microsoft/callback",
-    ),
-}
+# Default settings rely on environment variables to encourage secure deployments.
+# In unit tests or local experiments these can be overridden easily.
 
-settings = AuthSettings()
-auth_service = AuthService(default_providers, settings)
-app = FastAPI(title="Authentication Service", version="1.0.0")
+
+def _load_default_auth_service() -> AuthService:
+    oidc = AzureOIDCSettings(
+        tenant_id=os.getenv("AZURE_AD_TENANT_ID", "common"),
+        client_id=os.getenv("AZURE_AD_CLIENT_ID", "YOUR_CLIENT_ID"),
+        client_secret=SecretStr(os.getenv("AZURE_AD_CLIENT_SECRET", "development-secret")),
+        redirect_uri=os.getenv("AZURE_AD_REDIRECT_URI", "http://localhost:8000/auth/callback"),
+    )
+    settings = AuthSettings(
+        jwt_secret=SecretStr(os.getenv("AUTH_JWT_SECRET", secrets.token_urlsafe(32))),
+        jwt_issuer=os.getenv("AUTH_JWT_ISSUER", "aether/auth"),
+    )
+    return AuthService(oidc=oidc, settings=settings)
+
+
+auth_service = _load_default_auth_service()
+app = FastAPI(title="Auth Service", version="1.0.0")
 
 
 async def get_auth_service() -> AuthService:
     return auth_service
 
 
-@app.get("/auth/oidc/{provider}", response_model=AuthorizationResponse)
-async def start_oidc_flow(provider: str, state: Optional[str] = None, nonce: Optional[str] = None, service: AuthService = Depends(get_auth_service)) -> AuthorizationResponse:
-    """Returns an authorization URL for the requested OIDC provider."""
-
-    authorization_url = await service.build_authorization_url(provider, state=state, nonce=nonce)
-    return AuthorizationResponse(authorization_url=authorization_url, provider=provider)
+@app.get("/auth/login", response_model=AuthorizationURLResponse)
+async def start_login(state: Optional[str] = None, nonce: Optional[str] = None, service: AuthService = Depends(get_auth_service)) -> AuthorizationURLResponse:
+    url = await service.build_authorization_url(state=state, nonce=nonce)
+    return AuthorizationURLResponse(authorization_url=url)
 
 
-@app.post("/auth/oidc/{provider}/callback", response_model=OIDCCallbackResponse)
-async def oidc_callback(provider: str, request: OIDCCallbackRequest, service: AuthService = Depends(get_auth_service)) -> OIDCCallbackResponse:
-    """Processes the OIDC callback, stores a pending session, and enforces MFA."""
-
-    tokens = await service.exchange_code_for_tokens(provider, request.code)
+@app.post("/auth/callback", response_model=OIDCCallbackResponse)
+async def oidc_callback(payload: OIDCCallbackRequest, service: AuthService = Depends(get_auth_service)) -> OIDCCallbackResponse:
+    tokens = await service.exchange_code_for_tokens(payload.code)
     access_token = tokens.get("access_token")
     if not access_token:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Missing access token from provider")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Azure AD did not return an access token")
+    user_info = await service.fetch_user_info(access_token)
+    return service.start_mfa_session(user_info)
 
-    user_info = await service.fetch_user_info(provider, access_token)
-    return service.create_pending_session(user_info, request.mfa_method)
+
+@app.post("/auth/mfa/totp", response_model=TokenPair)
+async def verify_totp(request: MFAVerificationRequest, service: AuthService = Depends(get_auth_service)) -> TokenPair:
+    return service.verify_totp_and_issue_tokens(request.session_id, request.totp_code)
 
 
-@app.post("/auth/mfa/verify", response_model=TokenResponse)
-async def verify_mfa(request: MFAVerificationRequest, service: AuthService = Depends(get_auth_service)) -> TokenResponse:
-    """Verifies the MFA challenge and returns an admin JWT token."""
-
-    return service.verify_mfa_and_issue_token(request.session_id, request.method, request.code)
+@app.post("/auth/refresh", response_model=TokenPair)
+async def refresh_token(request: RefreshRequest, service: AuthService = Depends(get_auth_service)) -> TokenPair:
+    return service.refresh_access_token(request.refresh_token)
 
 
 @app.get("/auth/status", response_model=AuthStatusResponse)
 async def auth_status(authorization: Optional[str] = Header(default=None), service: AuthService = Depends(get_auth_service)) -> AuthStatusResponse:
-    """Returns authentication status for the caller based on their JWT."""
-
     if not authorization or not authorization.lower().startswith("bearer "):
         return AuthStatusResponse(authenticated=False)
     token = authorization.split(" ", 1)[1]
@@ -399,6 +380,15 @@ async def auth_status(authorization: Optional[str] = Header(default=None), servi
     except HTTPException:
         return AuthStatusResponse(authenticated=False)
     return AuthStatusResponse(authenticated=True, claims=claims)
+
+
+@app.post("/auth/logout")
+async def logout(request: LogoutRequest, authorization: Optional[str] = Header(default=None), service: AuthService = Depends(get_auth_service)) -> Dict[str, str]:
+    token = None
+    if authorization and authorization.lower().startswith("bearer "):
+        token = authorization.split(" ", 1)[1]
+    service.logout(request.refresh_token, token)
+    return {"status": "logged_out"}
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- replace the authentication service with an Azure AD focused FastAPI app
- enforce TOTP-based MFA before issuing admin-scoped JWT access tokens
- add refresh, status, and logout endpoints with in-memory session tracking

## Testing
- python -m compileall services/auth/auth_service.py

------
https://chatgpt.com/codex/tasks/task_e_68ddac14d68c832189d8ba24ff59ea39