### PR TITLE
Add Kubernetes secret for secrets-service encryption key

### DIFF
--- a/deploy/k8s/base/aether-services/deployment-secrets.yaml
+++ b/deploy/k8s/base/aether-services/deployment-secrets.yaml
@@ -43,6 +43,11 @@ spec:
               value: /var/run/secrets/kraken/director-1/credentials.json
             - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
               value: /var/run/secrets/kraken/director-2/credentials.json
+            - name: SECRET_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: secrets-service-config
+                  key: SECRET_ENCRYPTION_KEY
           readinessProbe:
             httpGet:
               path: /metrics

--- a/deploy/k8s/base/aether-services/kustomization.yaml
+++ b/deploy/k8s/base/aether-services/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment-oms.yaml
   - deployment-fees.yaml
   - deployment-secrets.yaml
+  - secret-secrets-service-config.yaml
   - deployment-universe.yaml
   - service-policy.yaml
   - service-risk.yaml

--- a/deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
+++ b/deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secrets-service-config
+  labels:
+    app.kubernetes.io/name: secrets-service
+    app.kubernetes.io/component: api
+    app: secrets-service
+type: Opaque
+stringData:
+  SECRET_ENCRYPTION_KEY: REPLACE_WITH_BASE64_AES_KEY

--- a/deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
+++ b/deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
@@ -8,4 +8,5 @@ metadata:
     app: secrets-service
 type: Opaque
 stringData:
-  SECRET_ENCRYPTION_KEY: REPLACE_WITH_BASE64_AES_KEY
+  # Placeholder value for development clusters. Replace using the rotation runbook before production use.
+  SECRET_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/docs/runbooks/secrets-service-key-rotation.md
+++ b/docs/runbooks/secrets-service-key-rotation.md
@@ -1,0 +1,51 @@
+# Secrets Service Encryption Key Rotation
+
+## Purpose
+Provide a standardized procedure for rotating the AES encryption key that protects payloads managed by the Secrets Service.
+
+## Preconditions
+- Access to the Aether Kubernetes clusters (staging and production) with permissions to update Secrets and restart Deployments.
+- Access to the Git repository to update the declarative manifest `deploy/k8s/base/aether-services/secret-secrets-service-config.yaml`.
+- A secure workstation with OpenSSL (or equivalent tooling) for generating random keys.
+- Coordinated maintenance window approved by Security and Platform teams if production traffic will be impacted.
+
+## Generate a Replacement Key
+1. On a secure host, generate a 32-byte AES key and encode it with base64:
+   ```bash
+   openssl rand -base64 32 > /tmp/secrets-service.aes
+   ```
+2. Copy the value into a password manager entry for audit purposes.
+
+## Update the Kubernetes Secret
+1. Edit `deploy/k8s/base/aether-services/secret-secrets-service-config.yaml` and replace the placeholder with the new base64 value.
+2. Commit the change and open a pull request for review.
+3. After approval, deploy to staging:
+   ```bash
+   kubectl --context aether-staging apply -f deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
+   kubectl --context aether-staging rollout restart deployment/secrets-service
+   kubectl --context aether-staging rollout status deployment/secrets-service
+   ```
+4. Verify the service logs show successful startup and encryption operations.
+
+## Promote to Production
+1. Once staging validation passes, apply the manifest to production:
+   ```bash
+   kubectl --context aether-production apply -f deploy/k8s/base/aether-services/secret-secrets-service-config.yaml
+   kubectl --context aether-production rollout restart deployment/secrets-service
+   kubectl --context aether-production rollout status deployment/secrets-service
+   ```
+2. Confirm production logs and metrics (error rate, latency) remain healthy for 30 minutes.
+
+## Post-Rotation Validation
+- Run the integration suite focused on encryption/decryption (`pytest tests/integration/test_audit_chain.py -k encryption`).
+- Confirm dependent services can retrieve and decrypt secrets without errors.
+- Update the rotation record in the secrets ledger with timestamp, operator, and key fingerprint (hash the base64 value using SHA-256).
+
+## Rollback Plan
+- If issues occur, reapply the previous manifest from Git history and restart the deployment.
+- Notify stakeholders via #security-ops and #platform-alerts channels.
+- Conduct a post-incident review to determine root cause before attempting rotation again.
+
+## Automation Opportunities
+- Integrate this runbook into the CI pipeline so that a merged PR automatically updates the clusters via Argo CD sync.
+- Schedule quarterly reminders in the Security team calendar to ensure the key rotation cadence is maintained.


### PR DESCRIPTION
## Summary
- add a dedicated Secret manifest for the secrets-service AES encryption key and include it in kustomization
- source the SECRET_ENCRYPTION_KEY environment variable from the new Secret in the secrets-service deployment
- document the manual rotation procedure for the encryption key

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68de51741ec08321a53cfca1743c71c0