### PR TITLE
Persist audit logs via Timescale adapter

### DIFF
--- a/shared/audit.py
+++ b/shared/audit.py
@@ -2,12 +2,21 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Protocol, TYPE_CHECKING
 
 from .correlation import get_correlation_id
+
+
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:  # pragma: no cover - import only used for typing
+    from services.common.adapters import TimescaleAdapter
 
 
 @dataclass(frozen=True)
@@ -23,17 +32,123 @@ class AuditLogEntry:
     created_at: dt.datetime = field(default_factory=lambda: dt.datetime.now(dt.timezone.utc))
 
 
-class AuditLogStore:
-    """TimescaleDB-backed audit log emulation enforcing immutability."""
+class AuditLogBackend(Protocol):
+    """Protocol describing the persistence surface required by the store."""
 
-    def __init__(self) -> None:
-        self._entries: List[AuditLogEntry] = []
+    def record_audit_log(self, record: Mapping[str, Any]) -> None:
+        ...
+
+    def audit_logs(self) -> Iterable[Mapping[str, Any]]:
+        ...
+
+
+SleepFn = Callable[[float], None]
+
+
+def _coerce_datetime(value: Any) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo else value.replace(tzinfo=dt.timezone.utc)
+
+    if isinstance(value, str):
+        try:
+            parsed = dt.datetime.fromisoformat(value)
+        except ValueError:
+            return dt.datetime.now(dt.timezone.utc)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
+
+    return dt.datetime.now(dt.timezone.utc)
+
+
+class AuditLogStore:
+    """TimescaleDB-backed audit log store enforcing immutability semantics."""
+
+    _DEFAULT_ACCOUNT_ID = "aether-audit"
+
+    def __init__(
+        self,
+        *,
+        account_id: str | None = None,
+        backend: AuditLogBackend | None = None,
+        max_retries: int = 3,
+        backoff_seconds: float = 0.05,
+        sleep_fn: SleepFn | None = None,
+    ) -> None:
+        self._account_id = account_id or self._DEFAULT_ACCOUNT_ID
+        self._backend_impl: AuditLogBackend | None = backend
+        self._max_retries = max(0, int(max_retries))
+        self._backoff_seconds = max(0.0, float(backoff_seconds))
+        self._sleep: SleepFn = sleep_fn or time.sleep
+
+    def _get_backend(self) -> AuditLogBackend:
+        if self._backend_impl is None:
+            from services.common.adapters import TimescaleAdapter  # local import to avoid cycles
+
+            self._backend_impl = TimescaleAdapter(account_id=self._account_id)
+        return self._backend_impl
 
     def append(self, entry: AuditLogEntry) -> None:
-        self._entries.append(entry)
+        payload = {
+            "before": dict(entry.before),
+            "after": dict(entry.after),
+            "correlation_id": entry.correlation_id,
+            "entry_id": str(entry.id),
+        }
+        record = {
+            "actor": entry.actor_id,
+            "action": entry.action,
+            "target": entry.correlation_id,
+            "created_at": entry.created_at,
+            "payload": payload,
+        }
+
+        attempt = 0
+        while True:
+            try:
+                self._get_backend().record_audit_log(record)
+                return
+            except Exception as exc:  # pragma: no cover - exercised via unit tests with stubs
+                if attempt >= self._max_retries:
+                    logger.error("Failed to persist audit log entry", exc_info=exc)
+                    raise
+                delay = self._backoff_seconds * (2 ** attempt)
+                logger.warning(
+                    "Transient error persisting audit log entry (attempt %s/%s): %s", 
+                    attempt + 1,
+                    self._max_retries + 1,
+                    exc,
+                )
+                if delay > 0:
+                    self._sleep(delay)
+                attempt += 1
 
     def all(self) -> Iterable[AuditLogEntry]:
-        return tuple(self._entries)
+        entries: List[AuditLogEntry] = []
+        for raw in self._get_backend().audit_logs():
+            payload = raw.get("payload", {})
+            before = MappingProxyType(dict(payload.get("before") or {}))
+            after = MappingProxyType(dict(payload.get("after") or {}))
+            correlation_id = payload.get("correlation_id") or raw.get("target")
+            created_at = _coerce_datetime(raw.get("created_at"))
+            raw_id: Any = payload.get("entry_id") or raw.get("id") or raw.get("log_id")
+            try:
+                entry_id = raw_id if isinstance(raw_id, uuid.UUID) else uuid.UUID(str(raw_id))
+            except (TypeError, ValueError):
+                entry_id = uuid.uuid4()
+
+            entries.append(
+                AuditLogEntry(
+                    id=entry_id,
+                    action=str(raw.get("action", "")),
+                    actor_id=str(raw.get("actor", "")),
+                    before=before,
+                    after=after,
+                    correlation_id=correlation_id,
+                    created_at=created_at,
+                )
+            )
+
+        entries.sort(key=lambda record: record.created_at)
+        return tuple(entries)
 
 
 class TimescaleAuditLogger:
@@ -55,8 +170,8 @@ class TimescaleAuditLogger:
             id=uuid.uuid4(),
             action=action,
             actor_id=actor_id,
-            before=MappingProxyType(before or {}),
-            after=MappingProxyType(after or {}),
+            before=MappingProxyType(dict(before or {})),
+            after=MappingProxyType(dict(after or {})),
             correlation_id=correlation_id,
         )
         self._store.append(entry)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -2,11 +2,61 @@ from __future__ import annotations
 
 import pytest
 
+import sys
+import types
+from typing import Any, Mapping
+
+if "cryptography" not in sys.modules:
+    crypto_mod = types.ModuleType("cryptography")
+    hazmat_mod = types.ModuleType("cryptography.hazmat")
+    primitives_mod = types.ModuleType("cryptography.hazmat.primitives")
+    ciphers_mod = types.ModuleType("cryptography.hazmat.primitives.ciphers")
+    aead_mod = types.ModuleType("cryptography.hazmat.primitives.ciphers.aead")
+
+    class _StubAESGCM:
+        def __init__(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple stub
+            self._key = args[0] if args else None
+
+        def encrypt(self, nonce: bytes, data: bytes, associated_data: bytes | None = None) -> bytes:
+            return data
+
+        def decrypt(self, nonce: bytes, data: bytes, associated_data: bytes | None = None) -> bytes:
+            return data
+
+    aead_mod.AESGCM = _StubAESGCM
+    crypto_mod.hazmat = hazmat_mod
+    hazmat_mod.primitives = primitives_mod
+    primitives_mod.ciphers = ciphers_mod
+    ciphers_mod.aead = aead_mod
+
+    sys.modules["cryptography"] = crypto_mod
+    sys.modules["cryptography.hazmat"] = hazmat_mod
+    sys.modules["cryptography.hazmat.primitives"] = primitives_mod
+    sys.modules["cryptography.hazmat.primitives.ciphers"] = ciphers_mod
+    sys.modules["cryptography.hazmat.primitives.ciphers.aead"] = aead_mod
+
+from services.common.adapters import TimescaleAdapter
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 
 
+class _FlakyBackend:
+    def __init__(self) -> None:
+        self.attempts = 0
+        self.records: list[dict[str, Any]] = []
+
+    def record_audit_log(self, record: Mapping[str, Any]) -> None:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise RuntimeError("transient failure")
+        self.records.append(dict(record))
+
+    def audit_logs(self) -> list[dict[str, Any]]:
+        return [dict(entry) for entry in self.records]
+
+
 def test_audit_log_entries_are_immutable():
-    store = AuditLogStore()
+    TimescaleAdapter.reset(account_id="immutable")
+    store = AuditLogStore(account_id="immutable")
     logger = TimescaleAuditLogger(store)
     recorder = SensitiveActionRecorder(logger)
 
@@ -22,3 +72,45 @@ def test_audit_log_entries_are_immutable():
 
     entries = list(store.all())
     assert entries[0] == entry
+
+
+def test_audit_log_store_persists_entries_across_instances():
+    TimescaleAdapter.reset(account_id="persistence")
+    store = AuditLogStore(account_id="persistence")
+    logger = TimescaleAuditLogger(store)
+
+    entry = logger.record(
+        action="config.update",
+        actor_id="system",
+        before={"feature": False},
+        after={"feature": True},
+        correlation_id="corr-123",
+    )
+
+    fresh_store = AuditLogStore(account_id="persistence")
+    persisted = list(fresh_store.all())
+
+    assert persisted == [entry]
+    with pytest.raises(TypeError):
+        persisted[0].before["feature"] = True
+
+
+def test_audit_log_store_retries_transient_errors():
+    backend = _FlakyBackend()
+    store = AuditLogStore(
+        backend=backend,
+        max_retries=1,
+        backoff_seconds=0.0,
+        sleep_fn=lambda _: None,
+    )
+    logger = TimescaleAuditLogger(store)
+
+    entry = logger.record(
+        action="secret.rotate",
+        actor_id="auditor",
+        before={"status": "active"},
+        after={"status": "rotated"},
+    )
+
+    assert backend.attempts == 2
+    assert list(store.all()) == [entry]


### PR DESCRIPTION
## Summary
- replace the in-memory AuditLogStore with a Timescale-backed implementation that uses retry/backoff when writing through the adapter
- extend the TimescaleAdapter with append-only audit log primitives that the store consumes
- expand audit log unit tests to cover persistence, immutability, and retry behaviour while stubbing optional crypto dependencies

## Testing
- pytest tests/test_audit_log.py

------
https://chatgpt.com/codex/tasks/task_e_68de515a90d08321bae2374c2506b29b