### PR TITLE
Implement graceful shutdown workflow for control plane services

### DIFF
--- a/ops/deploy/graceful_shutdown.py
+++ b/ops/deploy/graceful_shutdown.py
@@ -1,0 +1,210 @@
+"""Graceful shutdown orchestrator for trading control plane services.
+
+Rolling upgrade steps:
+1. Trigger a drain on the *policy* service (either via this CLI or the
+   Kubernetes ``preStop`` hook which should ``POST /ops/drain/start``).
+2. Wait until ``/ops/drain/status`` reports ``inflight=0`` so that no new
+   intents are accepted and buffered events are flushed.
+3. Roll the deployment for the drained service (for example with
+   ``kubectl rollout restart deployment/policy``) and wait for the new pod to
+   become Ready.
+4. Repeat the process for the *risk* service and finally the *oms* service to
+   avoid sending partially validated orders downstream.
+5. Once all services have been restarted, re-enable traffic (service mesh
+   routes, ingress, etc.) and optionally run this CLI with ``--dry-run`` to
+   verify that all drain endpoints are reachable.
+
+The CLI in this module provides a simple automation for the manual steps above
+so operators can coordinate drains across services from a single command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from typing import Dict, Iterable, List, Mapping
+
+import httpx
+
+
+DEFAULT_SERVICE_ORDER = ["policy", "risk", "oms"]
+SERVICE_ENV_VARS: Mapping[str, Iterable[str]] = {
+    "policy": (
+        "POLICY_DRAIN_URL",
+        "POLICY_SERVICE_BASE_URL",
+        "POLICY_SERVICE_URL",
+    ),
+    "risk": (
+        "RISK_DRAIN_URL",
+        "RISK_SERVICE_BASE_URL",
+        "RISK_SERVICE_URL",
+    ),
+    "oms": (
+        "OMS_DRAIN_URL",
+        "OMS_SERVICE_BASE_URL",
+        "OMS_SERVICE_URL",
+    ),
+}
+SERVICE_DEFAULTS: Mapping[str, str] = {
+    "policy": "http://policy-service",
+    "risk": "http://risk-service",
+    "oms": "http://oms-service",
+}
+
+
+logger = logging.getLogger("ops.graceful_shutdown")
+
+
+def _parse_overrides(pairs: List[str] | None) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    if not pairs:
+        return overrides
+    for item in pairs:
+        if "=" not in item:
+            raise ValueError(f"Invalid override '{item}', expected name=url")
+        name, url = item.split("=", 1)
+        name = name.strip().lower()
+        if not name:
+            raise ValueError(f"Invalid override '{item}', missing service name")
+        overrides[name] = url.strip()
+    return overrides
+
+
+def _resolve_base_url(service: str, overrides: Mapping[str, str]) -> str:
+    override = overrides.get(service)
+    if override:
+        return override.rstrip("/")
+    for env_key in SERVICE_ENV_VARS.get(service, ()):  # type: ignore[arg-type]
+        value = os.getenv(env_key)
+        if value:
+            return value.rstrip("/")
+    return SERVICE_DEFAULTS.get(service, f"http://{service}").rstrip("/")
+
+
+def _drain_service(
+    client: httpx.Client,
+    service: str,
+    base_url: str,
+    timeout: float,
+    poll_interval: float,
+    *,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    start_endpoint = f"{base_url}/ops/drain/start"
+    status_endpoint = f"{base_url}/ops/drain/status"
+    if dry_run:
+        logger.info("[dry-run] would drain %s via %s", service, start_endpoint)
+        return {"service": service, "dry_run": True}
+
+    logger.info("Triggering drain for %s via %s", service, start_endpoint)
+    response = client.post(start_endpoint)
+    response.raise_for_status()
+
+    deadline = time.monotonic() + timeout
+    while True:
+        status_response = client.get(status_endpoint)
+        status_response.raise_for_status()
+        payload = status_response.json()
+        inflight = int(payload.get("inflight", 0))
+        draining = bool(payload.get("draining", False))
+        logger.debug(
+            "Drain status for %s: inflight=%s draining=%s", service, inflight, draining
+        )
+        if draining and inflight == 0:
+            logger.info("Drain complete for %s", service)
+            return payload
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Timed out waiting for {service} to finish draining (last={payload})"
+            )
+        time.sleep(poll_interval)
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "services",
+        nargs="*",
+        default=DEFAULT_SERVICE_ORDER,
+        help="Ordered list of services to drain (default: policy risk oms)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.getenv("GRACEFUL_DRAIN_TIMEOUT", "180.0")),
+        help="Seconds to wait for each service to finish draining",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=1.0,
+        help="Seconds between drain status polls",
+    )
+    parser.add_argument(
+        "--base-url",
+        action="append",
+        help="Override service endpoint mapping, e.g. policy=http://localhost:8000",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log the drain sequence without issuing HTTP requests",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging for drain polling",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_argument_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    try:
+        overrides = _parse_overrides(args.base_url)
+    except ValueError as exc:  # pragma: no cover - argument parsing guard
+        parser.error(str(exc))
+        return 2
+
+    services = [service.lower() for service in (args.services or DEFAULT_SERVICE_ORDER)]
+
+    timeout = max(args.timeout, 1.0)
+    poll_interval = max(args.poll_interval, 0.1)
+
+    if args.dry_run:
+        logger.warning("Running in dry-run mode; no HTTP requests will be performed")
+
+    with httpx.Client(timeout=timeout) as client:
+        for service in services:
+            base_url = _resolve_base_url(service, overrides)
+            try:
+                _drain_service(
+                    client,
+                    service,
+                    base_url,
+                    timeout,
+                    poll_interval,
+                    dry_run=args.dry_run,
+                )
+            except httpx.HTTPError as exc:
+                logger.error("HTTP error while draining %s: %s", service, exc)
+                return 1
+            except RuntimeError as exc:
+                logger.error("Drain failed for %s: %s", service, exc)
+                return 1
+    logger.info("Drain sequence completed successfully")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    sys.exit(main())

--- a/shared/graceful_shutdown.py
+++ b/shared/graceful_shutdown.py
@@ -1,0 +1,251 @@
+"""Utilities for coordinating graceful shutdown behaviour across services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+import threading
+import time
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Callable, Iterable, List, Optional, Set
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from starlette import status as http_status
+
+
+logger = logging.getLogger(__name__)
+
+FlushCallback = Callable[[], None]
+
+
+def _normalise_path(path: str) -> str:
+    """Return a canonical representation for FastAPI request paths."""
+
+    if not path:
+        return "/"
+    clean = path.split("?", 1)[0]
+    if clean != "/" and clean.endswith("/"):
+        clean = clean.rstrip("/")
+    return clean or "/"
+
+
+class GracefulShutdownManager:
+    """Tracks draining state and coordinates graceful shutdown hooks."""
+
+    def __init__(
+        self,
+        service_name: str,
+        *,
+        allowed_paths: Optional[Iterable[str]] = None,
+        shutdown_timeout: float = 45.0,
+    ) -> None:
+        self.service_name = service_name
+        self._condition = threading.Condition()
+        self._draining = False
+        self._inflight = 0
+        self._drain_started_at: Optional[datetime] = None
+        self._shutdown_timeout = max(shutdown_timeout, 0.0)
+        self._allowed_paths: Set[str] = {
+            "/ops/drain/start",
+            "/ops/drain/status",
+            "/metrics",
+            "/health",
+            "/livez",
+            "/readyz",
+        }
+        if allowed_paths:
+            for path in allowed_paths:
+                self.allow_path(path)
+        self._flush_callbacks: List[FlushCallback] = []
+
+    @property
+    def draining(self) -> bool:
+        with self._condition:
+            return self._draining
+
+    @property
+    def inflight(self) -> int:
+        with self._condition:
+            return self._inflight
+
+    @property
+    def shutdown_timeout(self) -> float:
+        return self._shutdown_timeout
+
+    def allow_path(self, path: str) -> None:
+        self._allowed_paths.add(_normalise_path(path))
+
+    def is_path_allowed(self, path: str) -> bool:
+        return _normalise_path(path) in self._allowed_paths
+
+    def register_flush_callback(self, callback: FlushCallback) -> None:
+        self._flush_callbacks.append(callback)
+
+    def increment_inflight(self) -> None:
+        with self._condition:
+            self._inflight += 1
+
+    def decrement_inflight(self) -> None:
+        with self._condition:
+            if self._inflight > 0:
+                self._inflight -= 1
+            else:  # pragma: no cover - defensive guard
+                self._inflight = 0
+            if self._inflight == 0:
+                self._condition.notify_all()
+
+    def start_draining(self, *, reason: str = "manual") -> bool:
+        callbacks: List[FlushCallback] = []
+        with self._condition:
+            if self._draining:
+                started = False
+            else:
+                started = True
+                self._draining = True
+                self._drain_started_at = datetime.now(timezone.utc)
+                callbacks = list(self._flush_callbacks)
+        if callbacks:
+            logger.info("Initiating drain for service %s (reason=%s)", self.service_name, reason)
+        for callback in callbacks:
+            with suppress(Exception):
+                callback()
+        return started
+
+    def wait_for_inflight(self, timeout: Optional[float] = None) -> bool:
+        deadline = None if timeout is None else time.monotonic() + max(timeout, 0.0)
+        with self._condition:
+            while self._inflight > 0:
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return False
+                else:
+                    remaining = None
+                self._condition.wait(timeout=remaining)
+        return True
+
+    async def wait_for_inflight_async(self, timeout: Optional[float] = None) -> bool:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.wait_for_inflight, timeout)
+
+    def status(self) -> dict:
+        with self._condition:
+            started_at = self._drain_started_at.isoformat() if self._drain_started_at else None
+            elapsed = None
+            if self._draining and self._drain_started_at is not None:
+                elapsed = (datetime.now(timezone.utc) - self._drain_started_at).total_seconds()
+            return {
+                "service": self.service_name,
+                "draining": self._draining,
+                "inflight": self._inflight,
+                "started_at": started_at,
+                "elapsed_seconds": elapsed,
+                "allowed_paths": sorted(self._allowed_paths),
+            }
+
+
+def flush_logging_handlers(*logger_names: str) -> None:
+    """Flush handlers for the provided loggers (including the root logger)."""
+
+    if not logger_names:
+        logger_names = ("",)
+    seen_handlers: Set[int] = set()
+    for name in logger_names:
+        log = logging.getLogger(name)
+        for handler in log.handlers:
+            handler_id = id(handler)
+            if handler_id in seen_handlers:
+                continue
+            seen_handlers.add(handler_id)
+            with suppress(Exception):
+                handler.flush()
+
+
+def install_sigterm_handler(manager: GracefulShutdownManager) -> None:
+    """Register a SIGTERM handler that triggers draining before exit."""
+
+    original = signal.getsignal(signal.SIGTERM)
+
+    def _handle(signum, frame) -> None:  # pragma: no cover - signal path is hard to unit test
+        logger.info("SIGTERM received for %s; initiating drain", manager.service_name)
+        manager.start_draining(reason="sigterm")
+        completed = manager.wait_for_inflight(manager.shutdown_timeout)
+        if not completed:
+            logger.warning(
+                "Timed out waiting for in-flight requests during SIGTERM for %s",
+                manager.service_name,
+            )
+        if callable(original) and original is not _handle:
+            original(signum, frame)
+        elif original in {signal.SIG_DFL, None}:
+            sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _handle)
+
+
+def setup_graceful_shutdown(
+    app: FastAPI,
+    *,
+    service_name: str,
+    allowed_paths: Optional[Iterable[str]] = None,
+    shutdown_timeout: float = 45.0,
+    logger_instance: Optional[logging.Logger] = None,
+) -> GracefulShutdownManager:
+    """Configure graceful shutdown middleware, endpoints, and signal handling."""
+
+    manager = GracefulShutdownManager(
+        service_name,
+        allowed_paths=allowed_paths,
+        shutdown_timeout=shutdown_timeout,
+    )
+
+    if allowed_paths:
+        for path in allowed_paths:
+            manager.allow_path(path)
+    manager.allow_path("/ops/drain/start")
+    manager.allow_path("/ops/drain/status")
+
+    service_logger = logger_instance or logger
+
+    @app.middleware("http")
+    async def _drain_guard(request: Request, call_next):
+        if manager.draining and not manager.is_path_allowed(request.url.path):
+            detail = {
+                "detail": f"{service_name} is draining",
+                "status": manager.status(),
+            }
+            return JSONResponse(detail, status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE)
+        manager.increment_inflight()
+        try:
+            response = await call_next(request)
+        finally:
+            manager.decrement_inflight()
+        return response
+
+    @app.post("/ops/drain/start", tags=["ops"])
+    async def start_drain(response: Response):
+        started = manager.start_draining(reason="api")
+        response.status_code = (
+            http_status.HTTP_202_ACCEPTED if started else http_status.HTTP_200_OK
+        )
+        service_logger.info("Drain request acknowledged", extra={"draining": manager.draining})
+        return manager.status()
+
+    @app.get("/ops/drain/status", tags=["ops"])
+    async def drain_status():
+        return manager.status()
+
+    @app.on_event("startup")
+    async def _on_startup() -> None:
+        install_sigterm_handler(manager)
+
+    @app.on_event("shutdown")
+    async def _on_shutdown() -> None:
+        manager.start_draining(reason="shutdown_event")
+        await manager.wait_for_inflight_async(timeout=manager.shutdown_timeout)
+
+    return manager


### PR DESCRIPTION
## Summary
- add a shared graceful shutdown manager that provides drain middleware, signal handling, and status endpoints
- wire the policy, risk, and OMS services to expose /ops/drain APIs, reject new traffic while draining, and flush buffered events
- add adapter flush helpers plus an ops CLI documenting the rolling upgrade steps for orchestrating drains across services

## Testing
- python -m compileall shared/graceful_shutdown.py policy_service.py risk_service.py oms_service.py ops/deploy/graceful_shutdown.py

------
https://chatgpt.com/codex/tasks/task_e_68de467e17c48321a316489bb23a502b