### PR TITLE
Include missing knowledge and meta routers in app factory

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,6 +56,10 @@ def create_app() -> FastAPI:
 
     app.include_router(compliance_router)
 
+    app.include_router(knowledge_router)
+
+    app.include_router(meta_router)
+
 
     scaling_controller = build_scaling_controller_from_env()
     configure_scaling_controller(scaling_controller)

--- a/tests/test_app_routing.py
+++ b/tests/test_app_routing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from app import create_app
+import pack_exporter
+
+
+def test_knowledge_router_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pack_exporter, "_require_psycopg", lambda: None)
+    monkeypatch.setattr(pack_exporter, "_require_boto3", lambda: None)
+
+    class Repo:
+        def latest_pack(self) -> pack_exporter.PackRecord | None:
+            return None
+
+    monkeypatch.setattr(pack_exporter, "KnowledgePackRepository", lambda *_, **__: Repo())
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/knowledge/export/latest")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No knowledge pack available"}
+
+
+def test_meta_router_available() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get(
+            "/meta/weights",
+            params={"symbol": "BTC-USD"},
+            headers={"X-Account-ID": "company"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "BTC-USD"
+    assert body["regime"] in {"range", "trend", "high_vol"}
+    weights = body["weights"]
+    assert set(weights.keys()) >= {"trend_model", "meanrev_model", "vol_breakout"}


### PR DESCRIPTION
## Summary
- register the knowledge and meta routers when constructing the FastAPI app
- add routing coverage that exercises the knowledge and meta endpoints provided by the application factory

## Testing
- pytest tests/test_app_routing.py

------
https://chatgpt.com/codex/tasks/task_e_68de5188b2508321bc53e83b5d08a5e7