### PR TITLE
Protect safe mode endpoints with admin authentication

### DIFF
--- a/tests/integration/test_safe_mode.py
+++ b/tests/integration/test_safe_mode.py
@@ -51,7 +51,11 @@ def test_safe_mode_blocks_intents_but_allows_hedging_orders() -> None:
     assert engine.submit_intent() == "intent-submitted"
     assert engine.place_order(hedging=False) == "order-placed"
 
-    response = client.post("/safe_mode/enter", json={"reason": "test"})
+    response = client.post(
+        "/safe_mode/enter",
+        json={"reason": "test"},
+        headers={"X-Account-ID": "company"},
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["active"] is True
@@ -66,7 +70,9 @@ def test_safe_mode_blocks_intents_but_allows_hedging_orders() -> None:
         engine.place_order(hedging=False)
     assert engine.place_order(hedging=True) == "order-placed"
 
-    response = client.post("/safe_mode/exit")
+    response = client.post(
+        "/safe_mode/exit", headers={"X-Account-ID": "company"}
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["active"] is False


### PR DESCRIPTION
## Summary
- require the admin session dependency for the safe mode enter/exit routes and log the verified actor
- expand the safe mode service tests to cover authentication failures and authenticated flows
- update the integration test harness to call the endpoints with an authorized admin account

## Testing
- pytest tests/services/test_safe_mode.py tests/integration/test_safe_mode.py *(skipped: fastapi not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f4de7908321bc34c81962a4c7ff