### PR TITLE
Add TTL eviction to OMS idempotency store

### DIFF
--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -161,24 +161,47 @@ class ImpactCurveResponse(BaseModel):
     as_of: datetime
 
 
+@dataclass
+class _IdempotencyEntry:
+    future: asyncio.Future[OMSOrderStatusResponse]
+    timestamp: float = 0.0
+
+
 class _IdempotencyStore:
     """Cooperative idempotency cache used per-account."""
 
-    def __init__(self) -> None:
+    def __init__(self, ttl_seconds: float = 300.0) -> None:
         self._lock = asyncio.Lock()
-        self._entries: Dict[str, asyncio.Future[OMSOrderStatusResponse]] = {}
+        self._entries: Dict[str, _IdempotencyEntry] = {}
+        self._ttl_seconds = ttl_seconds
+
+    def _purge_expired(self) -> None:
+        if not self._entries:
+            return
+
+        now = time.monotonic()
+        expired = [
+            key
+            for key, entry in self._entries.items()
+            if entry.future.done() and now - entry.timestamp >= self._ttl_seconds
+        ]
+        for key in expired:
+            self._entries.pop(key, None)
 
     async def get_or_create(
         self, key: str, factory: Awaitable[OMSOrderStatusResponse]
     ) -> Tuple[OMSOrderStatusResponse, bool]:
         async with self._lock:
-            future = self._entries.get(key)
-            if future is None:
+            self._purge_expired()
+            entry = self._entries.get(key)
+            if entry is None:
                 loop = asyncio.get_event_loop()
                 future = loop.create_future()
-                self._entries[key] = future
+                entry = _IdempotencyEntry(future=future)
+                self._entries[key] = entry
                 create_future = True
             else:
+                future = entry.future
                 create_future = False
 
         if create_future:
@@ -186,8 +209,15 @@ class _IdempotencyStore:
                 result = await factory
             except Exception as exc:  # pragma: no cover - propagate to awaiting callers
                 future.set_exception(exc)
+                async with self._lock:
+                    self._entries.pop(key, None)
                 raise
             else:
+                completion_time = time.monotonic()
+                async with self._lock:
+                    entry = self._entries.get(key)
+                    if entry is not None:
+                        entry.timestamp = completion_time
                 future.set_result(result)
                 return result, False
 

--- a/tests/services/oms/test_idempotency_store.py
+++ b/tests/services/oms/test_idempotency_store.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import ast
+from pathlib import Path
+import types
+from typing import Any, Dict
+
+
+def _load_idempotency_store() -> type:
+    """Dynamically load the _IdempotencyStore definition from the service module."""
+
+    source = Path("services/oms/oms_service.py").read_text(encoding="utf-8")
+    module_ast = ast.parse(source)
+    target_names = {"_IdempotencyEntry", "_IdempotencyStore"}
+    snippets: list[str] = []
+
+    for node in module_ast.body:
+        if isinstance(node, ast.ClassDef) and node.name in target_names:
+            snippet = ast.get_source_segment(source, node)
+            if not snippet:
+                continue
+            decorators = [
+                f"@{ast.get_source_segment(source, decorator)}"
+                for decorator in node.decorator_list
+            ]
+            combined = "\n".join((*decorators, snippet)) if decorators else snippet
+            snippets.append(combined)
+
+    exec_source = "\n\n".join(snippets)
+    namespace: Dict[str, Any] = {}
+    exec(  # noqa: S102 - executing trusted project code for testing
+        "from dataclasses import dataclass\n"
+        "import asyncio\n"
+        "import time\n"
+        "from typing import Awaitable, Dict, Tuple\n"
+        "from typing import Any\n"
+        "OMSOrderStatusResponse = Any\n"
+        f"{exec_source}\n",
+        namespace,
+    )
+    return namespace["_IdempotencyStore"]
+
+
+_IdempotencyStore = _load_idempotency_store()
+
+
+async def _create_response(order_id: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(exchange_order_id=order_id)
+
+
+def test_idempotency_store_evicts_entries_after_ttl() -> None:
+    async def scenario() -> None:
+        store = _IdempotencyStore(ttl_seconds=0.05)
+
+        first_response, reused_first = await store.get_or_create(
+            "order", _create_response("first")
+        )
+
+        assert reused_first is False
+        assert first_response.exchange_order_id == "first"
+
+        await asyncio.sleep(0.06)
+
+        second_response, reused_second = await store.get_or_create(
+            "order", _create_response("second")
+        )
+
+        assert reused_second is False
+        assert second_response.exchange_order_id == "second"
+
+        async with store._lock:  # type: ignore[attr-defined]
+            assert len(store._entries) == 1  # type: ignore[attr-defined]
+
+    asyncio.run(scenario())
+
+
+def test_idempotency_store_retains_recent_entries() -> None:
+    async def scenario() -> None:
+        store = _IdempotencyStore(ttl_seconds=10.0)
+
+        first_response, reused_first = await store.get_or_create(
+            "order", _create_response("initial")
+        )
+
+        assert reused_first is False
+
+        next_factory = _create_response("should-not-run")
+        second_response, reused_second = await store.get_or_create("order", next_factory)
+        next_factory.close()
+
+        assert reused_second is True
+        assert second_response is first_response
+
+        async with store._lock:  # type: ignore[attr-defined]
+            assert len(store._entries) == 1  # type: ignore[attr-defined]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add TTL-based eviction logic to the OMS idempotency store and purge expired futures on each lookup
- timestamp completed futures and remove failed entries to keep the cache bounded
- add tests that dynamically load the store implementation and verify TTL expiry and reuse

## Testing
- pytest tests/services/oms/test_idempotency_store.py

------
https://chatgpt.com/codex/tasks/task_e_68de511fb0a08321abb45ed14761ad0a