### PR TITLE
Ensure policy fee math uses Decimal precision

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Iterable, List
 
@@ -246,20 +247,22 @@ def test_full_pipeline_records_audit_metrics_and_safe_mode(
     fees_client = TestClient(fees_app)
 
     async def fake_fetch_effective_fee(
-        account_id: str, symbol: str, liquidity: str, notional: float
-    ) -> float:
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        notional_decimal = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        notional_str = f"{notional_decimal.quantize(Decimal('0.00000001'), rounding=ROUND_HALF_UP)}"
         response = fees_client.get(
             "/fees/effective",
             params={
                 "pair": symbol,
                 "liquidity": liquidity,
-                "notional": f"{max(notional, 0.0):.8f}",
+                "notional": notional_str,
             },
             headers={"X-Account-ID": account_id},
         )
         response.raise_for_status()
         payload = response.json()
-        return float(payload["bps"])
+        return Decimal(str(payload["bps"]))
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", fake_fetch_effective_fee)
 
@@ -505,19 +508,21 @@ async def test_trading_sequencer_loop_preserves_correlation_and_audit(
     policy_service.ENABLE_SHADOW_EXECUTION = False
 
     async def fake_fetch_effective_fee(
-        account_id: str, symbol: str, liquidity: str, notional: float
-    ) -> float:
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        notional_decimal = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        notional_str = f"{notional_decimal.quantize(Decimal('0.00000001'), rounding=ROUND_HALF_UP)}"
         response = fees_client.get(
             "/fees/effective",
             params={
                 "pair": symbol,
                 "liquidity": liquidity,
-                "notional": f"{max(notional, 0.0):.8f}",
+                "notional": notional_str,
             },
             headers={"X-Account-ID": account_id},
         )
         response.raise_for_status()
-        return float(response.json()["bps"])
+        return Decimal(str(response.json()["bps"]))
 
     async def noop_submit_execution(*_: Any, **__: Any) -> None:
         return None
@@ -710,19 +715,21 @@ def test_policy_risk_oms_flow_emits_hashed_audit_and_metrics(
     policy_service.ENABLE_SHADOW_EXECUTION = False
 
     async def fake_fetch_effective_fee(
-        account_id: str, symbol: str, liquidity: str, notional: float
-    ) -> float:
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        notional_decimal = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        notional_str = f"{notional_decimal.quantize(Decimal('0.00000001'), rounding=ROUND_HALF_UP)}"
         response = fees_client.get(
             "/fees/effective",
             params={
                 "pair": symbol,
                 "liquidity": liquidity,
-                "notional": f"{max(notional, 0.0):.8f}",
+                "notional": notional_str,
             },
             headers={"X-Account-ID": account_id},
         )
         response.raise_for_status()
-        return float(response.json()["bps"])
+        return Decimal(str(response.json()["bps"]))
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", fake_fetch_effective_fee)
 
@@ -964,19 +971,21 @@ def test_pipeline_handles_flash_crash_and_feed_outage(
     policy_service.ENABLE_SHADOW_EXECUTION = False
 
     async def fake_fetch_effective_fee(
-        account: str, pair: str, liquidity: str, notional: float
-    ) -> float:
+        account: str, pair: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        notional_decimal = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        notional_str = f"{notional_decimal.quantize(Decimal('0.00000001'), rounding=ROUND_HALF_UP)}"
         response = fees_client.get(
             "/fees/effective",
             params={
                 "pair": pair,
                 "liquidity": liquidity,
-                "notional": f"{max(notional, 0.0):.8f}",
+                "notional": notional_str,
             },
             headers={"X-Account-ID": account},
         )
         response.raise_for_status()
-        return float(response.json()["bps"])
+        return Decimal(str(response.json()["bps"]))
 
     async def noop_submit_execution(*_: Any, **__: Any) -> None:
         return None
@@ -1238,19 +1247,21 @@ def test_trading_sequencer_lifecycle_preserves_correlation_and_audit_chain(
     policy_service.ENABLE_SHADOW_EXECUTION = False
 
     async def fake_fetch_effective_fee(
-        account_id: str, symbol: str, liquidity: str, notional: float
-    ) -> float:
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        notional_decimal = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        notional_str = f"{notional_decimal.quantize(Decimal('0.00000001'), rounding=ROUND_HALF_UP)}"
         response = fees_client.get(
             "/fees/effective",
             params={
                 "pair": symbol,
                 "liquidity": liquidity,
-                "notional": f"{max(notional, 0.0):.8f}",
+                "notional": notional_str,
             },
             headers={"X-Account-ID": account_id},
         )
         response.raise_for_status()
-        return float(response.json()["bps"])
+        return Decimal(str(response.json()["bps"]))
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", fake_fetch_effective_fee)
 

--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
+from decimal import Decimal
 from uuid import uuid4
 
 import pytest
@@ -83,8 +84,10 @@ def test_decide_policy_accepts_dataclass_intent(monkeypatch: pytest.MonkeyPatch,
         approved=True,
     )
 
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
-        return {"maker": 4.0, "taker": 7.0}[liquidity]
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return {"maker": Decimal("4.0"), "taker": Decimal("7.0")}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(policy_service, "predict_intent", lambda **_: intent)

--- a/tests/policy/test_policy_service_v2.py
+++ b/tests/policy/test_policy_service_v2.py
@@ -49,13 +49,16 @@ def _intent() -> Intent:
 
 
 def test_policy_service_decision(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
         assert account_id == "company"
         assert symbol == "BTC-USD"
         assert liquidity in {"maker", "taker"}
-        expected_notional = float(Decimal("30120.5") * Decimal("0.1235"))
-        assert notional == pytest.approx(expected_notional)
-        return 4.5
+        dec_notional = notional if isinstance(notional, Decimal) else Decimal(str(notional))
+        expected_notional = Decimal("30120.5") * Decimal("0.1235")
+        assert dec_notional == expected_notional
+        return Decimal("4.5")
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(policy_service, "predict_intent", lambda **_: _intent())

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -90,22 +90,31 @@ def _intent(*, edge_bps: float, approved: bool, selected: str, reason: str | Non
 def _validate_response(payload: dict) -> PolicyDecisionResponse:
     return PolicyDecisionResponse.model_validate(payload)
 
+
+def _coerce_decimal(value: float | Decimal) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
 def test_policy_decide_approves_when_edge_beats_costs(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
     recorded: List[dict[str, object]] = []
     dispatched: List[dict[str, object]] = []
 
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        dec_notional = _coerce_decimal(notional)
         recorded.append(
             {
                 "account_id": account_id,
                 "symbol": symbol,
                 "liquidity": liquidity,
-                "notional": notional,
+                "notional": dec_notional,
             }
         )
-        return {"maker": 4.5, "taker": 7.5}[liquidity]
+        return {"maker": Decimal("4.5"), "taker": Decimal("7.5")}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
@@ -172,19 +181,19 @@ def test_policy_decide_approves_when_edge_beats_costs(
 
     snapped_price = Decimal("30120.5")
     snapped_quantity = Decimal("0.1235")
-    expected_notional = float(snapped_price * snapped_quantity)
+    expected_notional = snapped_price * snapped_quantity
     assert recorded == [
         {
             "account_id": "company",
             "symbol": "BTC-USD",
             "liquidity": "maker",
-            "notional": pytest.approx(expected_notional),
+            "notional": expected_notional,
         },
         {
             "account_id": "company",
             "symbol": "BTC-USD",
             "liquidity": "taker",
-            "notional": pytest.approx(expected_notional),
+            "notional": expected_notional,
         },
     ]
     assert dispatched == [
@@ -192,11 +201,55 @@ def test_policy_decide_approves_when_edge_beats_costs(
     ]
 
 
+def test_policy_decide_preserves_tick_precision(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    captured: list[Decimal] = []
+
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        dec_notional = _coerce_decimal(notional)
+        captured.append(dec_notional)
+        return {"maker": Decimal("1.2345"), "taker": Decimal("2.3456")}[liquidity]
+
+    monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
+    monkeypatch.setitem(
+        policy_service.KRAKEN_PRECISION,
+        "TST-USD",
+        {"tick": 0.00000001, "lot": 0.00000001},
+    )
+
+    payload = {
+        "account_id": "company",
+        "order_id": "precise-1",
+        "instrument": "TST-USD",
+        "side": "BUY",
+        "quantity": 0.12345678,
+        "price": 1.23456789,
+        "fee": {"currency": "USD", "maker": 0.0, "taker": 0.0},
+        "features": [0.0, 0.0],
+        "book_snapshot": {"mid_price": 1.23456789, "spread_bps": 0.1, "imbalance": 0.0},
+    }
+
+    response = client.post("/policy/decide", json=payload)
+    assert response.status_code == 200
+
+    expected_notional = Decimal("1.23456789") * Decimal("0.12345678")
+    assert captured == [expected_notional, expected_notional]
+
+    body = _validate_response(response.json())
+    assert body.effective_fee.maker == pytest.approx(1.2345)
+    assert body.effective_fee.taker == pytest.approx(2.3456)
+
+
 def test_policy_decide_rejects_when_slippage_erodes_edge(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
-        return {"maker": 4.0, "taker": 6.0}[liquidity]
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return {"maker": Decimal("4.0"), "taker": Decimal("6.0")}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
@@ -230,8 +283,10 @@ def test_policy_decide_rejects_when_slippage_erodes_edge(
 def test_policy_decide_honours_request_risk_overrides(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
-        return 4.5
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return Decimal("4.5")
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
@@ -263,8 +318,8 @@ def test_policy_decide_honours_request_risk_overrides(
 
 
 def test_policy_decide_rejects_unknown_account(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
-    async def _fake_fee(*_: object, **__: object) -> float:
-        return 4.5
+    async def _fake_fee(*_: object, **__: object) -> Decimal:
+        return Decimal("4.5")
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
@@ -321,8 +376,10 @@ def test_policy_decide_requires_authorization(client: TestClient) -> None:
 def test_policy_decide_rejects_when_costs_exceed_edge(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    async def _fake_fee(account_id: str, symbol: str, liquidity: str, notional: float) -> float:
-        return {"maker": 18.0, "taker": 21.0}[liquidity]
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return {"maker": Decimal("18.0"), "taker": Decimal("21.0")}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
     monkeypatch.setattr(
@@ -541,7 +598,8 @@ async def test_fetch_effective_fee_parses_flat_payload(monkeypatch: pytest.Monke
         notional=123.456789,
     )
 
-    assert fee == pytest.approx(5.25)
+    assert isinstance(fee, Decimal)
+    assert fee == Decimal("5.25")
     request = recorded["request"]
     assert request["path"] == "/fees/effective"
     assert request["headers"] == {"X-Account-ID": "acct-123"}


### PR DESCRIPTION
## Summary
- keep notional, fee, and edge calculations in `policy_service` on `Decimal` values and defer float conversion to response serialization
- add a precision regression test for tick-sized inputs and update policy API tests to capture Decimal notional flow
- align integration and unit test stubs with the Decimal-returning fee helper

## Testing
- pytest tests/test_policy_service_api.py -k precision *(skipped: fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dee723ceb883218d9b7699fd39b611