### PR TITLE
Add Chrony drift monitoring and London timezone utilities

### DIFF
--- a/docs/runbooks/clock_drift.md
+++ b/docs/runbooks/clock_drift.md
@@ -1,0 +1,71 @@
+# Clock Drift Remediation Playbook
+
+Clock synchronisation is mandatory for regulatory audit trails and cross-venue
+latency comparisons. The `clock_drift_exceeds_200ms` Prometheus alert fires when
+Chrony reports more than 200 milliseconds of drift for at least 10 minutes.
+
+## Detection
+
+- Alert: `clock_drift_exceeds_200ms`
+- Severity: `critical`
+- Source metric: `chrony_tracking_last_offset_seconds` scraped from the
+  `chrony-monitor` DaemonSet.
+- Trigger condition: `abs(offset) > 0.2` for 10 minutes.
+
+## Immediate Actions
+
+1. **Acknowledge the alert** in PagerDuty and join the `#ops` Slack channel.
+2. **Identify affected nodes** by inspecting the alert labels (`instance` and
+   `node`) and querying Prometheus:
+   ```promql
+   chrony_tracking_last_offset_seconds{node="$NODE"}
+   ```
+3. **Check Chrony health** on the node:
+   ```bash
+   kubectl -n observability exec -it ds/chrony-monitor -c chronyd -- chronyc tracking
+   kubectl -n observability exec -it ds/chrony-monitor -c chronyd -- chronyc sources -v
+   ```
+4. **Verify host time** against a reference:
+   ```bash
+   kubectl -n observability exec -it ds/chrony-monitor -c chronyd -- date -u
+   ```
+5. **Inspect node conditions** for NTP/clock issues (kernel logs, `dmesg`,
+   virtualization host warnings).
+
+## Remediation Steps
+
+1. **Resync the node clock**:
+   ```bash
+   kubectl -n observability exec -it ds/chrony-monitor -c chronyd -- chronyc makestep
+   ```
+2. **Restart Chrony sidecar** if the offset persists:
+   ```bash
+   kubectl -n observability rollout restart ds/chrony-monitor
+   ```
+3. **Cordoning and draining**
+   - If drift remains above 200 ms after resync, cordon the node to prevent
+     trading workloads from scheduling:
+     ```bash
+     kubectl cordon $NODE
+     kubectl drain $NODE --ignore-daemonsets --delete-emptydir-data
+     ```
+   - Engage the platform team to investigate hypervisor clock sources.
+4. **Swap out hardware** when drift is correlated with specific bare-metal
+   hosts. Document the serial number and open a vendor ticket.
+
+## Post Incident
+
+1. Capture a snapshot of Chrony stats for the incident ticket:
+   ```bash
+   kubectl -n observability exec -it ds/chrony-monitor -c chronyd -- chronyc sourcestats
+   ```
+2. Submit an incident timeline including:
+   - When the alert fired and was acknowledged.
+   - Nodes impacted and remedial actions taken.
+   - Any secondary impacts (missed fills, reconciliation delays).
+3. File a retrospective if drift exceeded 500 ms or impacted market access.
+4. Update this runbook with contributing factors and mitigation learnings.
+
+## Related Resources
+
+- [Ops On-call Handbook](./oncall.md)

--- a/frontend/components/ApiKeyForm.tsx
+++ b/frontend/components/ApiKeyForm.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 type KrakenStatusResponse = {
@@ -27,13 +28,8 @@ const formatTimestamp = (timestamp?: string | null) => {
     return "Never";
   }
 
-  const date = new Date(timestamp);
-
-  if (Number.isNaN(date.getTime())) {
-    return timestamp;
-  }
-
-  return date.toLocaleString();
+  const formatted = formatLondonTime(timestamp);
+  return formatted || "Never";
 };
 
 const ApiKeyForm: React.FC = () => {

--- a/frontend/components/ApiKeyManager.tsx
+++ b/frontend/components/ApiKeyManager.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useState } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 type SecretsStatusResponse = {
@@ -23,13 +24,8 @@ const formatTimestamp = (timestamp?: string | null) => {
     return "Never";
   }
 
-  const date = new Date(timestamp);
-
-  if (Number.isNaN(date.getTime())) {
-    return timestamp;
-  }
-
-  return date.toLocaleString();
+  const formatted = formatLondonTime(timestamp);
+  return formatted || "Never";
 };
 
 const ApiKeyManager: React.FC = () => {

--- a/frontend/components/AuditViewer.tsx
+++ b/frontend/components/AuditViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { formatLondonTime } from "./timezone";
 
 type AuditLogEntry = {
   id?: string;
@@ -207,15 +208,11 @@ const formatTimestamp = (value: string): string => {
   if (!value) {
     return "—";
   }
-  const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) {
+  const formatted = formatLondonTime(value);
+  if (!formatted) {
     return value;
   }
-  try {
-    return new Date(parsed).toLocaleString();
-  } catch (error) {
-    return value;
-  }
+  return formatted;
 };
 
 const toCsvValue = (value: string): string => `"${value.replace(/"/g, '""')}"`;

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 interface ExposureBreakdown {
@@ -415,7 +416,7 @@ const Dashboard: React.FC = () => {
 
       const payload = (await response.json()) as KrakenRotationResponse;
       const rotatedAt = payload.rotated_at
-        ? new Date(payload.rotated_at).toLocaleString()
+        ? formatLondonTime(payload.rotated_at) || payload.rotated_at
         : null;
 
       setRotationMessage(
@@ -495,7 +496,7 @@ const Dashboard: React.FC = () => {
           </span>
           {state.reportGeneratedAt && (
             <span>
-              Report synced {new Date(state.reportGeneratedAt).toLocaleString()}
+              Report synced {formatLondonTime(state.reportGeneratedAt) || state.reportGeneratedAt}
             </span>
           )}
           <button
@@ -614,7 +615,8 @@ const Dashboard: React.FC = () => {
                   <div>
                     <span className="text-slate-400">Generated</span>
                     <div className="font-medium text-white">
-                      {new Date(state.universe.generated_at).toLocaleString()}
+                      {formatLondonTime(state.universe.generated_at) ||
+                        state.universe.generated_at}
                     </div>
                   </div>
                   <div className="space-y-2">
@@ -751,7 +753,7 @@ const Dashboard: React.FC = () => {
                     <dt className="uppercase tracking-wide">Since</dt>
                     <dd className="text-slate-200">
                       {state.safeMode?.since
-                        ? new Date(state.safeMode.since).toLocaleString()
+                        ? formatLondonTime(state.safeMode.since) || state.safeMode.since
                         : "--"}
                     </dd>
                   </div>

--- a/frontend/components/DevSandbox.tsx
+++ b/frontend/components/DevSandbox.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 type TradeSide = "buy" | "sell";
@@ -291,15 +292,11 @@ const formatTimestamp = (value?: string) => {
   if (!value) {
     return "—";
   }
-  const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) {
+  const formatted = formatLondonTime(value);
+  if (!formatted) {
     return value;
   }
-  try {
-    return new Date(parsed).toLocaleString();
-  } catch (error) {
-    return value;
-  }
+  return formatted;
 };
 
 const DevSandbox: React.FC = () => {

--- a/frontend/components/DirectorControls.tsx
+++ b/frontend/components/DirectorControls.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 interface SafeModeStatusResponse {
@@ -58,12 +59,8 @@ const formatTimestamp = (timestamp?: string | null) => {
     return "Unknown";
   }
 
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) {
-    return timestamp;
-  }
-
-  return date.toLocaleString();
+  const formatted = formatLondonTime(timestamp);
+  return formatted || "Unknown";
 };
 
 const ensureString = (value: unknown): string => {

--- a/frontend/components/SafeModePanel.tsx
+++ b/frontend/components/SafeModePanel.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 type SafeModeStatusResponse = {
@@ -20,12 +21,8 @@ const formatTimestamp = (timestamp?: string | null) => {
     return "Unknown";
   }
 
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) {
-    return timestamp;
-  }
-
-  return date.toLocaleString();
+  const formatted = formatLondonTime(timestamp);
+  return formatted || "Unknown";
 };
 
 const deriveEventLabel = (entry: SafeModeAuditEntry) => {

--- a/frontend/components/TrainingPanel.tsx
+++ b/frontend/components/TrainingPanel.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { formatLondonTime } from "./timezone";
 import { useAuthClaims } from "./useAuthClaims";
 
 type TrainingStartResponse = {
@@ -66,22 +67,12 @@ const normalizeTimestamp = (value?: string | number) => {
     return "—";
   }
 
-  const parsed =
-    typeof value === "number"
-      ? value
-      : Number.isNaN(Date.parse(value))
-      ? null
-      : Date.parse(value);
-
-  if (!parsed || Number.isNaN(parsed)) {
+  const formatted = formatLondonTime(value ?? null);
+  if (!formatted) {
     return typeof value === "string" ? value : String(value);
   }
 
-  try {
-    return new Date(parsed).toLocaleString();
-  } catch (error) {
-    return typeof value === "string" ? value : String(value);
-  }
+  return formatted;
 };
 
 const normalizeProgress = (value: unknown): string => {

--- a/frontend/components/timezone.ts
+++ b/frontend/components/timezone.ts
@@ -1,0 +1,53 @@
+const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+  timeZone: "Europe/London",
+};
+
+const defaultFormatter = new Intl.DateTimeFormat("en-GB", DEFAULT_OPTIONS);
+
+export type DateLike = string | number | Date | null | undefined;
+
+function toDate(value: DateLike): Date | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function formatLondonTime(
+  value: DateLike,
+  options?: Intl.DateTimeFormatOptions,
+  fallback?: string
+): string {
+  const date = toDate(value);
+
+  if (!date) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+
+    return typeof value === "string" ? value : "";
+  }
+
+  if (!options) {
+    return defaultFormatter.format(date);
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    timeZone: "Europe/London",
+  }).format(date);
+}

--- a/ops/monitoring/prometheus-rules.yaml
+++ b/ops/monitoring/prometheus-rules.yaml
@@ -123,3 +123,18 @@ spec:
             summary: OMS submission latency p95 above 500 ms for {{ $labels.symbol }}/{{ $labels.account_id }}
             runbook: docs/runbooks/oms_latency.md
             slo_reference: docs/slo.md#oms-latency
+    - name: infra.clock
+      rules:
+        - alert: clock_drift_exceeds_200ms
+          expr: |
+            max_over_time(abs(chrony_tracking_last_offset_seconds)[5m]) > 0.2
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Clock drift above 200 ms detected on {{ $labels.instance }}
+            description: >-
+              The Chrony exporter reported wall-clock drift greater than 200 ms for the
+              last 10 minutes. Trading systems rely on sub-200 ms synchronisation to
+              validate exchange timestamps and regulatory audit trails.
+            runbook: docs/runbooks/clock_drift.md

--- a/ops/monitoring/time-sync/chrony-daemonset.yaml
+++ b/ops/monitoring/time-sync/chrony-daemonset.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chrony-monitor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chrony-config
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+  annotations:
+    description: Chrony configuration tuned for low-latency trading workloads
+data:
+  chrony.conf: |
+    driftfile /var/lib/chrony/chrony.drift
+    makestep 0.5 3
+    rtcsync
+    logdir /var/log/chrony
+    cmdallow 127.0.0.1
+    noclientlog
+    pool time.cloudflare.com iburst maxsources 4
+    pool time.google.com iburst maxsources 4
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chrony-monitor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: chrony-monitor
+      app.kubernetes.io/component: time-sync
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: chrony-monitor
+        app.kubernetes.io/component: time-sync
+    spec:
+      serviceAccountName: chrony-monitor
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      securityContext:
+        runAsNonRoot: false
+      volumes:
+        - name: chrony-config
+          configMap:
+            name: chrony-config
+        - name: chrony-state
+          hostPath:
+            path: /var/lib/chrony
+            type: DirectoryOrCreate
+        - name: chrony-run
+          hostPath:
+            path: /run/chrony
+            type: DirectoryOrCreate
+      containers:
+        - name: chronyd
+          image: ghcr.io/cloudnativelabs/chrony:0.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -f
+            - /etc/chrony/chrony.conf
+            - -d
+          securityContext:
+            capabilities:
+              add:
+                - SYS_TIME
+                - SYS_NICE
+          ports:
+            - containerPort: 323
+              name: ntp
+              protocol: UDP
+          volumeMounts:
+            - mountPath: /etc/chrony
+              name: chrony-config
+            - mountPath: /var/lib/chrony
+              name: chrony-state
+            - mountPath: /run/chrony
+              name: chrony-run
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+        - name: chrony-exporter
+          image: ghcr.io/cloudnativelabs/chrony-exporter:0.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --addr=0.0.0.0:9123
+            - --chronyc-path=/usr/bin/chronyc
+            - --tracking
+          env:
+            - name: CHRONYC_HOST
+              value: 127.0.0.1
+            - name: CHRONYC_PORT
+              value: "323"
+          ports:
+            - containerPort: 9123
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /run/chrony
+              name: chrony-run
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chrony-monitor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+spec:
+  selector:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 9123
+      targetPort: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: chrony-monitor
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: chrony-monitor
+    app.kubernetes.io/component: time-sync
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: chrony-monitor
+      app.kubernetes.io/component: time-sync
+  namespaceSelector:
+    matchNames:
+      - observability
+  endpoints:
+    - port: metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true
+      metricRelabelings:
+        - action: replace
+          sourceLabels: [instance]
+          targetLabel: node

--- a/report_service.py
+++ b/report_service.py
@@ -26,6 +26,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from reports.storage import ArtifactStorage, build_storage_from_env
+from shared.timezone import format_london_time
 from services.models.model_server import get_active_model
 
 try:  # pragma: no cover - psycopg is an optional dependency in tests
@@ -548,12 +549,18 @@ def _regime_detection(frame: pd.DataFrame) -> list[dict[str, Any]]:
     else:
         volatility = float(returns.std())
     regime = "high_volatility" if volatility > 0.02 else "normal"
+    start = ""
+    end = ""
+    if not timestamps.isna().all():
+        start = format_london_time(timestamps.min())
+        end = format_london_time(timestamps.max())
+
     return [
         {
             "regime": regime,
             "volatility": volatility,
-            "start": timestamps.min().isoformat() if not timestamps.isna().all() else "",
-            "end": timestamps.max().isoformat() if not timestamps.isna().all() else "",
+            "start": start,
+            "end": end,
         }
     ]
 

--- a/shared/timezone.py
+++ b/shared/timezone.py
@@ -1,0 +1,66 @@
+"""Utilities for formatting timestamps in Europe/London with DST awareness."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from zoneinfo import ZoneInfo
+
+_LONDON_TZ = ZoneInfo("Europe/London")
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    """Convert *value* to :class:`datetime`.
+
+    ``pandas.Timestamp`` and ``numpy.datetime64`` instances expose ``to_pydatetime``
+    which we invoke when available so downstream code can operate on the standard
+    library ``datetime`` type. Values that are already ``datetime`` instances are
+    returned as-is. For naive datetimes we assume they are expressed in UTC because
+    that is the platform-wide storage convention.
+    """
+
+    if isinstance(value, datetime):
+        candidate = value
+    elif hasattr(value, "to_pydatetime"):
+        candidate = value.to_pydatetime()  # type: ignore[assignment]
+    else:
+        raise TypeError(f"Unsupported timestamp type: {type(value)!r}")
+
+    if candidate.tzinfo is None:
+        return candidate.replace(tzinfo=timezone.utc)
+    return candidate
+
+
+def as_london_time(value: Any) -> datetime:
+    """Return *value* converted to the Europe/London timezone.
+
+    The helper accepts ``datetime`` objects and pandas timestamps. DST transitions
+    are handled via :mod:`zoneinfo`, ensuring the correct GMT/BST offset is applied
+    for reporting and frontend presentation layers.
+    """
+
+    aware = _coerce_datetime(value)
+    return aware.astimezone(_LONDON_TZ)
+
+
+def format_london_time(value: Any, fmt: str = "%Y-%m-%d %H:%M:%S %Z") -> str:
+    """Format *value* using the Europe/London timezone.
+
+    Parameters
+    ----------
+    value:
+        Any datetime-like object accepted by :func:`as_london_time`.
+    fmt:
+        ``strftime``-style format string. Defaults to ``"%Y-%m-%d %H:%M:%S %Z"``.
+
+    Returns
+    -------
+    str
+        A string representation of ``value`` with DST-aware timezone information.
+    """
+
+    return as_london_time(value).strftime(fmt)
+
+
+__all__ = ["as_london_time", "format_london_time"]

--- a/tests/unit/test_timezone_utils.py
+++ b/tests/unit/test_timezone_utils.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from shared.timezone import as_london_time, format_london_time
+
+
+@pytest.mark.parametrize(
+    "instant,expected",
+    [
+        (datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc), "2024-01-15 12:00:00 GMT"),
+        (datetime(2024, 6, 15, 12, 0, tzinfo=timezone.utc), "2024-06-15 13:00:00 BST"),
+    ],
+)
+def test_format_london_time_handles_seasonal_offsets(instant: datetime, expected: str) -> None:
+    """Formatting respects GMT/BST offsets for winter and summer dates."""
+
+    assert format_london_time(instant) == expected
+
+
+def test_as_london_time_handles_dst_transition_forward() -> None:
+    """Times immediately before and after the DST change map to correct offsets."""
+
+    before_change = datetime(2024, 3, 31, 0, 30, tzinfo=timezone.utc)
+    after_change = datetime(2024, 3, 31, 1, 30, tzinfo=timezone.utc)
+
+    before_local = as_london_time(before_change)
+    after_local = as_london_time(after_change)
+
+    assert before_local.tzname() == "GMT"
+    assert before_local.hour == 0
+    assert after_local.tzname() == "BST"
+    assert after_local.hour == 2
+
+
+def test_naive_datetime_assumed_to_be_utc() -> None:
+    """Naive datetimes are treated as UTC and converted to London time."""
+
+    naive = datetime(2024, 10, 1, 8, 30)
+
+    result = as_london_time(naive)
+
+    assert result.tzname() == "BST"
+    assert result.hour == 9


### PR DESCRIPTION
## Summary
- add a Chrony-based DaemonSet and Prometheus alert to monitor clock drift beyond 200 ms
- add DST-aware London timezone helpers used by the backend and frontend timestamp formatting
- document the clock drift remediation playbook and add automated DST regression tests

## Testing
- pytest tests/unit/test_timezone_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dee7284b4883219ebd6950d9242b06