### PR TITLE
Add SHA-256 chained audit logging and hook sensitive endpoints

### DIFF
--- a/logging_export.py
+++ b/logging_export.py
@@ -102,7 +102,7 @@ def _fetch_audit_logs(
     with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[arg-type]
         cur.execute(
             """
-            SELECT id, actor, action, entity, before_json, after_json, ts, ip_hash
+            SELECT id, actor, action, entity, before, after, ts, ip_hash, hash, prev_hash
             FROM audit_log
             WHERE ts >= %s AND ts < %s
             ORDER BY ts ASC
@@ -113,8 +113,8 @@ def _fetch_audit_logs(
     records: List[dict[str, Any]] = []
     for row in rows:
         row = dict(row)
-        row["before_json"] = _normalise_json(row.get("before_json", "{}"))
-        row["after_json"] = _normalise_json(row.get("after_json", "{}"))
+        row["before"] = _normalise_json(row.get("before", "{}"))
+        row["after"] = _normalise_json(row.get("after", "{}"))
         if isinstance(row.get("ts"), dt.datetime):
             row["ts"] = row["ts"].astimezone(dt.timezone.utc).isoformat()
         records.append(row)

--- a/multiformat_export.py
+++ b/multiformat_export.py
@@ -347,7 +347,7 @@ class LogExporter:
             with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[arg-type]
                 cur.execute(
                     """
-                    SELECT id, actor, action, entity, before_json, after_json, ts, ip_hash
+                    SELECT id, actor, action, entity, before, after, ts, ip_hash, hash, prev_hash
                     FROM audit_log
                     WHERE ts >= %s AND ts < %s
                     ORDER BY ts ASC
@@ -389,7 +389,7 @@ class LogExporter:
     def _normalise_record(self, row: Mapping[str, Any]) -> Dict[str, Any]:
         normalised: Dict[str, Any] = {}
         for key, value in dict(row).items():
-            if key in {"before_json", "after_json", "payload"}:
+            if key in {"before", "after", "payload"}:
                 value = _normalise_json(value)
             value = _normalise_datetime(value)
             normalised[key] = value

--- a/tests/integration/test_audit_chain.py
+++ b/tests/integration/test_audit_chain.py
@@ -158,14 +158,15 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
         "override.human_decision",
     ]
 
-    prev_hash = audit_logger._GENESIS_HASH  # pylint: disable=protected-access
+    prev_entry_hash = audit_logger._GENESIS_HASH  # pylint: disable=protected-access
     for entry in entries:
-        assert entry["prev_hash"] == prev_hash
+        expected_prev_hash = hashlib.sha256(prev_entry_hash.encode("utf-8")).hexdigest()
+        assert entry["prev_hash"] == expected_prev_hash
         canonical = audit_logger._canonical_payload(entry)  # pylint: disable=protected-access
         serialized = audit_logger._canonical_serialized(canonical)  # pylint: disable=protected-access
-        expected_hash = hashlib.sha256((prev_hash + serialized).encode("utf-8")).hexdigest()
+        expected_hash = hashlib.sha256((expected_prev_hash + serialized).encode("utf-8")).hexdigest()
         assert entry["hash"] == expected_hash
-        prev_hash = entry["hash"]
+        prev_entry_hash = entry["hash"]
 
     capsys.readouterr()
     result = audit_logger.main(["verify"])

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -70,7 +71,10 @@ def test_log_audit_inserts_and_logs(monkeypatch, tmp_path, capsys):
 
     assert payload["ip_hash"] == hashed_ip
     assert payload["ts"] == "2023-01-01T12:00:00+00:00"
-    assert payload["prev_hash"] == audit_logger._GENESIS_HASH  # pylint: disable=protected-access
+    expected_prev_hash = hashlib.sha256(
+        audit_logger._GENESIS_HASH.encode("utf-8")
+    ).hexdigest()  # pylint: disable=protected-access
+    assert payload["prev_hash"] == expected_prev_hash
     assert "hash" in payload
     assert payload["sensitive"] is False
 
@@ -88,7 +92,7 @@ def test_log_audit_inserts_and_logs(monkeypatch, tmp_path, capsys):
     )
 
     db_entry_hash, db_prev_hash = params[6:]
-    assert db_prev_hash == audit_logger._GENESIS_HASH  # pylint: disable=protected-access
+    assert db_prev_hash == expected_prev_hash
     assert db_entry_hash == payload["hash"]
 
 


### PR DESCRIPTION
## Summary
- chain audit entries using a SHA-256 digest of the prior hash and persist the new columns
- update log exporters and verification logic to reflect the renamed audit payload fields
- add tamper-evident audit logging to safe mode and secrets rotation endpoints

## Testing
- pytest tests/test_audit_logger.py
- pytest tests/integration/test_audit_chain.py *(skipped: requires fastapi)*
- pytest tests/services/test_safe_mode.py *(skipped: requires fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68de391f29fc83218d32046941e1d6e7