### PR TITLE
Protect reporting endpoints with admin auth

### DIFF
--- a/docs/runbooks/reporting-automation.md
+++ b/docs/runbooks/reporting-automation.md
@@ -33,7 +33,10 @@ pass the new security dependencies:
 
 | Endpoint | Audience | Required headers |
 | --- | --- | --- |
-| `GET /reports/xai` | Admin only | `X-Account-ID` set to an account in `ADMIN_ACCOUNTS` |
+| `GET /reports/daily` | Admin only | `Authorization: Bearer <admin session>` and optional `X-Account-ID` matching the session |
+| `POST /reports/export` | Admin only | `Authorization: Bearer <admin session>` and optional `X-Account-ID` matching the session |
+| `GET /reports/explain` | Admin only | `Authorization: Bearer <admin session>` and optional `X-Account-ID` matching the session |
+| `GET /reports/xai` | Admin only | `Authorization: Bearer <admin session>` and `X-Account-ID` matching the session |
 | `GET /logs/export` | Auditors | `X-Role: auditor` and `X-Account-ID` matching the configured auditor allow-list |
 | `GET /compliance/export` | Auditors | `X-Role: auditor` and `X-Account-ID` matching the configured auditor allow-list |
 | `GET /alerts/prioritized` | Admin only | `X-Account-ID` set to an account in `ADMIN_ACCOUNTS` |


### PR DESCRIPTION
## Summary
- require admin authentication for the reporting service daily, export, and explain endpoints
- extend authorization tests to cover the reporting service routes
- document the admin session requirements for reporting APIs in the runbook

## Testing
- pytest tests/security/test_route_authorization.py

------
https://chatgpt.com/codex/tasks/task_e_68de80cc578483219018bf3d8cedecec