### PR TITLE
feat(auth): include roles in JWT payloads

### DIFF
--- a/docs/services/authentication_service.md
+++ b/docs/services/authentication_service.md
@@ -1,0 +1,45 @@
+# Authentication Service JWT Contract
+
+The authentication service issues JSON Web Tokens (JWTs) that encode the
+caller identity and authorization context.  Integrators consuming the service
+should expect the following claim schema:
+
+| Claim       | Type          | Description |
+| ----------- | ------------- | ----------- |
+| `sub`       | string        | Stable subject identifier (typically the admin's email). |
+| `role`      | string        | Authorization role resolved during login.  Current roles include `admin` and `auditor`. |
+| `iat`       | integer (sec) | Issued-at timestamp in UTC seconds. |
+| `exp`       | integer (sec) | Expiration timestamp in UTC seconds. |
+| `permissions` | array[string] | Optional list of fine-grained permissions for rich clients. |
+| `read_only` | boolean       | Convenience flag indicating whether the role is read-only. |
+
+Additional custom claims can be added through the authentication pipeline, but
+these core fields are always present.  Downstream services **must** validate the
+`role` claim before honouring privileged requests.
+
+## Role resolution
+
+The service determines the caller's role by inspecting the identity provider
+profile (preferred usernames, explicit role claims) and server-side account
+configuration.  When calling `services.auth.jwt_tokens.create_jwt` directly you
+must now provide either:
+
+* the explicit `role` argument (e.g. `role="admin"`), or
+* a claims mapping that already contains a `role` entry.
+
+If neither is supplied the helper will raise a `ValueError` to prevent issuing
+role-less tokens.  This ensures integrators request the appropriate role for the
+context they are operating in and makes subsequent validation deterministic.
+
+## Validating roles in downstream services
+
+Consumers should enforce authorization by:
+
+1. Verifying the token signature using the shared `AUTH_JWT_SECRET`.
+2. Confirming the token is not expired (`exp`).
+3. Inspecting the `role` claim and rejecting any unexpected values.
+
+This applies to internal services (e.g. OMS) and external tooling alike.  The
+`role` should be treated as authoritative—if a user requires elevated
+privileges they must complete the relevant onboarding process so the
+authentication service issues a token with the desired role.

--- a/tests/integration/test_oms_authentication.py
+++ b/tests/integration/test_oms_authentication.py
@@ -79,7 +79,7 @@ def client_fixture(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
 
 
 def _auth_headers(account_id: str) -> Dict[str, str]:
-    token, _ = create_jwt(subject=account_id, ttl_seconds=3600)
+    token, _ = create_jwt(subject=account_id, role="admin", ttl_seconds=3600)
     return {"Authorization": f"Bearer {token}"}
 
 

--- a/tests/services/test_auth_jwt.py
+++ b/tests/services/test_auth_jwt.py
@@ -17,7 +17,7 @@ def test_create_jwt_structure_and_claims(monkeypatch):
     monkeypatch.setenv("AUTH_JWT_SECRET", "super-secret-key")
     monkeypatch.setenv("AUTH_JWT_TTL_SECONDS", "120")
 
-    token, expires_at = create_jwt(subject="user-123")
+    token, expires_at = create_jwt(subject="user-123", role="admin")
 
     parts = token.split(".")
     assert len(parts) == 3, "JWT should contain header, payload, and signature"
@@ -43,4 +43,17 @@ def test_create_jwt_missing_secret(monkeypatch):
     monkeypatch.setenv("AUTH_JWT_TTL_SECONDS", "60")
 
     with pytest.raises(ValueError):
-        create_jwt(subject="user-456")
+        create_jwt(subject="user-456", role="auditor")
+
+
+def test_create_jwt_accepts_claim_mapping(monkeypatch):
+    monkeypatch.setenv("AUTH_JWT_SECRET", "super-secret-key")
+    extra_claims = {"role": "auditor", "permissions": ["read"]}
+
+    token, _ = create_jwt(subject="user-789", claims=extra_claims)
+
+    parts = token.split(".")
+    payload = _decode_segment(parts[1])
+
+    assert payload["role"] == "auditor"
+    assert payload["permissions"] == ["read"]

--- a/tests/unit/services/test_oms_service.py
+++ b/tests/unit/services/test_oms_service.py
@@ -83,7 +83,7 @@ def oms_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
 
 def _auth_headers(account_id: str) -> Dict[str, str]:
-    token, _ = create_jwt(subject=account_id, ttl_seconds=3600)
+    token, _ = create_jwt(subject=account_id, role="admin", ttl_seconds=3600)
     return {"Authorization": f"Bearer {token}"}
 
 


### PR DESCRIPTION
## Summary
- extend the shared JWT helper to require callers to supply a role or claims mapping
- update authentication-related tests and fixtures to pass explicit roles when minting tokens
- document the authentication service JWT schema and role handling for integrators

## Testing
- pytest tests/services/test_auth_jwt.py
- pytest tests/unit/services/test_oms_service.py tests/integration/test_oms_authentication.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68de5aec92c88321b37c92fb742cba9f