### PR TITLE
Add explicit scaling controller imports to app factory

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,11 @@ from alert_prioritizer import router as alert_prioritizer_router
 from services.report_service import router as reports_router
 from multiformat_export import router as log_export_router
 from compliance_pack import router as compliance_router
+from scaling_controller import (
+    build_scaling_controller_from_env,
+    configure_scaling_controller,
+    router as scaling_router,
+)
 
 from pack_exporter import router as knowledge_router
 


### PR DESCRIPTION
## Summary
- import the scaling controller utilities explicitly in app.py so the factory wiring uses named symbols

## Testing
- `pytest tests/test_auth.py::test_login_enforces_mfa_and_ip_allow_list` *(fails: ModuleNotFoundError: No module named 'pyotp')*

------
https://chatgpt.com/codex/tasks/task_e_68de51572ec48321867bed16c3d629eb