### PR TITLE
Enforce USD-quoted symbol validation across services

### DIFF
--- a/ml/training/data_loader_coingecko.py
+++ b/ml/training/data_loader_coingecko.py
@@ -410,6 +410,9 @@ def load_history(
     engine = _get_engine()
     _ensure_runs_table(engine)
 
+    if vs_currency.strip().lower() != "usd":
+        raise ValueError("Only USD quote currency is supported")
+
     if resume:
         try:
             run_uuid = UUID(resume)

--- a/tests/unit/services/test_universe_service.py
+++ b/tests/unit/services/test_universe_service.py
@@ -121,3 +121,10 @@ def test_override_symbol_rejects_unauthorized(universe_client: TestClient) -> No
         universe_service.app.dependency_overrides[universe_service.require_admin_account] = lambda: "ops-admin"
 
     assert response.status_code == 403
+
+
+def test_normalize_market_requires_usd_quote() -> None:
+    assert universe_service._normalize_market("BTC-EUR") is None
+    assert universe_service._normalize_market("XBTEUR") is None
+    assert universe_service._normalize_market("BTC/USDT") is None
+    assert universe_service._normalize_market("XXBTZUSD") == "BTC-USD"

--- a/tests/unit/test_training_service_validation.py
+++ b/tests/unit/test_training_service_validation.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi is required for training service validation tests")
+pytest.importorskip("sqlalchemy", reason="sqlalchemy is required for training service validation tests")
+
+from fastapi.testclient import TestClient
+
+try:  # pragma: no cover - skip the suite when dependencies are unavailable.
+    import training_service
+    _training_service_import_error: Exception | None = None
+except Exception as exc:  # noqa: BLE001
+    training_service = None  # type: ignore[assignment]
+    _training_service_import_error = exc
+
+
+@pytest.fixture
+def training_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Provide a test client without scheduling background jobs."""
+
+    if _training_service_import_error is not None:
+        pytest.skip(f"training_service unavailable: {_training_service_import_error}")
+
+    async def _noop_register_job(state):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(training_service, "_register_job", _noop_register_job)
+    return TestClient(training_service.app)
+
+
+def _request_payload(symbol: str) -> dict[str, object]:
+    now = datetime.now(timezone.utc)
+    return {
+        "symbols": [symbol],
+        "from": (now - timedelta(days=1)).isoformat(),
+        "to": now.isoformat(),
+        "gran": ["1h"],
+        "feature_version": "v1",
+        "model": "lstm",
+        "curriculum": False,
+        "label_horizon": "15m",
+        "run_name": "test-run",
+    }
+
+
+def test_start_training_rejects_non_usd(training_client: TestClient) -> None:
+    response = training_client.post("/ml/train/start", json=_request_payload("BTC-EUR"))
+    assert response.status_code == 400
+    assert "Only USD-quoted symbols" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- tighten Kraken whitelist normalisation so only USD-quoted markets are emitted while still reading existing feature keys
- reject non-USD trading symbols during training requests and canonicalise USD-denominated pairs before scheduling jobs
- require USD in the CoinGecko history loader and cover the new validation with focused unit tests

## Testing
- pytest tests/unit/services/test_universe_service.py tests/unit/test_training_service_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68dedbd2ba0c832189587f30bf3d7d98