### PR TITLE
Enhance backup manifest metadata

### DIFF
--- a/ops/backup/backup_job.py
+++ b/ops/backup/backup_job.py
@@ -255,7 +255,12 @@ class BackupJob:
 
         except Exception as exc:  # noqa: BLE001 - log & rethrow
             LOGGER.exception("Backup %s failed", manifest_id)
-            self._log_backup(manifest_id, timestamp, "FAILED")
+            failure_manifest = {
+                "manifest_id": manifest_id,
+                "timestamp": timestamp,
+                "error": str(exc),
+            }
+            self._log_backup(manifest_id, timestamp, "FAILED", failure_manifest)
             raise exc
 
     def restore_backup(self, manifest_id: str) -> None:
@@ -368,6 +373,11 @@ class BackupJob:
             "manifest_id": manifest_id,
             "timestamp": timestamp,
             "artifacts": [artifact.to_dict() for artifact in artifacts],
+            "config": {
+                "bucket": self.config.bucket_name,
+                "bucket_prefix": self.config.bucket_prefix,
+                "retention_days": self.config.retention_days,
+            },
         }
         manifest["hash"] = self._hash_manifest(manifest["artifacts"])
 


### PR DESCRIPTION
## Summary
- record backup configuration metadata in generated manifests so restores capture bucket context
- log structured failure details to `backup_log` when a backup run raises an exception

## Testing
- python -m compileall ops/backup/backup_job.py

------
https://chatgpt.com/codex/tasks/task_e_68de439d48dc8321bd39e38e54bb7fa8