### PR TITLE
Add auditor role permissions and guard privileged UI actions

### DIFF
--- a/frontend/components/ApiKeyForm.tsx
+++ b/frontend/components/ApiKeyForm.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useAuthClaims } from "./useAuthClaims";
 
 type KrakenStatusResponse = {
   rotated_at?: string | null;
@@ -45,6 +46,7 @@ const ApiKeyForm: React.FC = () => {
   const [lastRotatedAt, setLastRotatedAt] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const { readOnly } = useAuthClaims();
   const accountOptions = useMemo(() => {
     if (typeof window !== "undefined") {
       const adminAccounts = (window as typeof window & {
@@ -213,114 +215,120 @@ const ApiKeyForm: React.FC = () => {
         )}
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label
-            htmlFor="accountId"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            Account
-          </label>
-          <select
-            id="accountId"
-            name="accountId"
-            value={accountId}
-            onChange={(event) => {
-              const newAccountId = event.target.value;
-              setAccountId(newAccountId);
-              setSubmitError(null);
-              setSuccessMessage(null);
-              setStatusError(null);
-              if (!newAccountId) {
-                setStatusLoading(false);
-                setLastRotatedAt(null);
-              } else {
-                setStatusLoading(true);
-              }
-            }}
-            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            required
-          >
-            <option value="" disabled>
-              Select an account
-            </option>
-            {accountOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
+      {!readOnly ? (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="accountId"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Account
+            </label>
+            <select
+              id="accountId"
+              name="accountId"
+              value={accountId}
+              onChange={(event) => {
+                const newAccountId = event.target.value;
+                setAccountId(newAccountId);
+                setSubmitError(null);
+                setSuccessMessage(null);
+                setStatusError(null);
+                if (!newAccountId) {
+                  setStatusLoading(false);
+                  setLastRotatedAt(null);
+                } else {
+                  setStatusLoading(true);
+                }
+              }}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              required
+            >
+              <option value="" disabled>
+                Select an account
               </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label
-            htmlFor="apiKey"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            API Key
-          </label>
-          <input
-            id="apiKey"
-            name="apiKey"
-            type="text"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            placeholder="Enter your Kraken API key"
-            required
-            autoComplete="off"
-          />
-        </div>
-
-        <div>
-          <label
-            htmlFor="apiSecret"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            API Secret
-          </label>
-          <input
-            id="apiSecret"
-            name="apiSecret"
-            type="password"
-            value={apiSecret}
-            onChange={(event) => setApiSecret(event.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            placeholder="Enter your Kraken API secret"
-            required
-            autoComplete="new-password"
-          />
-        </div>
-
-        {submitError && (
-          <div
-            className="rounded-md bg-red-50 p-3 text-sm text-red-700"
-            role="alert"
-          >
-            {submitError}
+              {accountOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </div>
-        )}
 
-        {successMessage && (
-          <div
-            className="rounded-md bg-green-50 p-3 text-sm text-green-700"
-            role="status"
-            aria-live="polite"
-          >
-            {successMessage}
+          <div>
+            <label
+              htmlFor="apiKey"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              API Key
+            </label>
+            <input
+              id="apiKey"
+              name="apiKey"
+              type="text"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              placeholder="Enter your Kraken API key"
+              required
+              autoComplete="off"
+            />
           </div>
-        )}
 
-        <div className="flex justify-end">
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-75"
-          >
-            {isSubmitting ? "Saving…" : "Save Credentials"}
-          </button>
+          <div>
+            <label
+              htmlFor="apiSecret"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              API Secret
+            </label>
+            <input
+              id="apiSecret"
+              name="apiSecret"
+              type="password"
+              value={apiSecret}
+              onChange={(event) => setApiSecret(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              placeholder="Enter your Kraken API secret"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          {submitError && (
+            <div
+              className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+              role="alert"
+            >
+              {submitError}
+            </div>
+          )}
+
+          {successMessage && (
+            <div
+              className="rounded-md bg-green-50 p-3 text-sm text-green-700"
+              role="status"
+              aria-live="polite"
+            >
+              {successMessage}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-75"
+            >
+              {isSubmitting ? "Saving…" : "Save Credentials"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+          Auditor access is read-only. Updating Kraken credentials is disabled.
         </div>
-      </form>
+      )}
     </div>
   );
 };

--- a/frontend/components/ApiKeyManager.tsx
+++ b/frontend/components/ApiKeyManager.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useState } from "react";
+import { useAuthClaims } from "./useAuthClaims";
 
 type SecretsStatusResponse = {
   last_rotated_at?: string | null;
@@ -49,6 +50,7 @@ const ApiKeyManager: React.FC = () => {
     "idle"
   );
   const [confirmationInput, setConfirmationInput] = useState("");
+  const { readOnly } = useAuthClaims();
 
   const loadStatus = useCallback(
     async (signal: AbortSignal) => {
@@ -256,93 +258,99 @@ const ApiKeyManager: React.FC = () => {
         )}
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label htmlFor="apiKey" className="block text-sm font-medium text-gray-700 mb-1">
-            API Key
-          </label>
-          <input
-            id="apiKey"
-            name="apiKey"
-            type="text"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            placeholder="Enter your Kraken API key"
-            required
-            autoComplete="off"
-          />
-        </div>
-
-        <div>
-          <label htmlFor="apiSecret" className="block text-sm font-medium text-gray-700 mb-1">
-            API Secret
-          </label>
-          <input
-            id="apiSecret"
-            name="apiSecret"
-            type="password"
-            value={apiSecret}
-            onChange={(event) => setApiSecret(event.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            placeholder="Enter your Kraken API secret"
-            required
-            autoComplete="new-password"
-          />
-        </div>
-
-        {confirmationStage === "confirm" && (
-          <div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
-            <p className="text-sm text-yellow-800 mb-2">
-              Rotating the Kraken API credentials will immediately revoke access for the current key pair. Please confirm that
-              you intend to proceed by typing <span className="font-semibold">ROTATE</span> below.
-            </p>
+      {!readOnly ? (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="apiKey" className="block text-sm font-medium text-gray-700 mb-1">
+              API Key
+            </label>
             <input
+              id="apiKey"
+              name="apiKey"
               type="text"
-              value={confirmationInput}
-              onChange={(event) => setConfirmationInput(event.target.value)}
-              className="w-full rounded-md border border-yellow-300 px-3 py-2 focus:border-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-200"
-              placeholder="Type ROTATE to confirm"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              placeholder="Enter your Kraken API key"
+              required
               autoComplete="off"
             />
-            <div className="mt-3 flex items-center justify-between">
-              <button
-                type="button"
-                className="text-sm font-medium text-gray-600 hover:text-gray-800"
-                onClick={() => {
-                  setConfirmationStage("idle");
-                  setConfirmationInput("");
-                }}
-              >
-                Cancel rotation
-              </button>
-              <p className="text-xs text-gray-500">Confirmation required before submission</p>
+          </div>
+
+          <div>
+            <label htmlFor="apiSecret" className="block text-sm font-medium text-gray-700 mb-1">
+              API Secret
+            </label>
+            <input
+              id="apiSecret"
+              name="apiSecret"
+              type="password"
+              value={apiSecret}
+              onChange={(event) => setApiSecret(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              placeholder="Enter your Kraken API secret"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          {confirmationStage === "confirm" && (
+            <div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+              <p className="text-sm text-yellow-800 mb-2">
+                Rotating the Kraken API credentials will immediately revoke access for the current key pair. Please confirm that
+                you intend to proceed by typing <span className="font-semibold">ROTATE</span> below.
+              </p>
+              <input
+                type="text"
+                value={confirmationInput}
+                onChange={(event) => setConfirmationInput(event.target.value)}
+                className="w-full rounded-md border border-yellow-300 px-3 py-2 focus:border-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-200"
+                placeholder="Type ROTATE to confirm"
+                autoComplete="off"
+              />
+              <div className="mt-3 flex items-center justify-between">
+                <button
+                  type="button"
+                  className="text-sm font-medium text-gray-600 hover:text-gray-800"
+                  onClick={() => {
+                    setConfirmationStage("idle");
+                    setConfirmationInput("");
+                  }}
+                >
+                  Cancel rotation
+                </button>
+                <p className="text-xs text-gray-500">Confirmation required before submission</p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {submitError && (
-          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
-            {submitError}
-          </div>
-        )}
+          {submitError && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+              {submitError}
+            </div>
+          )}
 
-        {successMessage && (
-          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700" role="status" aria-live="polite">
-            {successMessage}
-          </div>
-        )}
+          {successMessage && (
+            <div className="rounded-md bg-green-50 p-3 text-sm text-green-700" role="status" aria-live="polite">
+              {successMessage}
+            </div>
+          )}
 
-        <div className="flex justify-end">
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-75"
-          >
-            {isSubmitting ? "Rotating…" : confirmationStage === "confirm" ? "Confirm Rotation" : "Rotate Keys"}
-          </button>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-75"
+            >
+              {isSubmitting ? "Rotating…" : confirmationStage === "confirm" ? "Confirm Rotation" : "Rotate Keys"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+          Auditor access is read-only. Credential rotation is disabled.
         </div>
-      </form>
+      )}
 
       <div className="mt-8">
         <h3 className="text-lg font-semibold text-gray-900 mb-3">Rotation History</h3>

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import { useAuthClaims } from "./useAuthClaims";
 
 interface ExposureBreakdown {
   asset: string;
@@ -201,6 +202,7 @@ const Dashboard: React.FC = () => {
   const [rotationMessage, setRotationMessage] = useState<string | null>(null);
   const [rotationError, setRotationError] = useState<string | null>(null);
   const [rotationSubmitting, setRotationSubmitting] = useState(false);
+  const { readOnly } = useAuthClaims();
 
   useEffect(() => {
     let isMounted = true;
@@ -751,50 +753,56 @@ const Dashboard: React.FC = () => {
                 </dl>
               </div>
 
-              <form onSubmit={handleRotateSecrets} className="space-y-3">
-                <div className="text-xs uppercase tracking-wide text-slate-500">
-                  Rotate Kraken API Keys
+              {!readOnly ? (
+                <form onSubmit={handleRotateSecrets} className="space-y-3">
+                  <div className="text-xs uppercase tracking-wide text-slate-500">
+                    Rotate Kraken API Keys
+                  </div>
+                  <label className="block text-xs text-slate-400">
+                    API Key
+                    <input
+                      type="text"
+                      value={apiKey}
+                      onChange={(event) => setApiKey(event.target.value)}
+                      className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-500"
+                      placeholder="Enter new API key"
+                      autoComplete="off"
+                    />
+                  </label>
+                  <label className="block text-xs text-slate-400">
+                    API Secret
+                    <input
+                      type="password"
+                      value={apiSecret}
+                      onChange={(event) => setApiSecret(event.target.value)}
+                      className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-500"
+                      placeholder="Enter new API secret"
+                      autoComplete="off"
+                    />
+                  </label>
+                  <button
+                    type="submit"
+                    disabled={rotationSubmitting}
+                    className="w-full rounded-md bg-emerald-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-slate-800 disabled:text-slate-400"
+                  >
+                    {rotationSubmitting ? "Rotating..." : "Rotate Credentials"}
+                  </button>
+                  {rotationError && (
+                    <div className="rounded-md border border-rose-500/40 bg-rose-950/40 px-3 py-2 text-xs text-rose-200">
+                      {rotationError}
+                    </div>
+                  )}
+                  {rotationMessage && (
+                    <div className="rounded-md border border-emerald-500/40 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">
+                      {rotationMessage}
+                    </div>
+                  )}
+                </form>
+              ) : (
+                <div className="rounded-md border border-slate-800 bg-slate-950/60 px-3 py-2 text-xs text-slate-300">
+                  Auditor access is read-only. Credential rotation is disabled.
                 </div>
-                <label className="block text-xs text-slate-400">
-                  API Key
-                  <input
-                    type="text"
-                    value={apiKey}
-                    onChange={(event) => setApiKey(event.target.value)}
-                    className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-500"
-                    placeholder="Enter new API key"
-                    autoComplete="off"
-                  />
-                </label>
-                <label className="block text-xs text-slate-400">
-                  API Secret
-                  <input
-                    type="password"
-                    value={apiSecret}
-                    onChange={(event) => setApiSecret(event.target.value)}
-                    className="mt-1 w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-500"
-                    placeholder="Enter new API secret"
-                    autoComplete="off"
-                  />
-                </label>
-                <button
-                  type="submit"
-                  disabled={rotationSubmitting}
-                  className="w-full rounded-md bg-emerald-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-slate-800 disabled:text-slate-400"
-                >
-                  {rotationSubmitting ? "Rotating..." : "Rotate Credentials"}
-                </button>
-                {rotationError && (
-                  <div className="rounded-md border border-rose-500/40 bg-rose-950/40 px-3 py-2 text-xs text-rose-200">
-                    {rotationError}
-                  </div>
-                )}
-                {rotationMessage && (
-                  <div className="rounded-md border border-emerald-500/40 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">
-                    {rotationMessage}
-                  </div>
-                )}
-              </form>
+              )}
             </div>
           </div>
         </section>

--- a/frontend/components/DirectorControls.tsx
+++ b/frontend/components/DirectorControls.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { useAuthClaims } from "./useAuthClaims";
 
 interface SafeModeStatusResponse {
   active: boolean;
@@ -96,6 +97,7 @@ const DirectorControls: React.FC = () => {
   const [auditTrail, setAuditTrail] = useState<DirectorAction[]>([]);
   const [auditLoading, setAuditLoading] = useState<boolean>(true);
   const [auditError, setAuditError] = useState<string | null>(null);
+  const { readOnly } = useAuthClaims();
 
   const safeModeStatusLabel = useMemo(() => {
     if (!safeModeStatus) {
@@ -417,133 +419,157 @@ const DirectorControls: React.FC = () => {
         </p>
         {safeModeLoading && <p>Loading safe mode status…</p>}
         {safeModeError && <p className="error">{safeModeError}</p>}
-        <div className="form-grid">
-          <label htmlFor="safe-mode-reason">Reason</label>
-          <input
-            id="safe-mode-reason"
-            type="text"
-            value={safeModeReason}
-            onChange={(event) => setSafeModeReason(event.target.value)}
-            placeholder="Reason for entering safe mode"
-          />
-          <label htmlFor="safe-mode-actor">Actor (optional)</label>
-          <input
-            id="safe-mode-actor"
-            type="text"
-            value={safeModeActor}
-            onChange={(event) => setSafeModeActor(event.target.value)}
-            placeholder="Recorded actor"
-          />
-        </div>
-        <div className="button-row">
-          <button
-            type="button"
-            onClick={() => handleSafeMode("enter")}
-            disabled={safeModeActionLoading}
-          >
-            Enter Safe Mode
-          </button>
-          <button
-            type="button"
-            onClick={() => handleSafeMode("exit")}
-            disabled={safeModeActionLoading}
-          >
-            Exit Safe Mode
-          </button>
-        </div>
-        {safeModeMessage && <p className="success">{safeModeMessage}</p>}
-        {safeModeActionError && <p className="error">{safeModeActionError}</p>}
+        {!readOnly ? (
+          <>
+            <div className="form-grid">
+              <label htmlFor="safe-mode-reason">Reason</label>
+              <input
+                id="safe-mode-reason"
+                type="text"
+                value={safeModeReason}
+                onChange={(event) => setSafeModeReason(event.target.value)}
+                placeholder="Reason for entering safe mode"
+              />
+              <label htmlFor="safe-mode-actor">Actor (optional)</label>
+              <input
+                id="safe-mode-actor"
+                type="text"
+                value={safeModeActor}
+                onChange={(event) => setSafeModeActor(event.target.value)}
+                placeholder="Recorded actor"
+              />
+            </div>
+            <div className="button-row">
+              <button
+                type="button"
+                onClick={() => handleSafeMode("enter")}
+                disabled={safeModeActionLoading}
+              >
+                Enter Safe Mode
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSafeMode("exit")}
+                disabled={safeModeActionLoading}
+              >
+                Exit Safe Mode
+              </button>
+            </div>
+            {safeModeMessage && <p className="success">{safeModeMessage}</p>}
+            {safeModeActionError && <p className="error">{safeModeActionError}</p>}
+          </>
+        ) : (
+          <p className="info">
+            Auditor access is read-only. Safe mode controls are hidden.
+          </p>
+        )}
       </div>
 
       <div className="control-card">
         <h3>Kill Switch</h3>
-        <form onSubmit={handleKillSwitch}>
-          <div className="form-grid">
-            <label htmlFor="kill-account">Account</label>
-            <input
-              id="kill-account"
-              type="text"
-              value={killAccount}
-              onChange={(event) => setKillAccount(event.target.value)}
-              placeholder="Account identifier"
-            />
-            <label htmlFor="kill-reason">Reason</label>
-            <select
-              id="kill-reason"
-              value={killReason}
-              onChange={(event) =>
-                setKillReason(event.target.value as KillSwitchReason)
-              }
-            >
-              {KILL_SWITCH_REASONS.map((reason) => (
-                <option key={reason.value} value={reason.value}>
-                  {reason.label}
-                </option>
-              ))}
-            </select>
-            <label htmlFor="first-approval">Director Approval #1</label>
-            <input
-              id="first-approval"
-              type="text"
-              value={firstApproval}
-              onChange={(event) => setFirstApproval(event.target.value)}
-              placeholder="director-1"
-            />
-            <label htmlFor="second-approval">Director Approval #2</label>
-            <input
-              id="second-approval"
-              type="text"
-              value={secondApproval}
-              onChange={(event) => setSecondApproval(event.target.value)}
-              placeholder="director-2"
-            />
-          </div>
-          <button type="submit" disabled={killLoading}>
-            {killArmed ? "Confirm Kill Switch" : "Engage Kill Switch"}
-          </button>
-        </form>
-        {killMessage && <p className="warning">{killMessage}</p>}
-        {killError && <p className="error">{killError}</p>}
+        {!readOnly ? (
+          <>
+            <form onSubmit={handleKillSwitch}>
+              <div className="form-grid">
+                <label htmlFor="kill-account">Account</label>
+                <input
+                  id="kill-account"
+                  type="text"
+                  value={killAccount}
+                  onChange={(event) => setKillAccount(event.target.value)}
+                  placeholder="Account identifier"
+                />
+                <label htmlFor="kill-reason">Reason</label>
+                <select
+                  id="kill-reason"
+                  value={killReason}
+                  onChange={(event) =>
+                    setKillReason(event.target.value as KillSwitchReason)
+                  }
+                >
+                  {KILL_SWITCH_REASONS.map((reason) => (
+                    <option key={reason.value} value={reason.value}>
+                      {reason.label}
+                    </option>
+                  ))}
+                </select>
+                <label htmlFor="first-approval">Director Approval #1</label>
+                <input
+                  id="first-approval"
+                  type="text"
+                  value={firstApproval}
+                  onChange={(event) => setFirstApproval(event.target.value)}
+                  placeholder="director-1"
+                />
+                <label htmlFor="second-approval">Director Approval #2</label>
+                <input
+                  id="second-approval"
+                  type="text"
+                  value={secondApproval}
+                  onChange={(event) => setSecondApproval(event.target.value)}
+                  placeholder="director-2"
+                />
+              </div>
+              <button type="submit" disabled={killLoading}>
+                {killArmed ? "Confirm Kill Switch" : "Engage Kill Switch"}
+              </button>
+            </form>
+            {killMessage && <p className="warning">{killMessage}</p>}
+            {killError && <p className="error">{killError}</p>}
+          </>
+        ) : (
+          <p className="info">
+            Auditor access is read-only. Kill switch controls are hidden.
+          </p>
+        )}
       </div>
 
       <div className="control-card">
         <h3>Override Decisions</h3>
-        <form onSubmit={handleOverride}>
-          <div className="form-grid">
-            <label htmlFor="override-asset">Asset</label>
-            <input
-              id="override-asset"
-              type="text"
-              value={overrideAsset}
-              onChange={(event) => setOverrideAsset(event.target.value)}
-              placeholder="e.g. BTC-USD"
-            />
-            <label htmlFor="override-reason">Reason</label>
-            <input
-              id="override-reason"
-              type="text"
-              value={overrideReason}
-              onChange={(event) => setOverrideReason(event.target.value)}
-              placeholder="Why this override is needed"
-            />
-            <label htmlFor="override-action">Action</label>
-            <select
-              id="override-action"
-              value={overrideAction}
-              onChange={(event) =>
-                setOverrideAction(event.target.value as "block" | "unblock")
-              }
-            >
-              <option value="block">Block Asset</option>
-              <option value="unblock">Unblock Asset</option>
-            </select>
-          </div>
-          <button type="submit" disabled={overrideLoading}>
-            Submit Override
-          </button>
-        </form>
-        {overrideMessage && <p className="success">{overrideMessage}</p>}
-        {overrideError && <p className="error">{overrideError}</p>}
+        {!readOnly ? (
+          <>
+            <form onSubmit={handleOverride}>
+              <div className="form-grid">
+                <label htmlFor="override-asset">Asset</label>
+                <input
+                  id="override-asset"
+                  type="text"
+                  value={overrideAsset}
+                  onChange={(event) => setOverrideAsset(event.target.value)}
+                  placeholder="e.g. BTC-USD"
+                />
+                <label htmlFor="override-reason">Reason</label>
+                <input
+                  id="override-reason"
+                  type="text"
+                  value={overrideReason}
+                  onChange={(event) => setOverrideReason(event.target.value)}
+                  placeholder="Why this override is needed"
+                />
+                <label htmlFor="override-action">Action</label>
+                <select
+                  id="override-action"
+                  value={overrideAction}
+                  onChange={(event) =>
+                    setOverrideAction(event.target.value as "block" | "unblock")
+                  }
+                >
+                  <option value="block">Block Asset</option>
+                  <option value="unblock">Unblock Asset</option>
+                </select>
+              </div>
+              <button type="submit" disabled={overrideLoading}>
+                Submit Override
+              </button>
+            </form>
+            {overrideMessage && <p className="success">{overrideMessage}</p>}
+            {overrideError && <p className="error">{overrideError}</p>}
+          </>
+        ) : (
+          <p className="info">
+            Auditor access is read-only. Override controls are hidden.
+          </p>
+        )}
       </div>
 
       <div className="control-card">

--- a/frontend/components/SafeModePanel.tsx
+++ b/frontend/components/SafeModePanel.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useAuthClaims } from "./useAuthClaims";
 
 type SafeModeStatusResponse = {
   active: boolean;
@@ -50,6 +51,7 @@ const SafeModePanel: React.FC = () => {
   const [actionLoading, setActionLoading] = useState(false);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const { readOnly } = useAuthClaims();
 
   const currentStatusLabel = useMemo(() => {
     if (!status) {
@@ -279,76 +281,93 @@ const SafeModePanel: React.FC = () => {
         </div>
       </div>
 
-      <form
-        onSubmit={handleEnterSafeMode}
-        className="grid gap-4 md:grid-cols-2"
-        aria-label="Safe mode controls"
-      >
-        <div className="md:col-span-2 grid gap-4 sm:grid-cols-2">
-          <label className="flex flex-col text-sm font-medium text-gray-700">
-            Reason
-            <input
-              type="text"
-              value={reason}
-              onChange={(event) => setReason(event.target.value)}
-              placeholder="Describe the issue triggering safe mode"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              required
-              disabled={actionLoading}
-            />
-          </label>
-          <label className="flex flex-col text-sm font-medium text-gray-700">
-            Actor (optional)
-            <input
-              type="text"
-              value={actor}
-              onChange={(event) => setActor(event.target.value)}
-              placeholder="ops-oncall"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              disabled={actionLoading}
-            />
-          </label>
-        </div>
+      {!readOnly ? (
+        <>
+          <form
+            onSubmit={handleEnterSafeMode}
+            className="grid gap-4 md:grid-cols-2"
+            aria-label="Safe mode controls"
+          >
+            <div className="md:col-span-2 grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                Reason
+                <input
+                  type="text"
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  placeholder="Describe the issue triggering safe mode"
+                  className="mt-1 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  required
+                  disabled={actionLoading}
+                />
+              </label>
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                Actor (optional)
+                <input
+                  type="text"
+                  value={actor}
+                  onChange={(event) => setActor(event.target.value)}
+                  placeholder="ops-oncall"
+                  className="mt-1 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  disabled={actionLoading}
+                />
+              </label>
+            </div>
 
-        <div className="flex flex-col gap-3 md:col-span-2 md:flex-row">
-          <button
-            type="submit"
-            className="inline-flex items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-red-400"
-            disabled={actionLoading}
-          >
-            {actionLoading ? "Processing..." : "Enter Safe Mode"}
-          </button>
-          <button
-            type="button"
-            onClick={handleExitSafeMode}
-            className="inline-flex items-center justify-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-green-400"
-            disabled={actionLoading}
-          >
-            {actionLoading ? "Processing..." : "Exit Safe Mode"}
-          </button>
+            <div className="flex flex-col gap-3 md:col-span-2 md:flex-row">
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-red-400"
+                disabled={actionLoading}
+              >
+                {actionLoading ? "Processing..." : "Enter Safe Mode"}
+              </button>
+              <button
+                type="button"
+                onClick={handleExitSafeMode}
+                className="inline-flex items-center justify-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-green-400"
+                disabled={actionLoading}
+              >
+                {actionLoading ? "Processing..." : "Exit Safe Mode"}
+              </button>
+              <button
+                type="button"
+                onClick={refreshAll}
+                className="inline-flex items-center justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed"
+                disabled={actionLoading}
+              >
+                Refresh
+              </button>
+            </div>
+          </form>
+
+          <div className="space-y-3">
+            {actionMessage && (
+              <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">
+                {actionMessage}
+              </div>
+            )}
+            {actionError && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+                {actionError}
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="space-y-3 md:col-span-2">
+          <div className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+            Auditor access is read-only. Safe mode controls are hidden.
+          </div>
           <button
             type="button"
             onClick={refreshAll}
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed"
-            disabled={actionLoading}
+            className="inline-flex items-center justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
           >
             Refresh
           </button>
         </div>
-      </form>
-
-      <div className="space-y-3">
-        {actionMessage && (
-          <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">
-            {actionMessage}
-          </div>
-        )}
-        {actionError && (
-          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-            {actionError}
-          </div>
-        )}
-      </div>
+      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">

--- a/frontend/components/useAuthClaims.ts
+++ b/frontend/components/useAuthClaims.ts
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+
+export interface AuthClaims {
+  role?: string;
+  permissions?: string[];
+  read_only?: boolean;
+  [key: string]: unknown;
+}
+
+declare global {
+  interface Window {
+    __AETHER_CLAIMS__?: AuthClaims;
+    __AETHER_ACCESS_TOKEN__?: string;
+  }
+}
+
+const decodeJwtClaims = (token: string): AuthClaims | null => {
+  const segments = token.split(".");
+  if (segments.length < 2) {
+    return null;
+  }
+  const payload = segments[1];
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+    if (typeof atob !== "function") {
+      console.warn("Base64 decoder not available in this environment");
+      return null;
+    }
+    const decoded = atob(padded);
+    const parsed = JSON.parse(decoded) as AuthClaims;
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to decode JWT payload", error);
+    return null;
+  }
+};
+
+const safeGetStorageItem = (
+  storageType: "localStorage" | "sessionStorage",
+  key: string
+): string | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const storage = window[storageType];
+    if (!storage) {
+      return null;
+    }
+    return storage.getItem(key);
+  } catch (error) {
+    console.warn(`Unable to access ${storageType}`, error);
+    return null;
+  }
+};
+
+const readClaimsFromEnvironment = (): AuthClaims | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (window.__AETHER_CLAIMS__) {
+    return window.__AETHER_CLAIMS__;
+  }
+
+  const tokenCandidates: (string | null | undefined)[] = [
+    window.__AETHER_ACCESS_TOKEN__,
+    safeGetStorageItem("sessionStorage", "aether.access_token"),
+    safeGetStorageItem("sessionStorage", "access_token"),
+    safeGetStorageItem("localStorage", "aether.access_token"),
+    safeGetStorageItem("localStorage", "access_token"),
+  ];
+
+  for (const token of tokenCandidates) {
+    if (token) {
+      const claims = decodeJwtClaims(token);
+      if (claims) {
+        return claims;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const useAuthClaims = () => {
+  const [claims, setClaims] = useState<AuthClaims | null>(() =>
+    readClaimsFromEnvironment()
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const syncClaims = () => {
+      setClaims(readClaimsFromEnvironment());
+    };
+
+    window.addEventListener("storage", syncClaims);
+    const interval = window.setInterval(syncClaims, 5000);
+
+    return () => {
+      window.removeEventListener("storage", syncClaims);
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const permissions = useMemo(() => {
+    if (!claims?.permissions) {
+      return [] as string[];
+    }
+    return Array.from(new Set(claims.permissions)).sort();
+  }, [claims]);
+
+  const readOnly = useMemo(() => {
+    if (!claims) {
+      return false;
+    }
+    if (typeof claims.read_only === "boolean") {
+      return claims.read_only;
+    }
+    const role = typeof claims.role === "string" ? claims.role.toLowerCase() : "";
+    return role === "auditor";
+  }, [claims]);
+
+  return { claims, permissions, readOnly } as const;
+};
+
+export default useAuthClaims;

--- a/services/auth/auth_service.py
+++ b/services/auth/auth_service.py
@@ -259,12 +259,12 @@ class AuthService:
         base_permissions = {
             "view_reports",
             "view_logs",
-            "view_trades",
+            "view_metrics",
         }
         if role == "auditor":
             return base_permissions
         if role == "admin":
-            return base_permissions | {"place_orders", "modify_configs"}
+            return base_permissions | {"view_trades", "place_orders", "modify_configs"}
         return set()
 
     def _encode_jwt(self, payload: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- ensure the authentication service maps configured accounts to the read-only auditor role and limits their permissions to reporting capabilities
- add a reusable React hook to surface JWT claims and read-only state for the frontend
- hide rotation, override, and other privileged controls in dashboard and admin views when the signed-in user is an auditor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de39c32c608321a668e054bb9d4b5b