### PR TITLE
feat: auto-refresh director controls dashboard

### DIFF
--- a/frontend/components/DirectorControls.tsx
+++ b/frontend/components/DirectorControls.tsx
@@ -357,6 +357,17 @@ const DirectorControls: React.FC = () => {
     };
   }, [loadTradingPairs]);
 
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      void refreshSafeModeStatus();
+      void refreshAuditTrail();
+    }, 30_000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [refreshAuditTrail, refreshSafeModeStatus]);
+
   const handleSafeMode = async (action: "enter" | "exit") => {
     setSafeModeActionError(null);
     setSafeModeMessage(null);


### PR DESCRIPTION
## Summary
- add a 30-second polling interval for safe mode status and director actions in DirectorControls
- ensure the auto-refresh cleans up its timer when the component unmounts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de437fab50832182474f398fa08089