### PR TITLE
Extend policy service imports

### DIFF
--- a/policy_service.py
+++ b/policy_service.py
@@ -7,8 +7,9 @@ import logging
 import math
 import os
 import time
-from collections import defaultdict
-from dataclasses import dataclass
+from collections import defaultdict, deque
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 
 from decimal import ROUND_HALF_UP, Decimal
 from threading import Lock


### PR DESCRIPTION
## Summary
- add deque, replace, and datetime/timezone imports to `policy_service.py`

## Testing
- pyflakes policy_service.py

------
https://chatgpt.com/codex/tasks/task_e_68decfb3b5148321bb7bc7949cc9d188