### PR TITLE
Persist admin password upgrades

### DIFF
--- a/auth/service.py
+++ b/auth/service.py
@@ -303,6 +303,7 @@ class AuthService:
                 return False
             if _ARGON2_HASHER.needs_update(stored_hash):
                 admin.password_hash = hash_password(password)
+                self._repository.add(admin)
             return True
 
         # Backwards compatibility with legacy SHA-256 hashes.
@@ -310,6 +311,7 @@ class AuthService:
         if hmac.compare_digest(candidate, stored_hash):
             # Upgrade legacy hash on successful login.
             admin.password_hash = hash_password(password)
+            self._repository.add(admin)
             return True
         return False
 


### PR DESCRIPTION
## Summary
- persist newly generated password hashes for both Argon2 upgrades and legacy SHA-256 logins
- provide lightweight auth-service test doubles for hashing and metrics when running without production dependencies
- add regression tests covering both legacy and Argon2 hash refresh paths to ensure repositories store the new credentials

## Testing
- pytest tests/test_auth.py::test_login_upgrades_legacy_hash_and_persists tests/test_auth.py::test_login_refreshes_outdated_argon_hash


------
https://chatgpt.com/codex/tasks/task_e_68de5dd97e448321a8fbf2e8794f5201