### PR TITLE
Add missing base64 import to auth service

### DIFF
--- a/auth_service.py
+++ b/auth_service.py
@@ -44,6 +44,7 @@ encoder to avoid adding new packages to the environment.
 """
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
- add the base64 standard-library import to `auth_service.py` so the module can reference the encoding helpers without lint failures

## Testing
- pyflakes auth_service.py *(reports existing `create_jwt` redefinition warning unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68decfb1b73c832198d4860359331f50