### PR TITLE
Add FastAPI Postgres session context manager

### DIFF
--- a/pg_session.py
+++ b/pg_session.py
@@ -1,0 +1,171 @@
+"""PostgreSQL session utilities for FastAPI services.
+
+This module exposes :func:`db_session`, a context manager tailored for
+FastAPI endpoints that need to execute SQL queries scoped by authorization
+middleware.  The context manager expects the FastAPI ``Request`` to expose a
+``db_sessionmaker`` attribute on ``app.state`` (commonly a ``sessionmaker``
+instance) and an ``account_scopes`` iterable on ``request.state`` populated by
+authorization middleware.  When invoked, it applies the caller's account scopes
+via ``set_config`` so that PostgreSQL row-level security policies are enforced
+for the duration of the request.  The configuration flag is reset when the
+connection is returned to the pool to avoid scope leakage across requests.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Callable, Iterable, Iterator, Sequence, Tuple, cast
+
+try:  # pragma: no cover - FastAPI is optional in some unit test environments
+    from fastapi import Request
+except Exception:  # pragma: no cover - fallback to satisfy type checkers when FastAPI missing
+    Request = Any  # type: ignore[assignment]
+try:  # pragma: no cover - SQLAlchemy may be unavailable in lightweight test environments
+    from sqlalchemy.engine import Connection
+    from sqlalchemy.orm import Session, sessionmaker
+except Exception:  # pragma: no cover - provide fallbacks when SQLAlchemy is missing
+    Connection = Any  # type: ignore[assignment]
+    Session = Any  # type: ignore[assignment]
+
+    class sessionmaker:  # type: ignore[override]
+        """Minimal stub allowing isinstance checks when SQLAlchemy is absent."""
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - defensive fallback
+            raise RuntimeError("sqlalchemy is required for database session management")
+
+logger = logging.getLogger(__name__)
+
+_SET_SCOPE_SQL = "SELECT set_config('app.account_scopes', %(scopes)s, true)"
+_RESET_SCOPE_SQL = "RESET app.account_scopes"
+
+SessionFactory = Callable[[], Session]
+
+
+def _resolve_session_factory(request: Request) -> SessionFactory:
+    """Return the configured SQLAlchemy session factory for *request*."""
+
+    factory = getattr(request.app.state, "db_sessionmaker", None)
+    if factory is None:
+        raise RuntimeError(
+            "FastAPI application state is missing 'db_sessionmaker'. "
+            "Configure request.app.state.db_sessionmaker with a sessionmaker instance."
+        )
+    if isinstance(factory, sessionmaker):
+        return cast(SessionFactory, factory)
+    if callable(factory):
+        return cast(SessionFactory, factory)
+    raise RuntimeError(
+        "Configured 'db_sessionmaker' is not callable. Ensure it is a sessionmaker or factory function."
+    )
+
+
+def _normalize_account_scopes(scopes: object) -> Tuple[str, ...]:
+    """Normalise account scopes from the request state into a tuple of strings."""
+
+    if scopes is None:
+        raise RuntimeError(
+            "Authorization middleware did not attach account scopes to the request state."
+        )
+
+    if isinstance(scopes, str):
+        candidates: Iterable[object] = (scopes,)
+    else:
+        try:
+            candidates = cast(Iterable[object], scopes)
+        except TypeError as exc:  # pragma: no cover - defensive programming
+            raise RuntimeError("Account scopes must be an iterable of strings.") from exc
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in candidates:
+        if raw is None:
+            continue
+        scope = str(raw).strip()
+        if not scope or scope in seen:
+            continue
+        normalized.append(scope)
+        seen.add(scope)
+
+    if not normalized:
+        raise RuntimeError("Request did not include any usable account scopes.")
+
+    return tuple(normalized)
+
+
+def _session_in_transaction(session: Session) -> bool:
+    """Return ``True`` when *session* currently owns an active transaction."""
+
+    in_transaction = getattr(session, "in_transaction", None)
+    if callable(in_transaction):
+        try:
+            return bool(in_transaction())
+        except Exception:  # pragma: no cover - defensive guard against driver quirks
+            logger.debug("Failed to determine transaction state via in_transaction", exc_info=True)
+    get_transaction = getattr(session, "get_transaction", None)
+    if callable(get_transaction):
+        try:
+            return get_transaction() is not None
+        except Exception:  # pragma: no cover - defensive guard against driver quirks
+            logger.debug("Failed to determine transaction state via get_transaction", exc_info=True)
+    # Fall back to assuming the session is in a transaction; better to err on the
+    # side of committing/rolling back than skipping it entirely.
+    return True
+
+
+def _set_account_scopes(connection: Connection, scopes: Sequence[str]) -> bool:
+    """Apply the caller's account scopes on the given *connection*."""
+
+    if connection.dialect.name != "postgresql":
+        logger.debug(
+            "Skipping account scope configuration because dialect is %s", connection.dialect.name
+        )
+        return False
+    joined = ",".join(scopes)
+    connection.exec_driver_sql(_SET_SCOPE_SQL, {"scopes": joined})
+    return True
+
+
+def _reset_account_scopes(connection: Connection) -> None:
+    """Reset the account scope configuration on *connection*."""
+
+    if connection.dialect.name != "postgresql":
+        return
+    try:
+        reset_conn = connection.execution_options(isolation_level="AUTOCOMMIT")
+        reset_conn.exec_driver_sql(_RESET_SCOPE_SQL)
+    except Exception:  # pragma: no cover - ensure connection close proceeds
+        logger.warning("Failed to reset app.account_scopes on connection", exc_info=True)
+
+
+@contextmanager
+def db_session(request: Request) -> Iterator[Session]:
+    """Provide a database session scoped to the request's authorized accounts.
+
+    The returned context manager yields a SQLAlchemy ``Session`` object. It will
+    automatically commit when the block exits successfully or roll back if an
+    exception is raised.  The Postgres ``app.account_scopes`` session variable is
+    set prior to yielding and reset when the connection is returned to the pool.
+    """
+
+    scopes = _normalize_account_scopes(getattr(request.state, "account_scopes", None))
+    session_factory = _resolve_session_factory(request)
+    session = session_factory()
+    connection = session.connection()
+    applied_scopes = _set_account_scopes(connection, scopes)
+
+    try:
+        yield session
+        if _session_in_transaction(session):
+            session.commit()
+    except Exception:
+        if _session_in_transaction(session):
+            session.rollback()
+        raise
+    finally:
+        if applied_scopes:
+            _reset_account_scopes(connection)
+        session.close()
+
+
+__all__ = ["db_session"]

--- a/tests/common/test_pg_session.py
+++ b/tests/common/test_pg_session.py
@@ -1,0 +1,127 @@
+"""Tests for the PostgreSQL session context manager utilities."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from pg_session import db_session
+
+
+class StubConnection:
+    def __init__(self, dialect_name: str = "postgresql") -> None:
+        self.dialect = SimpleNamespace(name=dialect_name)
+        self.commands: list[tuple[str, dict | None]] = []
+        self.execution_calls: list[dict] = []
+
+    def exec_driver_sql(self, statement: str, parameters: dict | None = None) -> None:
+        self.commands.append((statement, parameters))
+
+    def execution_options(self, **kwargs):  # type: ignore[override]
+        self.execution_calls.append(kwargs)
+        return self
+
+
+class StubSession:
+    def __init__(self, connection: StubConnection) -> None:
+        self._connection = connection
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = 0
+        self._in_transaction = True
+
+    def connection(self):  # type: ignore[override]
+        return self._connection
+
+    def in_transaction(self) -> bool:  # type: ignore[override]
+        return self._in_transaction
+
+    def get_transaction(self):  # type: ignore[override]
+        return object() if self._in_transaction else None
+
+    def commit(self) -> None:  # type: ignore[override]
+        self.commits += 1
+        self._in_transaction = False
+
+    def rollback(self) -> None:  # type: ignore[override]
+        self.rollbacks += 1
+        self._in_transaction = False
+
+    def close(self) -> None:  # type: ignore[override]
+        self.closed += 1
+
+
+def _build_request(session: StubSession, scopes) -> SimpleNamespace:
+    factory = lambda: session
+    app = SimpleNamespace(state=SimpleNamespace(db_sessionmaker=factory))
+    state = SimpleNamespace(account_scopes=scopes)
+    return SimpleNamespace(app=app, state=state)
+
+
+def test_db_session_sets_and_resets_account_scopes() -> None:
+    connection = StubConnection()
+    session = StubSession(connection)
+    request = _build_request(session, [" acct-1 ", "acct-2", "acct-1"])
+
+    with db_session(request) as active_session:
+        assert active_session is session
+        # Account scopes should be normalised and applied once upon entry.
+        assert connection.commands == [
+            ("SELECT set_config('app.account_scopes', %(scopes)s, true)", {"scopes": "acct-1,acct-2"})
+        ]
+        assert session.commits == 0
+
+    # Context manager commits and closes the session when exiting cleanly.
+    assert session.commits == 1
+    assert session.rollbacks == 0
+    assert session.closed == 1
+    assert connection.execution_calls == [{"isolation_level": "AUTOCOMMIT"}]
+    assert connection.commands[-1] == ("RESET app.account_scopes", None)
+
+
+def test_db_session_rolls_back_on_error() -> None:
+    connection = StubConnection()
+    session = StubSession(connection)
+    request = _build_request(session, ["acct-1"])
+
+    with pytest.raises(RuntimeError):
+        with db_session(request):
+            raise RuntimeError("boom")
+
+    assert session.commits == 0
+    assert session.rollbacks == 1
+    assert session.closed == 1
+    assert connection.commands[0][0].startswith("SELECT set_config")
+    assert connection.commands[-1] == ("RESET app.account_scopes", None)
+
+
+def test_db_session_requires_account_scopes() -> None:
+    connection = StubConnection()
+    session = StubSession(connection)
+    request = _build_request(session, [])
+
+    with pytest.raises(RuntimeError, match="account scopes"):
+        with db_session(request):
+            pass
+
+    # Session factory should not have been invoked because scopes were invalid.
+    assert session.commits == 0
+    assert session.rollbacks == 0
+    assert session.closed == 0
+    assert connection.commands == []
+
+
+def test_db_session_noop_for_non_postgres() -> None:
+    connection = StubConnection(dialect_name="sqlite")
+    session = StubSession(connection)
+    request = _build_request(session, ["acct-1"])
+
+    with db_session(request):
+        pass
+
+    # No Postgres-specific commands should be emitted for other dialects.
+    assert connection.commands == []
+    assert connection.execution_calls == []
+    assert session.commits == 1
+    assert session.closed == 1


### PR DESCRIPTION
## Summary
- add a reusable `db_session` context manager that applies `app.account_scopes` via `set_config`
- ensure the helper gracefully handles missing FastAPI/SQLAlchemy imports and resets scopes on cleanup
- cover the session helper with unit tests including commit, rollback, and non-Postgres scenarios

## Testing
- pytest tests/common/test_pg_session.py

------
https://chatgpt.com/codex/tasks/task_e_68ded7d38e1883219cc3decb56bb723a