### PR TITLE
Enforce admin authentication for strategy orchestrator

### DIFF
--- a/docs/runbooks/operations.md
+++ b/docs/runbooks/operations.md
@@ -61,3 +61,13 @@ This runbook describes the day-2 operational workflows for the Aether risk platf
 - [ ] Export Loki query for `service=risk-api` covering the incident window.
 - [ ] Attach SBOM artifacts from the latest pipeline run to the incident ticket.
 - [ ] Summarize remediations and create follow-up tasks in Jira.
+
+## 6. Strategy orchestrator access controls
+- All calls to the strategy orchestrator FastAPI service (**`/strategy/*` endpoints**) require an
+  administrator session token supplied via the `Authorization: Bearer <token>` header. Requests
+  without this header are rejected with `401 Unauthorized`.
+- The orchestrator enforces that the authenticated operator belongs to the admin allow-list. If the
+  session resolves to a non-admin account, the request fails with `403 Forbidden`.
+- When coordinating incident mitigations, obtain an admin session from the authentication service
+  and re-use that token across CLI `curl` probes or workflow automations interacting with the
+  orchestrator.

--- a/docs/services/strategy_orchestrator.md
+++ b/docs/services/strategy_orchestrator.md
@@ -1,0 +1,24 @@
+# Strategy Orchestrator API
+
+The strategy orchestrator coordinates strategy registration, state management, and risk routing.
+All endpoints are protected and require an authenticated administrator session token.
+
+## Authentication
+- Supply a valid administrator token from the authentication service using the
+  `Authorization: Bearer <token>` header on every request.
+- The orchestrator validates the token against the admin allow-list. Requests made with tokens for
+  non-admin users are rejected with `403 Forbidden`.
+- The `X-Account-ID` header is no longer required; the orchestrator logs the authenticated actor
+  derived from the token for auditing.
+
+## Endpoints
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/strategy/register` | Register or update a strategy allocation. |
+| `POST` | `/strategy/toggle` | Enable or disable an existing strategy. |
+| `GET` | `/strategy/status` | Retrieve the current strategy allocation snapshot. |
+| `POST` | `/strategy/intent` | Forward a trade intent to the risk engine with strategy context. |
+| `GET` | `/strategy/signals` | List the available strategy-aligned signal channels. |
+
+All endpoints return `401 Unauthorized` if the `Authorization` header is missing or invalid, and
+`403 Forbidden` if the session resolves to a caller without admin privileges.

--- a/tests/security/test_strategy_orchestrator_authorization.py
+++ b/tests/security/test_strategy_orchestrator_authorization.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for API authorization tests")
+
+from fastapi.testclient import TestClient
+
+from auth.service import InMemorySessionStore
+import strategy_orchestrator
+from services.common.security import reload_admin_accounts, set_default_session_store
+from tests.test_strategy_orchestrator import _make_request
+
+
+@pytest.fixture(autouse=True)
+def configure_security() -> InMemorySessionStore:
+    store = InMemorySessionStore()
+    set_default_session_store(store)
+    reload_admin_accounts(["company", "director-1", "director-2"])
+    try:
+        yield store
+    finally:
+        set_default_session_store(None)
+        reload_admin_accounts()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(strategy_orchestrator.app)
+
+
+def test_strategy_endpoints_require_authorization(client: TestClient) -> None:
+    request_payload = _make_request().model_dump(mode="json")
+    test_matrix = [
+        (client.post, "/strategy/register", {"json": {"name": "gamma", "description": "New", "max_nav_pct": 0.1}}),
+        (client.post, "/strategy/toggle", {"json": {"name": "alpha", "enabled": False}}),
+        (client.get, "/strategy/status", {}),
+        (client.post, "/strategy/intent", {"json": {"strategy_name": "alpha", "request": request_payload}}),
+        (client.get, "/strategy/signals", {}),
+    ]
+
+    for method, path, kwargs in test_matrix:
+        response = method(path, **kwargs)
+        assert response.status_code == 401
+
+
+def test_non_admin_session_is_rejected(client: TestClient, configure_security: InMemorySessionStore) -> None:
+    session = configure_security.create("analyst-1")
+    headers = {"Authorization": f"Bearer {session.token}"}
+
+    response = client.get("/strategy/status", headers=headers)
+
+    assert response.status_code == 403
+
+
+def test_admin_session_allows_access(client: TestClient, configure_security: InMemorySessionStore) -> None:
+    session = configure_security.create("company")
+    headers = {"Authorization": f"Bearer {session.token}"}
+
+    response = client.get("/strategy/status", headers=headers)
+
+    assert response.status_code == 200

--- a/tests/test_strategy_orchestrator.py
+++ b/tests/test_strategy_orchestrator.py
@@ -44,9 +44,13 @@ class _FastAPI:
         return decorator
 
 
+def _depends(*args: Any, **kwargs: Any) -> Any:
+    return None
+
+
 sys.modules.setdefault(
     "fastapi",
-    SimpleNamespace(FastAPI=_FastAPI, HTTPException=_HTTPException),
+    SimpleNamespace(FastAPI=_FastAPI, HTTPException=_HTTPException, Depends=_depends),
 )
 
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary
- require admin authentication on every strategy orchestrator endpoint and log the verified actor
- extend tests to cover FastAPI authorization behaviour and update stubs used in unit tests
- document the orchestrator credential requirements in the operations runbook and new service API guide

## Testing
- pytest tests/security/test_strategy_orchestrator_authorization.py *(skipped: fastapi is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded73e633483219ed1d973c472c964