### PR TITLE
Add admin repository builder and tests for app factory

### DIFF
--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from fastapi import APIRouter
+
+
+def _install_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[name] = module
+    return module
+
+
+def _install_module(name: str, module: types.ModuleType) -> None:
+    sys.modules[name] = module
+    package_name, _, attr = name.rpartition(".")
+    if package_name:
+        package = sys.modules.setdefault(package_name, _install_package(package_name))
+        setattr(package, attr, module)
+
+
+# Stub audit mode wiring to avoid pulling optional dependencies during import.
+audit_mode = types.ModuleType("audit_mode")
+
+def _configure_audit_mode(app) -> None:  # pragma: no cover - behaviour not under test
+    app.audit_mode_configured = True
+
+audit_mode.configure_audit_mode = _configure_audit_mode  # type: ignore[attr-defined]
+_install_module("audit_mode", audit_mode)
+
+
+# Minimal accounts service stub.
+accounts_service = types.ModuleType("accounts.service")
+
+
+class _StubAccountsService:
+    def __init__(self, recorder) -> None:  # pragma: no cover - behaviour not under test
+        self.recorder = recorder
+
+
+accounts_service.AccountsService = _StubAccountsService  # type: ignore[attr-defined]
+_install_module("accounts.service", accounts_service)
+
+
+# Minimal auth routing stub.
+auth_routes = types.ModuleType("auth.routes")
+
+def _get_auth_service():  # pragma: no cover - overridden in create_app
+    raise RuntimeError("dependency override not configured")
+
+
+auth_routes.get_auth_service = _get_auth_service  # type: ignore[attr-defined]
+auth_routes.router = APIRouter()
+_install_module("auth.routes", auth_routes)
+
+
+# Authentication service primitives for the application factory.
+auth_service_module = types.ModuleType("auth.service")
+
+
+class AdminRepositoryProtocol:  # pragma: no cover - structural stub
+    pass
+
+
+class InMemoryAdminRepository(AdminRepositoryProtocol):
+    def __init__(self) -> None:
+        self._admins: dict[str, object] = {}
+
+    def add(self, admin) -> None:  # pragma: no cover - behaviour not under test
+        self._admins[getattr(admin, "email", "")] = admin
+
+    def get_by_email(self, email: str):  # pragma: no cover - behaviour not under test
+        return self._admins.get(email)
+
+
+class SessionStoreProtocol:  # pragma: no cover - structural stub
+    pass
+
+
+class InMemorySessionStore(SessionStoreProtocol):
+    def __init__(self, ttl_minutes: int = 60) -> None:
+        self.ttl_minutes = ttl_minutes
+        self._sessions: dict[str, object] = {}
+
+    def create(self, admin_id: str):  # pragma: no cover - behaviour not under test
+        token = f"token-{admin_id}"
+        session = types.SimpleNamespace(token=token, admin_id=admin_id)
+        self._sessions[token] = session
+        return session
+
+    def get(self, token: str):  # pragma: no cover - behaviour not under test
+        return self._sessions.get(token)
+
+
+class RedisSessionStore(SessionStoreProtocol):  # pragma: no cover - structural stub
+    def __init__(self, client, ttl_minutes: int = 60) -> None:
+        self.client = client
+        self.ttl_minutes = ttl_minutes
+
+
+class PostgresAdminRepository(AdminRepositoryProtocol):
+    def __init__(self, dsn: str) -> None:  # pragma: no cover - behaviour not under test
+        self.dsn = dsn
+
+
+class AuthService:
+    def __init__(self, repository: AdminRepositoryProtocol, sessions: SessionStoreProtocol) -> None:
+        self.repository = repository
+        self.sessions = sessions
+
+
+# Backwards-compatible aliases used by the application module.
+AdminRepository = InMemoryAdminRepository
+SessionStore = InMemorySessionStore
+
+auth_service_module.AdminRepositoryProtocol = AdminRepositoryProtocol  # type: ignore[attr-defined]
+auth_service_module.InMemoryAdminRepository = InMemoryAdminRepository  # type: ignore[attr-defined]
+auth_service_module.PostgresAdminRepository = PostgresAdminRepository  # type: ignore[attr-defined]
+auth_service_module.AuthService = AuthService  # type: ignore[attr-defined]
+auth_service_module.SessionStoreProtocol = SessionStoreProtocol  # type: ignore[attr-defined]
+auth_service_module.InMemorySessionStore = InMemorySessionStore  # type: ignore[attr-defined]
+auth_service_module.RedisSessionStore = RedisSessionStore  # type: ignore[attr-defined]
+auth_service_module.SessionStore = SessionStore  # type: ignore[attr-defined]
+_install_module("auth.service", auth_service_module)
+
+
+# Metrics wiring.
+metrics_module = types.ModuleType("metrics")
+
+
+def setup_metrics(app, *, service_name: str) -> None:  # pragma: no cover - behaviour not under test
+    app.metrics_service_name = service_name
+
+
+metrics_module.setup_metrics = setup_metrics  # type: ignore[attr-defined]
+_install_module("metrics", metrics_module)
+
+
+# Alerting stubs.
+services_pkg = _install_package("services")
+
+alert_manager_module = types.ModuleType("services.alert_manager")
+
+def setup_alerting(app, *, alertmanager_url=None) -> None:  # pragma: no cover - behaviour not under test
+    app.alertmanager_url = alertmanager_url
+
+
+alert_manager_module.setup_alerting = setup_alerting  # type: ignore[attr-defined]
+_install_module("services.alert_manager", alert_manager_module)
+
+alerts_pkg = _install_package("services.alerts")
+alert_dedupe_module = types.ModuleType("services.alerts.alert_dedupe")
+alert_dedupe_module.router = APIRouter()
+
+def setup_alert_dedupe(app, *, alertmanager_url=None) -> None:  # pragma: no cover - behaviour not under test
+    app.alert_dedupe_url = alertmanager_url
+
+
+alert_dedupe_module.setup_alert_dedupe = setup_alert_dedupe  # type: ignore[attr-defined]
+_install_module("services.alerts.alert_dedupe", alert_dedupe_module)
+
+
+# Shared audit primitives.
+shared_pkg = _install_package("shared")
+shared_audit_module = types.ModuleType("shared.audit")
+
+
+class AuditLogStore:  # pragma: no cover - structural stub
+    pass
+
+
+class TimescaleAuditLogger:  # pragma: no cover - structural stub
+    def __init__(self, store: AuditLogStore) -> None:
+        self.store = store
+
+
+class SensitiveActionRecorder:  # pragma: no cover - structural stub
+    def __init__(self, logger: TimescaleAuditLogger) -> None:
+        self.logger = logger
+
+
+shared_audit_module.AuditLogStore = AuditLogStore  # type: ignore[attr-defined]
+shared_audit_module.TimescaleAuditLogger = TimescaleAuditLogger  # type: ignore[attr-defined]
+shared_audit_module.SensitiveActionRecorder = SensitiveActionRecorder  # type: ignore[attr-defined]
+_install_module("shared.audit", shared_audit_module)
+
+shared_correlation_module = types.ModuleType("shared.correlation")
+
+
+class CorrelationIdMiddleware:  # pragma: no cover - structural stub
+    pass
+
+
+shared_correlation_module.CorrelationIdMiddleware = CorrelationIdMiddleware  # type: ignore[attr-defined]
+_install_module("shared.correlation", shared_correlation_module)
+
+
+# Scaling controller infrastructure.
+scaling_controller_module = types.ModuleType("scaling_controller")
+
+
+class _ScalingController:
+    async def start(self) -> None:  # pragma: no cover - behaviour not under test
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover - behaviour not under test
+        return None
+
+
+def build_scaling_controller_from_env() -> _ScalingController:
+    return _ScalingController()
+
+
+def configure_scaling_controller(controller: _ScalingController) -> None:  # pragma: no cover - behaviour not under test
+    controller.configured = True
+
+
+scaling_controller_module.build_scaling_controller_from_env = build_scaling_controller_from_env  # type: ignore[attr-defined]
+scaling_controller_module.configure_scaling_controller = configure_scaling_controller  # type: ignore[attr-defined]
+scaling_controller_module.router = APIRouter()
+_install_module("scaling_controller", scaling_controller_module)
+
+
+import app as app_module
+
+
+def test_create_app_uses_postgres_repository_when_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_POSTGRES_DSN", "postgresql://example.com/admin")
+
+    created: dict[str, str] = {}
+
+    class DummyPostgresRepository(app_module.InMemoryAdminRepository):
+        def __init__(self, dsn: str) -> None:
+            super().__init__()
+            created["dsn"] = dsn
+
+    monkeypatch.setattr(app_module, "PostgresAdminRepository", DummyPostgresRepository)
+
+    session_store = app_module.InMemorySessionStore()
+    application = app_module.create_app(session_store=session_store)
+
+    assert isinstance(application.state.admin_repository, DummyPostgresRepository)
+    assert created["dsn"] == "postgresql://example.com/admin"
+
+
+def test_create_app_defaults_to_in_memory_repository(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ADMIN_POSTGRES_DSN", raising=False)
+    monkeypatch.delenv("ADMIN_DATABASE_DSN", raising=False)
+    monkeypatch.delenv("ADMIN_DB_DSN", raising=False)
+
+    application = app_module.create_app(session_store=app_module.InMemorySessionStore())
+
+    assert isinstance(application.state.admin_repository, app_module.InMemoryAdminRepository)


### PR DESCRIPTION
## Summary
- update the FastAPI application factory to import the explicit admin/session abstractions and build the admin repository from DSN environment variables
- fall back to the in-memory admin repository when no DSN is configured while keeping the existing session store helper
- add focused tests for `create_app` that exercise the Postgres and in-memory repository code paths without pulling optional dependencies

## Testing
- pytest tests/test_app_factory.py


------
https://chatgpt.com/codex/tasks/task_e_68de5ae9f3d4832191c23343e5f9fa22