### PR TITLE
Ensure kill switch endpoint places Request before default params

### DIFF
--- a/kill_switch.py
+++ b/kill_switch.py
@@ -53,10 +53,10 @@ def _normalize_account(account_id: str) -> str:
 
 @app.post("/risk/kill")
 def trigger_kill_switch(
+    request: Request,
     account_id: str = Query(..., min_length=1),
     reason_code: KillSwitchReason = Query(KillSwitchReason.LOSS_CAP_BREACH),
     actor_account: str = Depends(require_admin_account),
-    request: Request,
 ) -> Dict[str, Any]:
     """Trigger the kill switch for the provided account."""
 


### PR DESCRIPTION
## Summary
- reorder the `trigger_kill_switch` FastAPI endpoint parameters so the `Request` argument precedes defaulted parameters to satisfy validation

## Testing
- python -m py_compile kill_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68de66131d188321b600aa990173c4f2