### PR TITLE
Enforce actor binding for Kraken secret rotations

### DIFF
--- a/docs/services/kraken_secrets_service.md
+++ b/docs/services/kraken_secrets_service.md
@@ -1,0 +1,11 @@
+# Kraken Secrets Service
+
+The Kraken Secrets Service manages encryption, validation, and rotation of exchange API credentials.
+
+## Actor Attribution
+
+* Rotation requests require a bearer token configured via `SECRETS_SERVICE_AUTH_TOKENS` and labelled in `KRAKEN_SECRETS_AUTH_TOKENS`.
+* The actor recorded in metadata, logs, and audit entries is derived from the authenticated token's label. The optional `actor` field in the request body is ignored unless it matches the authenticated identity.
+* If the supplied payload actor conflicts with the authenticated actor label, the service rejects the request with `400 Actor identity does not match provided credentials` to prevent spoofed attribution.
+
+API consumers no longer need to send an `actor` value when rotating a secret—the service will attribute the rotation automatically based on the caller's credentials.

--- a/tests/integration/test_audit_chain.py
+++ b/tests/integration/test_audit_chain.py
@@ -96,6 +96,7 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
     encryption_key = base64.b64encode(b"0" * 32).decode()
     monkeypatch.setenv("SECRET_ENCRYPTION_KEY", encryption_key)
     monkeypatch.setenv("SECRETS_SERVICE_AUTH_TOKENS", "integration-token")
+    monkeypatch.setenv("KRAKEN_SECRETS_AUTH_TOKENS", "integration-token:ops.brigade")
 
     conn_mock, cursor_mock = _make_connection_mock()
     monkeypatch.setattr(audit_logger, "psycopg", MagicMock(connect=MagicMock(return_value=conn_mock)))
@@ -130,7 +131,7 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
                 "account_id": "admin-eu",
                 "api_key": "api-key-123",
                 "api_secret": "api-secret-xyz",
-                "actor": "sre.bob",
+                "actor": "ops.brigade",
             },
             headers={"Authorization": "Bearer integration-token"},
         )


### PR DESCRIPTION
## Summary
- derive the rotation actor in `store_kraken_secret` from the authenticated token and reject spoofed payload actors
- align unit and integration tests with the enforced actor binding behaviour
- document the actor attribution expectations for the Kraken Secrets Service

## Testing
- pytest tests/secrets/test_authorization.py *(fails: FastAPI not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de961ac9ac8321adace0080082bc4b