### PR TITLE
Add latency observability metrics and dashboards

### DIFF
--- a/docs/runbooks/oms_latency.md
+++ b/docs/runbooks/oms_latency.md
@@ -1,0 +1,28 @@
+# OMS Latency Investigation
+
+This runbook covers mitigation for OMS submission latency SLO alerts.
+
+## Quick Checklist
+- [ ] Confirm `oms_latency_p95_slo_breach` alert context for impacted symbols/accounts.
+- [ ] Review OMS infrastructure dashboards for connection pool saturation.
+- [ ] Check with exchange status pages for upstream incidents.
+
+## Diagnostic Steps
+1. **Exchange Connectivity**
+   - Inspect FIX/REST gateway logs for throttling or rate-limit errors.
+   - Run synthetic order submissions against the sandbox endpoint to gauge response times.
+2. **Infrastructure Health**
+   - Validate pod resource usage with `kubectl top pods -n trading | grep oms`.
+   - Check Nginx ingress latency and error rates.
+3. **Downstream Dependencies**
+   - Ensure clearing service acknowledgements are not delayed.
+   - Review message broker lag metrics for the OMS topic.
+
+## Mitigation
+- Increase OMS worker replicas during sustained load.
+- Switch affected symbols to backup gateways when available.
+- Coordinate with exchanges to raise rate limits if necessary.
+
+## Post-Incident
+- Capture remediation steps in the incident tracker.
+- Schedule load testing if capacity limits were reached.

--- a/docs/runbooks/policy_latency.md
+++ b/docs/runbooks/policy_latency.md
@@ -1,0 +1,28 @@
+# Policy Latency Investigation
+
+This runbook outlines the steps to follow when the policy evaluation latency SLO is at risk.
+
+## Quick Checklist
+- [ ] Confirm the `policy_latency_p95_slo_breach` alert in Prometheus.
+- [ ] Review the `Trading Latency Percentiles` Grafana dashboard for the affected symbol/account pair.
+- [ ] Check the policy service autoscaling status and recent deploys.
+
+## Diagnostic Steps
+1. **Validate Input Load**
+   - Inspect the policy service request rate in Grafana and compare it with historical baselines.
+   - Verify upstream sequencer message backlog using `kubectl logs deploy/sequencer`.
+2. **Service Health**
+   - Ensure pods are not CPU throttled: `kubectl top pods -n trading | grep policy`.
+   - Look for recent restarts: `kubectl get pods -n trading -l app=policy-service`.
+3. **Model Performance**
+   - Review model inference logs for anomalies or slow responses.
+   - If a new model was deployed, consider rolling back using the change management procedure.
+
+## Mitigation
+- Scale the policy service horizontally by increasing the replica count.
+- If external dependencies are slow, enable the policy cache feature flag.
+- Escalate to the on-call ML engineer if latency is caused by model regression.
+
+## Post-Incident
+- Record findings in the incident tracker.
+- Update the SLO dashboard annotations with remediation details.

--- a/docs/runbooks/risk_latency.md
+++ b/docs/runbooks/risk_latency.md
@@ -1,0 +1,28 @@
+# Risk Latency Investigation
+
+Follow this procedure when the risk validation latency SLO is threatened.
+
+## Quick Checklist
+- [ ] Verify `risk_latency_p95_slo_breach` alert details, focusing on symbol/account labels.
+- [ ] Inspect upstream policy responses for anomalies that could cascade.
+- [ ] Confirm risk engine pods are healthy and autoscaling rules are active.
+
+## Diagnostic Steps
+1. **Queue Depth**
+   - Use `kubectl exec` to inspect Redis or Kafka queue depth powering the risk engine.
+   - Ensure there is no backlog by checking the `risk_queue_depth` metric.
+2. **Dependency Latency**
+   - Review database slow query logs for the `risk_decisions` table.
+   - Check external credit services status pages for incidents.
+3. **Resource Saturation**
+   - Run `kubectl top pods -n trading | grep risk-engine` to validate CPU and memory headroom.
+   - Inspect pod events for OOM kills or restarts.
+
+## Mitigation
+- Temporarily raise the risk service concurrency limit using feature flags.
+- Engage the database team if queries are throttled.
+- Fail over to the backup region if dependency degradation is regional.
+
+## Post-Incident
+- File an incident review summarising root cause and remediation.
+- Update runbook steps if new mitigations were required.

--- a/ops/monitoring/prometheus-rules.yaml
+++ b/ops/monitoring/prometheus-rules.yaml
@@ -62,3 +62,44 @@ spec:
             summary: Consecutive canary promotions exceeding 30 minute alert threshold
             runbook: docs/runbooks/model_rollback.md
             slo_reference: docs/slo.md#model-canary-promotion
+    - name: trade-latency.slo
+      rules:
+        - alert: policy_latency_p95_slo_breach
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(policy_latency_ms_bucket[5m])) by (le, symbol, account_id)
+            ) > 200
+          for: 10m
+          labels:
+            severity: warning
+            slo_target: "p95<=200ms"
+          annotations:
+            summary: Policy evaluation latency p95 above 200 ms for {{ $labels.symbol }}/{{ $labels.account_id }}
+            runbook: docs/runbooks/policy_latency.md
+            slo_reference: docs/slo.md#policy-latency
+        - alert: risk_latency_p95_slo_breach
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(risk_latency_ms_bucket[5m])) by (le, symbol, account_id)
+            ) > 200
+          for: 10m
+          labels:
+            severity: warning
+            slo_target: "p95<=200ms"
+          annotations:
+            summary: Risk validation latency p95 above 200 ms for {{ $labels.symbol }}/{{ $labels.account_id }}
+            runbook: docs/runbooks/risk_latency.md
+            slo_reference: docs/slo.md#risk-latency
+        - alert: oms_latency_p95_slo_breach
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(oms_latency_ms_bucket[5m])) by (le, symbol, account_id)
+            ) > 500
+          for: 10m
+          labels:
+            severity: critical
+            slo_target: "p95<=500ms"
+          annotations:
+            summary: OMS submission latency p95 above 500 ms for {{ $labels.symbol }}/{{ $labels.account_id }}
+            runbook: docs/runbooks/oms_latency.md
+            slo_reference: docs/slo.md#oms-latency

--- a/ops/observability/grafana/latency-overview-dashboard.json
+++ b/ops/observability/grafana/latency-overview-dashboard.json
@@ -1,0 +1,261 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1700000000000,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "policy p50 {{symbol}}/{{account_id}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "policy p95 {{symbol}}/{{account_id}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "policy p99 {{symbol}}/{{account_id}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Policy Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "risk p50 {{symbol}}/{{account_id}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "risk p95 {{symbol}}/{{account_id}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "risk p99 {{symbol}}/{{account_id}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Risk Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "oms p50 {{symbol}}/{{account_id}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "oms p95 {{symbol}}/{{account_id}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
+          "legendFormat": "oms p99 {{symbol}}/{{account_id}}",
+          "refId": "C"
+        }
+      ],
+      "title": "OMS Latency Percentiles",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "latency",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Trading Latency Percentiles",
+  "uid": "trading-latency",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/observability/latency_metrics.py
+++ b/ops/observability/latency_metrics.py
@@ -83,9 +83,9 @@ class LatencyMetrics:
     """Collect latency metrics for trading services."""
 
     _HISTOGRAM_SPECS = {
-        "policy_latency": 200.0,
-        "risk_latency": 200.0,
-        "oms_latency": 500.0,
+        "policy_latency_ms": 200.0,
+        "risk_latency_ms": 200.0,
+        "oms_latency_ms": 500.0,
     }
 
     _BUCKETS = (5, 10, 25, 50, 100, 200, 300, 500, 750, 1000, float("inf"))


### PR DESCRIPTION
## Summary
- expose policy, risk, and OMS latency histograms with rolling p95 alert tracking
- provision Prometheus SLO alerts and runbooks for latency regressions
- add Grafana dashboard for latency percentile visibility

## Testing
- python -m compileall ops/observability/latency_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68de3da6c1008321a5d98cb197a58329