### PR TITLE
Add alert deduplication service with suppression policies

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from accounts.service import AccountsService
 from auth.routes import get_auth_service, router as auth_router
 from auth.service import AdminRepository, AuthService, SessionStore
 from services.alert_manager import setup_alerting
+from services.alerts.alert_dedupe import router as alert_dedupe_router, setup_alert_dedupe
 from alert_prioritizer import router as alert_prioritizer_router
 from services.report_service import router as reports_router
 from multiformat_export import router as log_export_router
@@ -47,6 +48,7 @@ def create_app() -> FastAPI:
     app.include_router(reports_router)
     app.include_router(exposure_router)
     app.include_router(alert_prioritizer_router)
+    app.include_router(alert_dedupe_router)
 
     app.include_router(models_router)
 
@@ -81,6 +83,7 @@ def create_app() -> FastAPI:
 
     alertmanager_url = os.getenv("ALERTMANAGER_URL")
     setup_alerting(app, alertmanager_url=alertmanager_url)
+    setup_alert_dedupe(app, alertmanager_url=alertmanager_url)
 
     return app
 

--- a/services/alerts/__init__.py
+++ b/services/alerts/__init__.py
@@ -1,0 +1,21 @@
+"""Alert service package providing deduplication utilities."""
+
+from .alert_dedupe import (
+    AlertDedupeMetrics,
+    AlertDedupeService,
+    AlertPolicy,
+    configure_alert_dedupe_service,
+    get_alert_dedupe_service,
+    router,
+    setup_alert_dedupe,
+)
+
+__all__ = [
+    "AlertDedupeMetrics",
+    "AlertDedupeService",
+    "AlertPolicy",
+    "configure_alert_dedupe_service",
+    "get_alert_dedupe_service",
+    "router",
+    "setup_alert_dedupe",
+]

--- a/services/alerts/alert_dedupe.py
+++ b/services/alerts/alert_dedupe.py
@@ -1,0 +1,379 @@
+"""Alert deduplication service coordinating Alertmanager ingestion."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - fastapi is optional for unit tests
+    from fastapi import APIRouter, Depends, FastAPI, HTTPException
+except ModuleNotFoundError:  # pragma: no cover - fallback stub for tests
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class _RouterStub:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.routes: list[tuple[str, Any, Any]] = []
+
+        def get(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+                self.routes.append(("GET", args[0] if args else None, func))
+                return func
+
+            return decorator
+
+    def Depends(dependency: Callable[..., Any]) -> Callable[..., Any]:
+        return dependency
+
+    class FastAPI:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.state = type("State", (), {})()
+
+        def on_event(self, *_: Any, **__: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+                return func
+
+            return decorator
+
+        def include_router(self, *_: Any, **__: Any) -> None:
+            return None
+
+    APIRouter = _RouterStub  # type: ignore[assignment]
+
+from prometheus_client import CollectorRegistry, Counter
+
+if TYPE_CHECKING:
+    import httpx
+
+_DEFAULT_ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093")
+_ALERT_ENDPOINT = "/api/v2/alerts"
+
+router = APIRouter(prefix="/alerts", tags=["alerts"])
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AlertPolicy:
+    """Configuration for deduplication behaviour."""
+
+    suppression_window: timedelta = timedelta(minutes=10)
+    escalation_threshold: int = 3
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "suppression_window_seconds": int(self.suppression_window.total_seconds()),
+            "escalation_threshold": self.escalation_threshold,
+        }
+
+
+@dataclass
+class AlertGroupState:
+    """Tracks the lifecycle of a grouped alert."""
+
+    service: str
+    alert_type: str
+    symbol: str
+    severity: str
+    first_seen: datetime
+    last_seen: datetime
+    count: int = 1
+    escalated: bool = False
+    alert_ids: set[str] = field(default_factory=set)
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "service": self.service,
+            "alert_type": self.alert_type,
+            "symbol": self.symbol,
+            "severity": "high" if self.escalated else self.severity,
+            "first_seen": self.first_seen.isoformat(),
+            "last_seen": self.last_seen.isoformat(),
+            "count": self.count,
+            "suppressed": max(self.count - 1, 0),
+            "escalated": self.escalated,
+        }
+
+
+class AlertDedupeMetrics:
+    """Prometheus counters exposed by the dedupe service."""
+
+    def __init__(self, registry: Optional[CollectorRegistry] = None) -> None:
+        metric_kwargs = {"registry": registry} if registry is not None else {}
+        self.registry = registry
+        self.alerts_suppressed_total = Counter(
+            "aether_alerts_suppressed_total",
+            "Total number of alerts suppressed within the suppression window.",
+            ("service", "alert_type", "symbol"),
+            **metric_kwargs,
+        )
+        self.alerts_escalated_total = Counter(
+            "aether_alerts_escalated_total",
+            "Total number of alert groups escalated due to repeated occurrences.",
+            ("service", "alert_type", "symbol"),
+            **metric_kwargs,
+        )
+
+
+FetchCallable = Callable[[], Awaitable[Sequence[Mapping[str, Any]]]] | Callable[[], Sequence[Mapping[str, Any]]]
+
+
+class AlertDedupeService:
+    """Ingests alerts from Alertmanager and applies deduplication policies."""
+
+    def __init__(
+        self,
+        *,
+        alertmanager_url: str = _DEFAULT_ALERTMANAGER_URL,
+        policy: Optional[AlertPolicy] = None,
+        metrics: Optional[AlertDedupeMetrics] = None,
+        fetcher: Optional[FetchCallable] = None,
+    ) -> None:
+        self.alertmanager_url = alertmanager_url.rstrip("/")
+        self.policy = policy or AlertPolicy()
+        self.metrics = metrics or AlertDedupeMetrics()
+        self._fetcher = fetcher
+        self._client: Optional["httpx.AsyncClient"] = None
+        self._group_states: Dict[Tuple[str, str, str], AlertGroupState] = {}
+        self._alert_index: Dict[str, Tuple[str, str, str]] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+    async def _get_client(self):
+        try:
+            import httpx
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("httpx is required to fetch alerts from Alertmanager") from exc
+
+        if self._client is None:
+            self._client = httpx.AsyncClient()
+        return self._client
+
+    async def _default_fetch(self) -> Sequence[Mapping[str, Any]]:
+        client = await self._get_client()
+        url = f"{self.alertmanager_url}{_ALERT_ENDPOINT}"
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=502, detail=f"Failed to fetch alerts: {exc}") from exc
+
+        try:
+            payload = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=502, detail="Invalid alert payload from Alertmanager") from exc
+
+        if not isinstance(payload, list):
+            raise HTTPException(status_code=502, detail="Unexpected alert payload structure")
+
+        return payload
+
+    async def _fetch_alerts(self) -> Sequence[Mapping[str, Any]]:
+        if self._fetcher is None:
+            return await self._default_fetch()
+
+        result = self._fetcher()
+        if inspect.isawaitable(result):
+            result = await result  # type: ignore[assignment]
+        return list(result)
+
+    # ------------------------------------------------------------------
+    # Alert ingestion
+    # ------------------------------------------------------------------
+    async def refresh(self) -> List[Dict[str, Any]]:
+        """Fetch latest alerts from Alertmanager and update state."""
+
+        async with self._lock:
+            payload = await self._fetch_alerts()
+            self.ingest_alerts(payload)
+            return self.active_alerts()
+
+    def ingest_alerts(self, alerts: Iterable[Mapping[str, Any]]) -> None:
+        """Update internal state with the provided active alerts."""
+
+        new_active_ids: set[str] = set()
+        for alert in alerts:
+            alert_id = self._alert_identifier(alert)
+            new_active_ids.add(alert_id)
+            self._process_alert(alert_id, alert)
+
+        expired = set(self._alert_index) - new_active_ids
+        for alert_id in expired:
+            key = self._alert_index.pop(alert_id)
+            state = self._group_states.get(key)
+            if state:
+                state.alert_ids.discard(alert_id)
+                if not state.alert_ids:
+                    del self._group_states[key]
+
+    def active_alerts(self) -> List[Dict[str, Any]]:
+        """Return the currently active, deduplicated alerts."""
+
+        return [state.to_payload() for state in self._group_states.values()]
+
+    def policies(self) -> Dict[str, Any]:
+        return self.policy.as_dict()
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _process_alert(self, alert_id: str, alert: Mapping[str, Any]) -> None:
+        key = self._group_key(alert)
+        timestamp = self._alert_timestamp(alert)
+        severity = self._alert_severity(alert)
+        state = self._group_states.get(key)
+
+        if alert_id in self._alert_index:
+            # Already accounted for; refresh timestamps
+            if state:
+                state.last_seen = max(state.last_seen, timestamp)
+                state.alert_ids.add(alert_id)
+            return
+
+        if state is None:
+            state = AlertGroupState(
+                service=key[0],
+                alert_type=key[1],
+                symbol=key[2],
+                severity=severity,
+                first_seen=timestamp,
+                last_seen=timestamp,
+            )
+            self._group_states[key] = state
+        else:
+            delta = timestamp - state.last_seen
+            if delta <= self.policy.suppression_window:
+                state.count += 1
+                state.last_seen = max(state.last_seen, timestamp)
+                self.metrics.alerts_suppressed_total.labels(
+                    service=key[0], alert_type=key[1], symbol=key[2]
+                ).inc()
+            else:
+                state.count = 1
+                state.first_seen = timestamp
+                state.last_seen = timestamp
+                state.escalated = False
+                state.severity = severity
+
+        state.alert_ids.add(alert_id)
+        self._alert_index[alert_id] = key
+
+        if state.count >= self.policy.escalation_threshold and not state.escalated:
+            state.escalated = True
+            self.metrics.alerts_escalated_total.labels(
+                service=key[0], alert_type=key[1], symbol=key[2]
+            ).inc()
+
+    def _group_key(self, alert: Mapping[str, Any]) -> Tuple[str, str, str]:
+        labels = alert.get("labels", {})
+        service = str(labels.get("service", "unknown"))
+        alert_type = str(labels.get("alert_type", labels.get("alertname", "generic")))
+        symbol = str(labels.get("symbol", "*"))
+        return service, alert_type, symbol
+
+    def _alert_identifier(self, alert: Mapping[str, Any]) -> str:
+        fingerprint = alert.get("fingerprint")
+        if fingerprint:
+            return str(fingerprint)
+        labels = alert.get("labels", {})
+        if isinstance(labels, Mapping):
+            ordered = sorted(labels.items())
+            return json.dumps(ordered, sort_keys=True)
+        return json.dumps(alert, sort_keys=True)
+
+    def _alert_timestamp(self, alert: Mapping[str, Any]) -> datetime:
+        starts_at = alert.get("startsAt") or alert.get("starts_at")
+        if isinstance(starts_at, str):
+            try:
+                return datetime.fromisoformat(starts_at.replace("Z", "+00:00"))
+            except ValueError:  # pragma: no cover - defensive guard
+                pass
+        return datetime.now(timezone.utc)
+
+    def _alert_severity(self, alert: Mapping[str, Any]) -> str:
+        labels = alert.get("labels", {})
+        severity = labels.get("severity")
+        return str(severity) if severity else "warning"
+
+
+# ---------------------------------------------------------------------------
+# Dependency wiring for FastAPI
+# ---------------------------------------------------------------------------
+
+_service_lock = threading.Lock()
+_service: Optional[AlertDedupeService] = None
+
+
+def configure_alert_dedupe_service(service: Optional[AlertDedupeService]) -> None:
+    global _service
+    with _service_lock:
+        _service = service
+
+
+def get_alert_dedupe_service() -> AlertDedupeService:
+    with _service_lock:
+        if _service is None:
+            configure_alert_dedupe_service(AlertDedupeService())
+        assert _service is not None  # for type checkers
+        return _service
+
+
+@router.get("/active")
+async def get_active_alerts(service: AlertDedupeService = Depends(get_alert_dedupe_service)) -> List[Dict[str, Any]]:
+    return await service.refresh()
+
+
+@router.get("/policies")
+def get_alert_policies(service: AlertDedupeService = Depends(get_alert_dedupe_service)) -> Dict[str, Any]:
+    return service.policies()
+
+
+def setup_alert_dedupe(app, alertmanager_url: Optional[str] = None) -> None:
+    """Bind lifecycle hooks for the dedupe service on a FastAPI app."""
+
+    if not isinstance(app, FastAPI):  # pragma: no cover - defensive guard
+        raise TypeError("setup_alert_dedupe expects a FastAPI application")
+
+    @app.on_event("startup")
+    async def _configure_dedupe() -> None:  # pragma: no cover - FastAPI lifecycle
+        service = AlertDedupeService(alertmanager_url=alertmanager_url or _DEFAULT_ALERTMANAGER_URL)
+        configure_alert_dedupe_service(service)
+        app.state.alert_dedupe_service = service
+
+    @app.on_event("shutdown")
+    async def _shutdown_dedupe() -> None:  # pragma: no cover - FastAPI lifecycle
+        service = get_alert_dedupe_service()
+        await service.aclose()
+        configure_alert_dedupe_service(None)
+        if hasattr(app.state, "alert_dedupe_service"):
+            delattr(app.state, "alert_dedupe_service")
+
+
+__all__ = [
+    "AlertDedupeMetrics",
+    "AlertDedupeService",
+    "AlertPolicy",
+    "configure_alert_dedupe_service",
+    "get_alert_dedupe_service",
+    "router",
+    "setup_alert_dedupe",
+]

--- a/tests/services/alerts/test_alert_dedupe.py
+++ b/tests/services/alerts/test_alert_dedupe.py
@@ -1,0 +1,139 @@
+"""Tests for the alert deduplication service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from prometheus_client import CollectorRegistry
+
+from services.alerts.alert_dedupe import AlertDedupeMetrics, AlertDedupeService, AlertPolicy
+
+
+def _metric_value(metric: object) -> float:
+    value = getattr(metric, "_value", 0.0)
+    return value.get() if hasattr(value, "get") else float(value)
+
+
+def _build_alert(
+    *,
+    fingerprint: str,
+    service: str,
+    alert_type: str,
+    symbol: str,
+    severity: str,
+    timestamp: datetime,
+) -> dict[str, object]:
+    return {
+        "fingerprint": fingerprint,
+        "labels": {
+            "service": service,
+            "alert_type": alert_type,
+            "symbol": symbol,
+            "severity": severity,
+        },
+        "startsAt": timestamp.isoformat(),
+    }
+
+
+def test_alerts_grouped_and_suppressed_within_window() -> None:
+    registry = CollectorRegistry()
+    metrics = AlertDedupeMetrics(registry=registry)
+    policy = AlertPolicy(suppression_window=timedelta(minutes=10), escalation_threshold=5)
+    service = AlertDedupeService(policy=policy, metrics=metrics)
+
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    alert_one = _build_alert(
+        fingerprint="a1",
+        service="pricing",
+        alert_type="LatencyBreach",
+        symbol="BTC-USD",
+        severity="warning",
+        timestamp=base,
+    )
+    alert_two = _build_alert(
+        fingerprint="a2",
+        service="pricing",
+        alert_type="LatencyBreach",
+        symbol="BTC-USD",
+        severity="warning",
+        timestamp=base + timedelta(minutes=5),
+    )
+    alert_other_symbol = _build_alert(
+        fingerprint="b1",
+        service="pricing",
+        alert_type="LatencyBreach",
+        symbol="ETH-USD",
+        severity="warning",
+        timestamp=base + timedelta(minutes=6),
+    )
+
+    service.ingest_alerts([alert_one])
+    active = service.active_alerts()
+    assert len(active) == 1
+    assert active[0]["count"] == 1
+
+    service.ingest_alerts([alert_one, alert_two, alert_other_symbol])
+    active = sorted(service.active_alerts(), key=lambda item: item["symbol"])
+    assert len(active) == 2
+    btc_entry = next(item for item in active if item["symbol"] == "BTC-USD")
+    eth_entry = next(item for item in active if item["symbol"] == "ETH-USD")
+
+    assert btc_entry["count"] == 2
+    assert btc_entry["suppressed"] == 1
+    assert btc_entry["severity"] == "warning"
+    assert eth_entry["count"] == 1
+
+    suppressed_metric = _metric_value(
+        metrics.alerts_suppressed_total.labels(
+            service="pricing", alert_type="LatencyBreach", symbol="BTC-USD"
+        )
+    )
+    assert suppressed_metric == 1.0
+
+
+def test_alerts_escalate_after_threshold() -> None:
+    registry = CollectorRegistry()
+    metrics = AlertDedupeMetrics(registry=registry)
+    policy = AlertPolicy(suppression_window=timedelta(minutes=10), escalation_threshold=3)
+    service = AlertDedupeService(policy=policy, metrics=metrics)
+
+    base = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    alerts = [
+        _build_alert(
+            fingerprint=f"f{i}",
+            service="risk",
+            alert_type="FeeSpike",
+            symbol="UNI-USD",
+            severity="warning",
+            timestamp=base + timedelta(minutes=i * 2),
+        )
+        for i in range(3)
+    ]
+
+    service.ingest_alerts([alerts[0]])
+    service.ingest_alerts(alerts[:2])
+    service.ingest_alerts(alerts[:3])
+
+    active = service.active_alerts()
+    assert len(active) == 1
+    entry = active[0]
+    assert entry["count"] == 3
+    assert entry["severity"] == "high"
+    assert entry["escalated"] is True
+
+    suppressed_metric = _metric_value(
+        metrics.alerts_suppressed_total.labels(
+            service="risk", alert_type="FeeSpike", symbol="UNI-USD"
+        )
+    )
+    assert suppressed_metric == 2.0
+    escalated_metric = _metric_value(
+        metrics.alerts_escalated_total.labels(
+            service="risk", alert_type="FeeSpike", symbol="UNI-USD"
+        )
+    )
+    assert escalated_metric == 1.0
+
+    policies = service.policies()
+    assert policies["suppression_window_seconds"] == int(timedelta(minutes=10).total_seconds())
+    assert policies["escalation_threshold"] == 3


### PR DESCRIPTION
## Summary
- add an alert deduplication service that groups alerts, applies suppression, and escalates persistent issues
- expose /alerts/active and /alerts/policies endpoints on the FastAPI app and register lifecycle hooks
- provide metrics for suppressed and escalated alerts along with unit tests covering grouping and escalation

## Testing
- `pytest tests/services/alerts/test_alert_dedupe.py`


------
https://chatgpt.com/codex/tasks/task_e_68de472d3348832190feae872cd259bc