### PR TITLE
Secure watchdog oversight status endpoint

### DIFF
--- a/tests/security/test_watchdog_authorization.py
+++ b/tests/security/test_watchdog_authorization.py
@@ -1,0 +1,70 @@
+"""Authorization tests for the watchdog oversight endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for watchdog authorization tests")
+
+from fastapi.testclient import TestClient
+
+import watchdog
+from auth.service import InMemorySessionStore
+from services.common.security import set_default_session_store
+
+
+@pytest.fixture
+def watchdog_client() -> tuple[TestClient, InMemorySessionStore]:
+    """Provide a TestClient with an isolated session store."""
+
+    store = InMemorySessionStore()
+    set_default_session_store(store)
+    watchdog.app.state.session_store = store
+
+    try:
+        with TestClient(watchdog.app) as client:
+            yield client, store
+    finally:
+        set_default_session_store(None)
+        if hasattr(watchdog.app.state, "session_store"):
+            delattr(watchdog.app.state, "session_store")
+
+
+def test_oversight_status_requires_authenticated_session(
+    watchdog_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, _store = watchdog_client
+
+    response = client.get("/oversight/status")
+
+    assert response.status_code == 401
+
+
+def test_oversight_status_rejects_non_admin_sessions(
+    watchdog_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, store = watchdog_client
+    session = store.create("guest")
+
+    response = client.get(
+        "/oversight/status",
+        headers={"Authorization": f"Bearer {session.token}"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_oversight_status_allows_admin_sessions(
+    watchdog_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, store = watchdog_client
+    session = store.create("company")
+
+    response = client.get(
+        "/oversight/status",
+        headers={"Authorization": f"Bearer {session.token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "total_vetoes" in payload

--- a/watchdog.py
+++ b/watchdog.py
@@ -31,6 +31,7 @@ from sqlalchemy.pool import StaticPool
 
 from common.schemas.contracts import IntentEvent
 from services.common.adapters import KafkaNATSAdapter
+from services.common.security import require_admin_account
 
 try:  # pragma: no cover - LightGBM is optional in many environments
     import lightgbm as lgb  # type: ignore
@@ -802,6 +803,7 @@ def get_repository() -> WatchdogRepository:
 async def oversight_status(
     limit: int = Query(20, ge=1, le=200, description="Maximum number of recent vetoes to return"),
     repository: WatchdogRepository = Depends(get_repository),
+    _admin_account: str = Depends(require_admin_account),
 ) -> OversightStatusResponse:
     total, entries, counts = await asyncio.to_thread(repository.summary, limit)
 


### PR DESCRIPTION
## Summary
- require admin authentication for the `/oversight/status` watchdog endpoint
- add FastAPI authorization tests covering admin and non-admin access to the watchdog status API

## Testing
- pytest tests/security/test_watchdog_authorization.py

------
https://chatgpt.com/codex/tasks/task_e_68ded45c55bc832183ca0975269fcd31