### PR TITLE
Restrict OMS NetworkPolicy ingress and add validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
         run: |
           if [ -f pyproject.toml ]; then poe lint || true; fi
           if [ -f Makefile ]; then make lint || true; fi
+      - name: Validate OMS NetworkPolicy manifest
+        run: |
+          pytest tests/test_networkpolicy_oms_manifest.py -q
       - name: Run tests
         run: |
           if [ -f pytest.ini ] || [ -d tests ]; then pytest --maxfail=1 --disable-warnings -q; else echo "No tests"; fi

--- a/deploy/k8s/base/aether-services/networkpolicy-oms.yaml
+++ b/deploy/k8s/base/aether-services/networkpolicy-oms.yaml
@@ -13,7 +13,16 @@ spec:
     - Egress
   ingress:
     - from:
-        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              networking.aether.io/trusted: "true"
   egress:
     - to:
         - podSelector: {}

--- a/docs/config/oms-networkpolicy.md
+++ b/docs/config/oms-networkpolicy.md
@@ -1,0 +1,40 @@
+# OMS NetworkPolicy Allowlist
+
+The `allow-egress-kraken-coingecko-oms` NetworkPolicy confines inbound traffic to the OMS API to a small
+set of controller and operator namespaces. This prevents lateral movement from arbitrary workloads in
+our clusters while still allowing ingress traffic that is intentionally proxied.
+
+## Approved ingress sources
+
+| Source | Selector | Notes |
+| ------ | -------- | ----- |
+| NGINX ingress controller | `namespaceSelector.matchLabels.kubernetes.io/metadata.name=ingress-nginx`<br>`podSelector.matchLabels.app.kubernetes.io/name=ingress-nginx` | Required for public traffic that terminates at the managed ingress controller. |
+| Trusted operator namespaces | `namespaceSelector.matchLabels.networking.aether.io/trusted="true"` | Apply this label to namespaces that host incident response or smoke-test jobs which must reach the OMS API. Keep this list short and review quarterly. |
+
+Namespaces that legitimately need direct OMS access (for example `trading-ops` or temporary red-team
+validations) **must** be labelled with `networking.aether.io/trusted: "true"`. Remove the label as soon as
+access is no longer required.
+
+## Verification checklist
+
+Run the following smoke tests after deploying policy updates:
+
+1. Confirm ingress controller connectivity:
+   ```bash
+   kubectl -n ingress-nginx exec deploy/ingress-nginx-controller -- \
+     wget -qO- --timeout=5 http://oms-service.aether-services.svc.cluster.local:8000/healthz
+   ```
+   The command should return the OMS health payload with a `200 OK` status.
+2. Validate trusted namespace access (replace `<namespace>` with a labelled namespace):
+   ```bash
+   kubectl -n <namespace> run oms-smoke --rm -i --image=busybox:1.36 --restart=Never --labels="networking.aether.io/trusted=true" -- \
+     wget -qO- --timeout=5 http://oms-service.aether-services.svc.cluster.local:8000/healthz
+   ```
+3. Ensure untrusted namespaces are blocked:
+   ```bash
+   kubectl -n default run oms-block-test --rm -i --image=busybox:1.36 --restart=Never -- \
+     wget -qO- --timeout=5 http://oms-service.aether-services.svc.cluster.local:8000/healthz
+   ```
+   This command must fail with a timeout or `wget: server returned error` response.
+
+Record the outcomes in the change ticket and attach the CLI output for auditability.

--- a/tests/test_networkpolicy_oms_manifest.py
+++ b/tests/test_networkpolicy_oms_manifest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+import yaml
+
+MANIFEST = Path("deploy/k8s/base/aether-services/networkpolicy-oms.yaml")
+
+
+def _load_manifest() -> dict:
+    with MANIFEST.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_ingress_sources_are_restricted() -> None:
+    manifest = _load_manifest()
+    ingress_rules = manifest["spec"].get("ingress", [])
+    assert ingress_rules, "Expected at least one ingress rule in the OMS NetworkPolicy"
+
+    sources: list[dict] = []
+    for rule in ingress_rules:
+        sources.extend(rule.get("from", []))
+
+    assert sources, "Ingress rules must define at least one allowed source"
+
+    for source in sources:
+        assert source.get("podSelector", None) != {}, "podSelector must not allow all pods"
+
+    allows_ingress_controller = any(
+        source.get("namespaceSelector", {})
+        .get("matchLabels", {})
+        .get("kubernetes.io/metadata.name")
+        == "ingress-nginx"
+        and source.get("podSelector", {})
+        .get("matchLabels", {})
+        .get("app.kubernetes.io/name")
+        == "ingress-nginx"
+        for source in sources
+    )
+    assert allows_ingress_controller, "OMS policy must allow traffic from the ingress-nginx controller"
+
+    allows_trusted_namespaces = any(
+        source.get("namespaceSelector", {})
+        .get("matchLabels", {})
+        .get("networking.aether.io/trusted")
+        == "true"
+        for source in sources
+    )
+    assert allows_trusted_namespaces, "OMS policy must allow traffic from trusted labelled namespaces"


### PR DESCRIPTION
## Summary
- restrict the OMS NetworkPolicy to ingress-nginx and namespaces labelled as trusted
- document the namespace labelling and connectivity smoke tests for the OMS NetworkPolicy
- add a CI assertion that validates the OMS NetworkPolicy manifest structure

## Testing
- pytest tests/test_networkpolicy_oms_manifest.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de51209f808321b06da200e8071c0d