### PR TITLE
Add authorization dependency to secrets service routes

### DIFF
--- a/secrets_service.py
+++ b/secrets_service.py
@@ -12,12 +12,12 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
 import httpx
-from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, status, Header
 from fastapi.responses import JSONResponse
 from kubernetes import client, config
 from kubernetes.client import ApiException
 from kubernetes.config.config_exception import ConfigException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 try:  # pragma: no cover - optional audit dependency
@@ -41,16 +41,37 @@ class Settings(BaseModel):
     kraken_api_url: str = Field(
         default_factory=lambda: os.getenv("KRAKEN_API_URL", "https://api.kraken.com")
     )
+    authorized_tokens: Tuple[str, ...] = Field(..., alias="SECRETS_SERVICE_AUTH_TOKENS")
 
     class Config:
         allow_population_by_field_name = True
+
+    @validator("authorized_tokens", pre=True)
+    def _split_tokens(cls, value: Any) -> Tuple[str, ...]:  # type: ignore[override]
+        if isinstance(value, str):
+            tokens = [item.strip() for item in value.split(",") if item.strip()]
+        elif isinstance(value, (list, tuple, set)):
+            tokens = [str(item).strip() for item in value if str(item).strip()]
+        else:
+            raise ValueError("authorized tokens must be provided as a string or sequence")
+
+        if not tokens:
+            raise ValueError("at least one authorized token must be configured")
+
+        return tuple(tokens)
 
 
 def load_settings() -> Settings:
     secret_key = os.getenv("SECRET_ENCRYPTION_KEY")
     if not secret_key:
         raise RuntimeError("SECRET_ENCRYPTION_KEY environment variable must be set")
-    return Settings(SECRET_ENCRYPTION_KEY=secret_key)
+    tokens = os.getenv("SECRETS_SERVICE_AUTH_TOKENS")
+    if not tokens:
+        raise RuntimeError("SECRETS_SERVICE_AUTH_TOKENS environment variable must be set")
+    return Settings(
+        SECRET_ENCRYPTION_KEY=secret_key,
+        SECRETS_SERVICE_AUTH_TOKENS=tokens,
+    )
 
 
 SETTINGS = load_settings()
@@ -95,6 +116,37 @@ class SecretCipher:
 
 
 CIPHER = SecretCipher(_decode_encryption_key(SETTINGS.encryption_key_b64))
+AUTHORIZED_TOKENS = set(SETTINGS.authorized_tokens)
+
+
+def require_authorized_caller(
+    authorization: Optional[str] = Header(None, alias="Authorization")
+) -> str:
+    """Ensure that the caller presents a valid bearer token."""
+
+    if not authorization:
+        LOGGER.warning("Rejected request without authorization header")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization header is required",
+        )
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        LOGGER.warning("Rejected request with malformed authorization header")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header",
+        )
+
+    if token not in AUTHORIZED_TOKENS:
+        LOGGER.warning("Rejected request with unauthorized token")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Caller is not authorized",
+        )
+
+    return token
 
 
 class KrakenSecretManager:
@@ -263,6 +315,7 @@ def get_secret_manager() -> KrakenSecretManager:
 async def store_kraken_secret(
     payload: KrakenSecretRequest,
     request: Request,
+    _: str = Depends(require_authorized_caller),
     manager: KrakenSecretManager = Depends(get_secret_manager),
 ) -> JSONResponse:
     masked_key = redact_secret(payload.api_key)
@@ -321,6 +374,7 @@ async def store_kraken_secret(
 @app.get("/secrets/kraken/status")
 async def kraken_secret_status(
     account_id: str = Query(..., min_length=1),
+    _: str = Depends(require_authorized_caller),
     manager: KrakenSecretManager = Depends(get_secret_manager),
 ) -> Dict[str, str]:
     LOGGER.info("Status requested for Kraken secret %s", account_id)
@@ -330,7 +384,9 @@ async def kraken_secret_status(
 
 @app.post("/secrets/kraken/test")
 async def test_kraken_credentials(
-    payload: KrakenTestRequest, manager: KrakenSecretManager = Depends(get_secret_manager)
+    payload: KrakenTestRequest,
+    _: str = Depends(require_authorized_caller),
+    manager: KrakenSecretManager = Depends(get_secret_manager),
 ) -> Dict[str, Any]:
     LOGGER.info("Testing Kraken credentials for account %s", payload.account_id)
     credentials = manager.get_decrypted_credentials(payload.account_id)
@@ -370,5 +426,5 @@ async def test_kraken_credentials(
     return {"result": "success", "data": response.get("result", {})}
 
 
-__all__ = ["app"]
+__all__ = ["app", "require_authorized_caller", "get_secret_manager"]
 

--- a/tests/integration/test_audit_chain.py
+++ b/tests/integration/test_audit_chain.py
@@ -95,6 +95,7 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("OVERRIDE_DATABASE_URL", f"sqlite:///{tmp_path / 'override.db'}")
     encryption_key = base64.b64encode(b"0" * 32).decode()
     monkeypatch.setenv("SECRET_ENCRYPTION_KEY", encryption_key)
+    monkeypatch.setenv("SECRETS_SERVICE_AUTH_TOKENS", "integration-token")
 
     conn_mock, cursor_mock = _make_connection_mock()
     monkeypatch.setattr(audit_logger, "psycopg", MagicMock(connect=MagicMock(return_value=conn_mock)))
@@ -131,6 +132,7 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
                 "api_secret": "api-secret-xyz",
                 "actor": "sre.bob",
             },
+            headers={"Authorization": "Bearer integration-token"},
         )
         assert response.status_code == 201
 

--- a/tests/secrets/test_secrets_service_auth.py
+++ b/tests/secrets/test_secrets_service_auth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import base64
+import importlib
+import sys
+from datetime import datetime, timezone
+from typing import Dict, Tuple
+
+import pytest
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+def _configure_environment(monkeypatch: pytest.MonkeyPatch, token: str) -> None:
+    encryption_key = base64.b64encode(b"0" * 32).decode()
+    monkeypatch.setenv("SECRET_ENCRYPTION_KEY", encryption_key)
+    monkeypatch.setenv("SECRETS_SERVICE_AUTH_TOKENS", token)
+
+    import kubernetes.config as k8s_config
+
+    monkeypatch.setattr(k8s_config, "load_incluster_config", lambda: None)
+    monkeypatch.setattr(k8s_config, "load_kube_config", lambda: None)
+
+
+class _DummyManager:
+    def __init__(self) -> None:
+        self._status: Dict[str, str] = {
+            "secret_name": "kraken-keys-admin",
+            "last_rotated": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        }
+
+    def upsert_secret(self, account_id: str, payload: Dict[str, str], actor: str) -> Dict[str, str]:
+        return {
+            "secret_name": f"kraken-keys-{account_id}",
+            "last_rotated": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def get_status(self, account_id: str) -> Dict[str, str]:
+        return dict(self._status)
+
+    def get_decrypted_credentials(self, account_id: str) -> Dict[str, str]:
+        return {"api_key": "key", "api_secret": "secret"}
+
+
+@pytest.fixture()
+def secrets_client(monkeypatch: pytest.MonkeyPatch) -> Tuple[TestClient, str]:
+    token = "unit-test-token"
+    _configure_environment(monkeypatch, token)
+
+    sys.modules.pop("secrets_service", None)
+    secrets_service = importlib.import_module("secrets_service")
+
+    secrets_service.app.dependency_overrides[secrets_service.get_secret_manager] = lambda: _DummyManager()
+
+    async def _fake_balance(**_: Dict[str, str]) -> Dict[str, Dict[str, str]]:
+        return {"error": [], "result": {}}
+
+    monkeypatch.setattr(secrets_service, "kraken_get_balance", _fake_balance)
+
+    client = TestClient(secrets_service.app)
+    try:
+        yield client, token
+    finally:
+        client.close()
+        secrets_service.app.dependency_overrides.clear()
+        sys.modules.pop("secrets_service", None)
+
+
+def test_missing_authorization_is_rejected(secrets_client: Tuple[TestClient, str]) -> None:
+    client, _ = secrets_client
+
+    response = client.get("/secrets/kraken/status", params={"account_id": "admin"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authorization header is required"
+
+
+def test_invalid_token_is_rejected(secrets_client: Tuple[TestClient, str]) -> None:
+    client, _ = secrets_client
+
+    response = client.post(
+        "/secrets/kraken",
+        json={"account_id": "admin", "api_key": "key", "api_secret": "secret"},
+        headers={"Authorization": "Bearer wrong-token", "X-Forwarded-Proto": "https"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Caller is not authorized"
+
+
+def test_authorized_request_succeeds(secrets_client: Tuple[TestClient, str]) -> None:
+    client, token = secrets_client
+
+    response = client.get(
+        "/secrets/kraken/status",
+        params={"account_id": "admin"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["secret_name"] == "kraken-keys-admin"


### PR DESCRIPTION
## Summary
- require configured bearer tokens for the standalone secrets service
- apply the authorization dependency to all Kraken secrets endpoints and update integration coverage
- add tests that exercise authorized and unauthorized requests

## Testing
- pytest tests/secrets/test_secrets_service_auth.py


------
https://chatgpt.com/codex/tasks/task_e_68de517ec7808321a97151c16b1f2f5b