### PR TITLE
Secure universe override endpoint

### DIFF
--- a/tests/universe/test_universe_service_api.py
+++ b/tests/universe/test_universe_service_api.py
@@ -141,8 +141,8 @@ def test_manual_override_migrates_legacy_symbols(session: Session) -> None:
     )
     session.commit()
 
-    request = OverrideRequest(symbol="xbt/usd", enabled=True, reason="Enable trading", actor="tester")
-    response = universe_service.override_symbol(request, session=session)
+    request = OverrideRequest(symbol="xbt/usd", enabled=True, reason="Enable trading")
+    response = universe_service.override_symbol(request, session=session, actor_account="ops-admin")
 
     assert response.symbol == "BTC-USD"
 


### PR DESCRIPTION
## Summary
- enforce administrative authentication on the universe override endpoint and record the verified actor in override and audit metadata
- remove reliance on the request payload for actor identity when persisting overrides
- update FastAPI tests to cover authorized and unauthorized override attempts and adapt direct calls to provide an authenticated actor

## Testing
- pytest tests/unit/services/test_universe_service.py tests/universe/test_universe_service_api.py *(fails: fixture expects SQLAlchemy metadata with drop_all when using patched SimpleNamespace)*

------
https://chatgpt.com/codex/tasks/task_e_68ded34e9bb483219db83ce85f4d750e