### PR TITLE
Add Kraken balance reconciliation to OMS

### DIFF
--- a/services/oms/kraken_rest.py
+++ b/services/oms/kraken_rest.py
@@ -60,6 +60,11 @@ class KrakenRESTClient:
     async def open_orders(self) -> Dict[str, Any]:
         return await self._request("/private/OpenOrders", {})
 
+    async def balance(self) -> Dict[str, Any]:
+        """Return the latest balance snapshot for the authenticated account."""
+
+        return await self._request("/private/Balance", {})
+
     async def own_trades(self, *, start: Optional[int] = None, end: Optional[int] = None) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"trades": True}
         if start is not None:


### PR DESCRIPTION
## Summary
- add a REST client helper to pull Kraken account balances
- track and update local balance snapshots on each OMS account
- rebuild the OMS reconciler to compare balances and open orders, log results, and raise alerts when mismatches persist

## Testing
- python -m compileall services/oms

------
https://chatgpt.com/codex/tasks/task_e_68de34a3fcd48321940d7bf3b69a906c