### PR TITLE
Fix audit chain hashing to store previous entry hash

### DIFF
--- a/common/utils/audit_logger.py
+++ b/common/utils/audit_logger.py
@@ -111,12 +111,6 @@ def _append_chain_log(log_path: Path, entry: Dict[str, Any]) -> None:
         fh.write(json.dumps(entry, separators=(",", ":"), sort_keys=True) + "\n")
 
 
-def _chain_previous_hash(prev_hash: str) -> str:
-    """Return the SHA-256 digest of the previous hash value."""
-
-    return hashlib.sha256(prev_hash.encode("utf-8")).hexdigest()
-
-
 def _canonical_payload(entry: Dict[str, Any]) -> Dict[str, Any]:
     canonical: Dict[str, Any] = {}
     for field in _CORE_FIELDS:
@@ -166,12 +160,11 @@ def log_audit(
 
     state_path = _chain_state_path()
     prev_entry_hash = _read_last_hash(state_path)
-    chained_prev_hash = _chain_previous_hash(prev_entry_hash)
     canonical_serialized = _canonical_serialized(core_payload)
-    entry_hash = hashlib.sha256((chained_prev_hash + canonical_serialized).encode("utf-8")).hexdigest()
+    entry_hash = hashlib.sha256((prev_entry_hash + canonical_serialized).encode("utf-8")).hexdigest()
 
     chained_payload = dict(core_payload)
-    chained_payload["prev_hash"] = chained_prev_hash
+    chained_payload["prev_hash"] = prev_entry_hash
     chained_payload["hash"] = entry_hash
 
     sys.stdout.write(_canonical_serialized(chained_payload) + "\n")
@@ -208,7 +201,7 @@ def log_audit(
                     after_json,
                     timestamp,
                     entry_hash,
-                    chained_prev_hash,
+                    prev_entry_hash,
                 ),
             )
 
@@ -246,7 +239,7 @@ def verify_audit_chain() -> bool:
                 valid = False
                 break
 
-            expected_prev_hash = _chain_previous_hash(prev_entry_hash)
+            expected_prev_hash = prev_entry_hash
 
             if entry_prev != expected_prev_hash:
                 print(

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -71,9 +70,7 @@ def test_log_audit_inserts_and_logs(monkeypatch, tmp_path, capsys):
 
     assert payload["ip_hash"] == hashed_ip
     assert payload["ts"] == "2023-01-01T12:00:00+00:00"
-    expected_prev_hash = hashlib.sha256(
-        audit_logger._GENESIS_HASH.encode("utf-8")
-    ).hexdigest()  # pylint: disable=protected-access
+    expected_prev_hash = audit_logger._GENESIS_HASH  # pylint: disable=protected-access
     assert payload["prev_hash"] == expected_prev_hash
     assert "hash" in payload
     assert payload["sensitive"] is False


### PR DESCRIPTION
## Summary
- update audit chain computation to use the raw previous entry hash when linking records
- persist the previous entry hash in the database/log for tamper-evident verification
- adjust audit logger tests to reflect the new hashing scheme

## Testing
- pytest tests/test_audit_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68de3d6263b08321be156c76799706fa