### PR TITLE
Enhance audit logging sensitivity tracking

### DIFF
--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -1,6 +1,13 @@
 """Utilities for application-wide helpers."""
 
 from . import audit_logger as audit_logger
-from .audit_logger import hash_ip, log_audit, main, verify_audit_chain
+from .audit_logger import hash_ip, is_sensitive_action, log_audit, main, verify_audit_chain
 
-__all__ = ["audit_logger", "hash_ip", "log_audit", "main", "verify_audit_chain"]
+__all__ = [
+    "audit_logger",
+    "hash_ip",
+    "is_sensitive_action",
+    "log_audit",
+    "main",
+    "verify_audit_chain",
+]


### PR DESCRIPTION
## Summary
- mark sensitive audit actions automatically using shared prefixes for config changes, secret rotations, overrides, and safe mode events
- persist the sensitivity flag in chained payloads while continuing to write tamper-evident hashes to the audit_log table
- expose the sensitivity helper via the utils package and extend tests to cover the new behaviour and chain verification

## Testing
- pytest tests/test_audit_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68de34edc8248321a308ce5b56e70865