### PR TITLE
Enhance audit chain verification and CLI options

### DIFF
--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -160,6 +160,64 @@ def test_verify_audit_chain(tmp_path, monkeypatch, capsys):
     assert "Audit chain verified successfully." in out
 
 
+def test_verify_audit_chain_detects_state_tampering(tmp_path, monkeypatch, capsys):
+    hashed_ip = audit_logger.hash_ip("203.0.113.9")
+    chain_log = tmp_path / "chain.log"
+    chain_state = tmp_path / "chain_state.json"
+    monkeypatch.setenv("AUDIT_DATABASE_URL", "postgresql://audit:audit@localhost:5432/audit")
+    monkeypatch.setenv("AUDIT_CHAIN_LOG", str(chain_log))
+    monkeypatch.setenv("AUDIT_CHAIN_STATE", str(chain_state))
+
+    conn, cursor = _make_connection_mock()
+    monkeypatch.setattr(audit_logger, "psycopg", MagicMock(connect=MagicMock(return_value=conn)))
+
+    audit_logger.log_audit(
+        actor="erin",
+        action="update",
+        entity="record",
+        before={},
+        after={"status": "done"},
+        ip_hash=hashed_ip,
+    )
+
+    capsys.readouterr()
+
+    # tamper with the state file by resetting the stored hash to genesis
+    chain_state.write_text(json.dumps({"last_hash": audit_logger._GENESIS_HASH}))  # pylint: disable=protected-access
+
+    assert audit_logger.verify_audit_chain() is False
+    out = capsys.readouterr().out
+    assert "State hash mismatch" in out
+
+
+def test_cli_verify_command(tmp_path, monkeypatch, capsys):
+    chain_log = tmp_path / "cli_chain.log"
+    chain_state = tmp_path / "cli_state.json"
+    monkeypatch.setenv("AUDIT_DATABASE_URL", "postgresql://audit:audit@localhost:5432/audit")
+    monkeypatch.setenv("AUDIT_CHAIN_LOG", str(chain_log))
+    monkeypatch.setenv("AUDIT_CHAIN_STATE", str(chain_state))
+
+    conn, cursor = _make_connection_mock()
+    monkeypatch.setattr(audit_logger, "psycopg", MagicMock(connect=MagicMock(return_value=conn)))
+
+    audit_logger.log_audit(
+        actor="ivy",
+        action="create",
+        entity="ticket",
+        before={},
+        after={"status": "open"},
+        ip_hash=None,
+    )
+
+    capsys.readouterr()
+
+    exit_code = audit_logger.main(["verify", "--log", str(chain_log), "--state", str(chain_state)])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "Audit chain verified successfully." in out
+
+
 def test_sensitive_action_flag(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("AUDIT_DATABASE_URL", "postgresql://audit:audit@localhost:5432/audit")
     monkeypatch.setenv("AUDIT_CHAIN_LOG", str(tmp_path / "chain.log"))


### PR DESCRIPTION
## Summary
- ensure audit chain verification cross-checks the stored state hash and accept optional log/state paths
- expose --log/--state options in the audit logger CLI verify command
- add regression tests for tampered state detection and CLI verification workflow

## Testing
- pytest tests/test_audit_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68de433c3a5083218f39ce0fd2ecbf4a