### PR TITLE
Add admin and auditor auth guards to reporting endpoints

### DIFF
--- a/alert_prioritizer.py
+++ b/alert_prioritizer.py
@@ -10,11 +10,13 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder
+
+from services.common.security import require_admin_account
 
 _DEFAULT_ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093")
 _ALERT_ENDPOINT = "/api/v2/alerts"
@@ -283,7 +285,7 @@ _service = AlertPrioritizerService()
 
 
 @router.get("/alerts/prioritized")
-async def prioritized_alerts() -> List[Dict[str, Any]]:
+async def prioritized_alerts(_: str = Depends(require_admin_account)) -> List[Dict[str, Any]]:
     """Return alerts prioritised by the ML classifier."""
 
     return await _service.get_prioritized_alerts()
@@ -295,4 +297,3 @@ async def shutdown_prioritizer() -> None:
 
 
 __all__ = ["router", "AlertPrioritizerService"]
-

--- a/compliance_pack.py
+++ b/compliance_pack.py
@@ -11,8 +11,10 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
+
+from audit_mode import AuditorPrincipal, require_auditor_identity
 
 try:  # pragma: no cover - optional dependency during unit tests.
     import boto3
@@ -560,6 +562,7 @@ def _cached_exporter() -> CompliancePackExporter:
 def export_compliance_pack(
     export_format: str = Query("sec", alias="format"),
     export_date: dt.date = Query(..., alias="date"),
+    _: AuditorPrincipal = Depends(require_auditor_identity),
 ) -> Response:
     try:
         exporter = _cached_exporter()

--- a/docs/runbooks/reporting-automation.md
+++ b/docs/runbooks/reporting-automation.md
@@ -24,3 +24,20 @@ If the script exits with a non-zero status:
    ```bash
    python docs/runbooks/scripts/daily_report.py --date $(date -u +%Y-%m-%d)
    ```
+
+## API authentication requirements
+
+Operations frequently uses the reporting and compliance endpoints while audit partners
+review daily exports. The following HTTP headers must be provided with each request to
+pass the new security dependencies:
+
+| Endpoint | Audience | Required headers |
+| --- | --- | --- |
+| `GET /reports/xai` | Admin only | `X-Account-ID` set to an account in `ADMIN_ACCOUNTS` |
+| `GET /logs/export` | Auditors | `X-Role: auditor` and `X-Account-ID` matching the configured auditor allow-list |
+| `GET /compliance/export` | Auditors | `X-Role: auditor` and `X-Account-ID` matching the configured auditor allow-list |
+| `GET /alerts/prioritized` | Admin only | `X-Account-ID` set to an account in `ADMIN_ACCOUNTS` |
+| `GET /alerts/active`, `GET /alerts/policies` | Admin only | `X-Account-ID` set to an account in `ADMIN_ACCOUNTS` |
+
+Auditor accounts are defined in the audit mode configuration (see `audit_mode.AuditModeConfig`).
+Administrative calls may additionally require MFA headers where noted by each service.

--- a/multiformat_export.py
+++ b/multiformat_export.py
@@ -12,12 +12,14 @@ from typing import Any, Dict, List, Mapping
 
 import markdown2
 import pandas as pd
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import LETTER
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from audit_mode import AuditorPrincipal, require_auditor_identity
 
 try:  # pragma: no cover - boto3 is optional in some environments.
     import boto3
@@ -448,6 +450,7 @@ def export_logs(
         pattern="^(json|csv|pdf|md)$",
         description="Desired response format",
     ),
+    _: AuditorPrincipal = Depends(require_auditor_identity),
 ) -> Response:
     """Trigger a multi-format export and return the requested artifact."""
 

--- a/services/alerts/alert_dedupe.py
+++ b/services/alerts/alert_dedupe.py
@@ -51,6 +51,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub for tests
 
 from prometheus_client import CollectorRegistry, Counter
 
+from services.common.security import require_admin_account
+
 if TYPE_CHECKING:
     import httpx
 
@@ -338,12 +340,18 @@ def get_alert_dedupe_service() -> AlertDedupeService:
 
 
 @router.get("/active")
-async def get_active_alerts(service: AlertDedupeService = Depends(get_alert_dedupe_service)) -> List[Dict[str, Any]]:
+async def get_active_alerts(
+    _: str = Depends(require_admin_account),
+    service: AlertDedupeService = Depends(get_alert_dedupe_service),
+) -> List[Dict[str, Any]]:
     return await service.refresh()
 
 
 @router.get("/policies")
-def get_alert_policies(service: AlertDedupeService = Depends(get_alert_dedupe_service)) -> Dict[str, Any]:
+def get_alert_policies(
+    _: str = Depends(require_admin_account),
+    service: AlertDedupeService = Depends(get_alert_dedupe_service),
+) -> Dict[str, Any]:
     return service.policies()
 
 

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -13,12 +13,13 @@ from datetime import date, datetime, timedelta, timezone
 from statistics import mean
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Sequence
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from psycopg2 import sql
 from psycopg2.extras import RealDictCursor
 
 from reports.storage import ArtifactStorage, StoredArtifact, TimescaleSession as StorageSession, build_storage_from_env
 from services.common.config import TimescaleSession, get_timescale_session
+from services.common.security import require_admin_account
 
 
 DAILY_ACCOUNT_PNL_QUERY = """
@@ -366,7 +367,10 @@ def get_report_service() -> ReportService:
 
 
 @router.get("/xai")
-async def recent_xai(account_id: Optional[str] = Query(default=None)) -> Dict[str, Any]:
+async def recent_xai(
+    account_id: Optional[str] = Query(default=None),
+    _: str = Depends(require_admin_account),
+) -> Dict[str, Any]:
     """Return aggregated SHAP explanations for recent trades."""
 
     service = get_report_service()

--- a/tests/security/test_route_authorization.py
+++ b/tests/security/test_route_authorization.py
@@ -1,0 +1,257 @@
+"""Authorization tests for admin and auditor protected endpoints."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for API authorization tests")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import alert_prioritizer
+import compliance_pack
+import multiformat_export
+import services.report_service as account_report_service
+from audit_mode import AuditorPrincipal
+from services.alerts import alert_dedupe
+from services.common.security import require_admin_account
+
+
+@pytest.fixture
+def report_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Create a test client for the account report endpoints."""
+
+    app = FastAPI()
+    app.include_router(account_report_service.router)
+
+    class StubReportService:
+        def recent_feature_attribution(self, account_id: str | None = None) -> Dict[str, Any]:
+            return {
+                "account_id": account_id or "default",
+                "feature_attribution": [],
+            }
+
+    stub_service = StubReportService()
+    app.dependency_overrides[account_report_service.get_report_service] = lambda: stub_service
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_recent_xai_requires_admin_header(report_client: TestClient) -> None:
+    response = report_client.get("/reports/xai")
+    assert response.status_code == 403
+
+
+def test_recent_xai_allows_admin_override(report_client: TestClient) -> None:
+    report_client.app.dependency_overrides[require_admin_account] = lambda: "company"
+    try:
+        response = report_client.get("/reports/xai")
+    finally:
+        report_client.app.dependency_overrides.pop(require_admin_account, None)
+
+    assert response.status_code == 200
+    assert response.json()["account_id"] == "default"
+
+
+@pytest.fixture
+def export_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Client for the log export endpoint with exporter stubbed out."""
+
+    app = FastAPI()
+    app.include_router(multiformat_export.router)
+
+    class StubExporter:
+        def export(self, *, for_date: dt.date) -> multiformat_export.ExportResult:
+            artifact = multiformat_export.ExportArtifact(
+                format="json",
+                object_key="logs/export.json",
+                content_type="application/json",
+                data=b"{}",
+            )
+            return multiformat_export.ExportResult(
+                run_id="run-123",
+                export_date=for_date,
+                artifacts={"json": artifact},
+            )
+
+    monkeypatch.setattr(multiformat_export, "_get_exporter", lambda: StubExporter())
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_export_logs_rejects_non_auditors(export_client: TestClient) -> None:
+    response = export_client.get(
+        "/logs/export",
+        params={"date": "2024-01-01", "format": "json"},
+        headers={"X-Role": "engineer", "X-Account-ID": "analyst"},
+    )
+    assert response.status_code == 403
+
+
+def test_export_logs_allows_auditor_override(export_client: TestClient) -> None:
+    export_client.app.dependency_overrides[multiformat_export.require_auditor_identity] = (
+        lambda: AuditorPrincipal(account_id="auditor-1")
+    )
+    try:
+        response = export_client.get(
+            "/logs/export",
+            params={"date": "2024-01-01", "format": "json"},
+        )
+    finally:
+        export_client.app.dependency_overrides.pop(multiformat_export.require_auditor_identity, None)
+
+    assert response.status_code == 200
+    assert response.headers["X-Run-ID"] == "run-123"
+
+
+@pytest.fixture
+def compliance_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Client for the compliance pack export endpoint."""
+
+    app = FastAPI()
+    app.include_router(compliance_pack.router)
+
+    @dataclass
+    class StubPack:
+        data: bytes = b"{}"
+        content_type: str = "application/json"
+        sha256: str = "abc123"
+        s3_bucket: str = "bucket"
+        s3_key: str = "key"
+        export_format: str = "sec"
+        export_date: dt.date = dt.date(2024, 1, 1)
+        generated_at: dt.datetime = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+    class StubExporter:
+        def export(self, *, for_date: dt.date, export_format: str) -> StubPack:
+            return StubPack(export_format=export_format, export_date=for_date)
+
+    monkeypatch.setattr(compliance_pack, "_cached_exporter", lambda: StubExporter())
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_export_compliance_pack_rejects_non_auditors(compliance_client: TestClient) -> None:
+    response = compliance_client.get(
+        "/compliance/export",
+        params={"date": "2024-01-01", "format": "sec"},
+        headers={"X-Role": "engineer", "X-Account-ID": "auditor-1"},
+    )
+    assert response.status_code == 403
+
+
+def test_export_compliance_pack_allows_auditor_override(compliance_client: TestClient) -> None:
+    compliance_client.app.dependency_overrides[compliance_pack.require_auditor_identity] = (
+        lambda: AuditorPrincipal(account_id="auditor-1")
+    )
+    try:
+        response = compliance_client.get(
+            "/compliance/export",
+            params={"date": "2024-01-01", "format": "sec"},
+        )
+    finally:
+        compliance_client.app.dependency_overrides.pop(compliance_pack.require_auditor_identity, None)
+
+    assert response.status_code == 200
+    assert response.headers["X-Compliance-SHA256"] == "abc123"
+
+
+@pytest.fixture
+def prioritizer_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Client for the alert prioritizer endpoint."""
+
+    app = FastAPI()
+    app.include_router(alert_prioritizer.router)
+
+    class StubService:
+        async def get_prioritized_alerts(self) -> List[Dict[str, Any]]:
+            return [{"id": "a1", "severity": "high"}]
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(alert_prioritizer, "_service", StubService())
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_prioritized_alerts_require_admin(prioritizer_client: TestClient) -> None:
+    response = prioritizer_client.get("/alerts/prioritized")
+    assert response.status_code == 403
+
+
+def test_prioritized_alerts_allow_admin_override(prioritizer_client: TestClient) -> None:
+    prioritizer_client.app.dependency_overrides[require_admin_account] = lambda: "company"
+    try:
+        response = prioritizer_client.get("/alerts/prioritized")
+    finally:
+        prioritizer_client.app.dependency_overrides.pop(require_admin_account, None)
+
+    assert response.status_code == 200
+    assert response.json() == [{"id": "a1", "severity": "high"}]
+
+
+@pytest.fixture
+def alert_dedupe_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Client for the alert dedupe endpoints."""
+
+    app = FastAPI()
+    app.include_router(alert_dedupe.router)
+
+    class StubService:
+        async def refresh(self) -> List[Dict[str, Any]]:
+            return [{"id": "alert"}]
+
+        def policies(self) -> Dict[str, Any]:
+            return {"suppression_window_seconds": 600}
+
+    stub_service = StubService()
+    app.dependency_overrides[alert_dedupe.get_alert_dedupe_service] = lambda: stub_service
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_alert_dedupe_endpoints_require_admin(alert_dedupe_client: TestClient) -> None:
+    active_response = alert_dedupe_client.get("/alerts/active")
+    policies_response = alert_dedupe_client.get("/alerts/policies")
+    assert active_response.status_code == 403
+    assert policies_response.status_code == 403
+
+
+def test_alert_dedupe_endpoints_allow_admin_override(alert_dedupe_client: TestClient) -> None:
+    alert_dedupe_client.app.dependency_overrides[require_admin_account] = lambda: "company"
+    try:
+        active_response = alert_dedupe_client.get("/alerts/active")
+        policies_response = alert_dedupe_client.get("/alerts/policies")
+    finally:
+        alert_dedupe_client.app.dependency_overrides.pop(require_admin_account, None)
+
+    assert active_response.status_code == 200
+    assert policies_response.status_code == 200
+    assert active_response.json() == [{"id": "alert"}]
+    assert policies_response.json() == {"suppression_window_seconds": 600}


### PR DESCRIPTION
## Summary
- require administrative authentication for sensitive reporting and alert management endpoints
- gate log and compliance exports behind the auditor identity dependency and document the required headers
- add authorization-focused FastAPI tests with dependency overrides for the secured routes

## Testing
- pytest tests/security/test_route_authorization.py

------
https://chatgpt.com/codex/tasks/task_e_68de56c756188321a3d2d1c02a74cc54