### PR TITLE
Add scaling controller imports to app factory

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,12 @@ from exposure_forecast import router as exposure_router
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 from shared.correlation import CorrelationIdMiddleware
 
+from scaling_controller import (
+    build_scaling_controller_from_env,
+    configure_scaling_controller,
+    router as scaling_router,
+)
+
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Aether Admin Platform")


### PR DESCRIPTION
## Summary
- import the scaling controller factory utilities and router in the FastAPI app factory

## Testing
- python -c "from app import create_app; create_app()"

------
https://chatgpt.com/codex/tasks/task_e_68de51625ddc8321950b0b594b036fc2