### PR TITLE
Handle stale Kraken feeds before routing

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -85,6 +85,13 @@ _oms_child_orders_total = Counter(
     registry=_REGISTRY,
 )
 
+_oms_stale_feed_total = Counter(
+    "oms_stale_feed_total",
+    "Number of OMS operations impacted by stale data feeds.",
+    ["service", "account", "symbol", "source", "action"],
+    registry=_REGISTRY,
+)
+
 _oms_latency_ms = Gauge(
     "oms_latency_ms",
     "Current latency of OMS interactions in milliseconds.",
@@ -203,6 +210,7 @@ _METRICS: Dict[str, Counter | Gauge | Histogram] = {
     "oms_errors_total": _oms_errors_total,
     "oms_auth_failures_total": _oms_auth_failures_total,
     "oms_child_orders_total": _oms_child_orders_total,
+    "oms_stale_feed_total": _oms_stale_feed_total,
     "oms_latency_ms": _oms_latency_ms,
     "pipeline_latency_ms": _pipeline_latency_ms,
     "policy_abstention_rate": _policy_abstention_rate,
@@ -471,6 +479,23 @@ def increment_oms_child_orders_total(
     ).inc()
 
 
+def increment_oms_stale_feed(
+    account: str,
+    symbol: str,
+    *,
+    source: str,
+    action: str,
+    service: Optional[str] = None,
+) -> None:
+    _oms_stale_feed_total.labels(
+        service=_service_value(service),
+        account=_normalised(account, "unknown"),
+        symbol=_normalised(symbol, "unknown"),
+        source=_normalised(source, "unknown"),
+        action=_normalised(action, "unknown"),
+    ).inc()
+
+
 def set_oms_latency(
     latency_ms: float,
     *,
@@ -636,6 +661,7 @@ __all__ = [
     "increment_oms_error_count",
     "increment_oms_auth_failures",
     "increment_oms_child_orders_total",
+    "increment_oms_stale_feed",
     "set_oms_latency",
     "record_oms_latency",
     "set_pipeline_latency",

--- a/services/oms/kraken_ws.py
+++ b/services/oms/kraken_ws.py
@@ -118,6 +118,7 @@ class KrakenWSClient:
         self._reqid = 1
         self._backoff = _JitterBackoff()
         self._subscriptions: List[List[str]] = []
+        self._last_private_heartbeat: Optional[float] = None
 
     async def _default_transport(self, url: str) -> _WebsocketTransport:
         protocol = await websockets.connect(url, ping_interval=None)
@@ -375,6 +376,7 @@ class KrakenWSClient:
         elif channel == "ownTrades":
             await self._handle_own_trades(payload)
         elif channel == "heartbeat":
+            self._last_private_heartbeat = time.time()
             return
         else:
             logger.debug("Unhandled websocket payload: %s", payload)
@@ -440,6 +442,11 @@ class KrakenWSClient:
     def _next_reqid(self) -> int:
         self._reqid += 1
         return self._reqid
+
+    def heartbeat_age(self) -> Optional[float]:
+        if self._last_private_heartbeat is None:
+            return None
+        return max(time.time() - self._last_private_heartbeat, 0.0)
 
 
 def _to_float(value: Any) -> Optional[float]:

--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -44,6 +44,7 @@ from metrics import (
     increment_oms_auth_failures,
     increment_oms_child_orders_total,
     increment_oms_error_count,
+    increment_oms_stale_feed,
     record_oms_latency,
     setup_metrics,
 )
@@ -451,6 +452,16 @@ class _PublicOrderBookState:
         async with self._lock:
             return self._last_ts
 
+    async def is_stale(self, threshold_seconds: float) -> bool:
+        if threshold_seconds <= 0:
+            return False
+        async with self._lock:
+            last_ts = self._last_ts
+            ready = self._ready.is_set()
+        if not ready or last_ts is None:
+            return True
+        return (time.time() - last_ts) > threshold_seconds
+
 
 class KrakenOrderBookStore:
     def __init__(self, depth: int = 10) -> None:
@@ -740,6 +751,13 @@ class AccountContext:
         self._reconcile_task: Optional[asyncio.Task[None]] = None
         self._reconcile_interval = max(float(os.environ.get("OMS_RECONCILE_INTERVAL", "30")), 0.0)
         self._reconcile_lock = asyncio.Lock()
+        try:
+            self._feed_sla_seconds = max(
+                float(os.environ.get("OMS_FEED_SLA_SECONDS", "2.0")),
+                0.0,
+            )
+        except ValueError:
+            self._feed_sla_seconds = 2.0
 
 
     async def _throttle_ws(self, endpoint: str, *, urgent: bool = False) -> None:
@@ -1410,16 +1428,74 @@ class AccountContext:
             )
             book_symbol = _resolve_book_symbol(request.symbol, metadata)
             depth: Optional[Decimal] = None
+            book: _PublicOrderBookState | None = None
             try:
                 book = await order_book_store.ensure_book(book_symbol)
-                depth = await book.depth(request.side, levels=10)
             except Exception as exc:
                 logger.debug(
-                    "Unable to fetch order book depth for %s on account %s: %s",
+                    "Unable to fetch order book for %s on account %s: %s",
                     book_symbol,
                     self.account_id,
                     exc,
                 )
+            if book is not None:
+                try:
+                    if self._feed_sla_seconds > 0 and await book.is_stale(
+                        self._feed_sla_seconds
+                    ):
+                        last_update = await book.last_update()
+                        age = (
+                            max(time.time() - last_update, 0.0)
+                            if last_update is not None
+                            else None
+                        )
+                        increment_oms_stale_feed(
+                            self.account_id,
+                            request.symbol,
+                            source="public_order_book",
+                            action="rejected",
+                        )
+                        age_display = f"{age:.2f}s" if age is not None else "unknown"
+                        logger.warning(
+                            "Rejecting order for account %s symbol %s due to stale public order book (age=%s, threshold=%.2fs)",
+                            self.account_id,
+                            request.symbol,
+                            age_display,
+                            self._feed_sla_seconds,
+                        )
+                        raise HTTPException(
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            detail="Market data is stale; please retry",
+                        )
+                    depth = await book.depth(request.side, levels=10)
+                except HTTPException:
+                    raise
+                except Exception as exc:
+                    logger.debug(
+                        "Unable to fetch order book depth for %s on account %s: %s",
+                        book_symbol,
+                        self.account_id,
+                        exc,
+                    )
+
+            force_rest = False
+            if self._feed_sla_seconds > 0:
+                heartbeat_age = self.ws_client.heartbeat_age()
+                if heartbeat_age is not None and heartbeat_age > self._feed_sla_seconds:
+                    force_rest = True
+                    increment_oms_stale_feed(
+                        self.account_id,
+                        request.symbol,
+                        source="private_stream",
+                        action="rerouted",
+                    )
+                    logger.warning(
+                        "Private stream heartbeat stale for account %s symbol %s (age=%.2fs > %.2fs); forcing REST submission",
+                        self.account_id,
+                        request.symbol,
+                        heartbeat_age,
+                        self._feed_sla_seconds,
+                    )
 
             child_quantities = self._plan_child_quantities(request, qty, metadata, depth)
             if not child_quantities:
@@ -1450,7 +1526,11 @@ class AccountContext:
                     request, child_qty, px, client_id=child_client_base
                 )
                 ack, transport, client_id_used, _ = await self._submit_order_with_preference(
-                    payload, request.symbol, child_client_base
+                    payload,
+                    request.symbol,
+                    child_client_base,
+                    preferred_transport="rest" if force_rest else None,
+                    allow_fallback=not force_rest,
                 )
                 transports_used.add(transport)
                 child_result = self._order_result_from_ack(client_id_used, ack)
@@ -1781,6 +1861,9 @@ class AccountContext:
         payload: Dict[str, Any],
         symbol: str,
         base_client_id: str,
+        *,
+        preferred_transport: Optional[str] = None,
+        allow_fallback: bool = True,
     ) -> Tuple[OrderAck, str, str, float]:
         assert self.ws_client is not None
         assert self.rest_client is not None
@@ -1788,10 +1871,10 @@ class AccountContext:
         base_payload = dict(payload)
         base_payload.setdefault("idempotencyKey", base_client_id)
         self.routing.update_probe_template(base_payload)
-        preferred = self.routing.preferred_path
+        preferred = preferred_transport or self.routing.preferred_path
         transports = [preferred]
         fallback = "rest" if preferred == "websocket" else "websocket"
-        if fallback not in transports:
+        if allow_fallback and fallback not in transports:
             transports.append(fallback)
 
         ws_failed = False

--- a/tests/integration/test_warm_start.py
+++ b/tests/integration/test_warm_start.py
@@ -524,6 +524,9 @@ class StubWSClient(_ExchangeClientBase):
             await self._stream_update_cb(state)
         return ack
 
+    def heartbeat_age(self) -> float:
+        return 0.0
+
 
 class StubRESTClient(_ExchangeClientBase):
     def __init__(

--- a/tests/integration/test_ws_rest_fallback.py
+++ b/tests/integration/test_ws_rest_fallback.py
@@ -114,6 +114,9 @@ class _StubWSClient:
             await self._stream_update_cb(state)
         return ack
 
+    def heartbeat_age(self) -> float:
+        return 0.0
+
 
 class _StubRESTClient:
     def __init__(self, *, credential_getter, exchange) -> None:

--- a/tests/unit/services/test_oms_credentials.py
+++ b/tests/unit/services/test_oms_credentials.py
@@ -1,19 +1,44 @@
+import importlib.util
 import json
 import logging
+import sys
+import time
 from pathlib import Path
 from decimal import Decimal
+from typing import Any, Dict, List, Optional
 
 import pytest
 
 pytest.importorskip("fastapi")
 
-from services.oms import oms_service
-from services.oms.oms_service import (
+from fastapi import HTTPException, Request, status
+
+import metrics as metrics_module
+
+metrics_module.setup_metrics = lambda *_, **__: None  # type: ignore[assignment]
+metrics_module.init_metrics = lambda *_, **__: None  # type: ignore[assignment]
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "services" / "oms" / "oms_service.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("services.oms.oms_service", MODULE_PATH)
+assert MODULE_SPEC and MODULE_SPEC.loader
+oms_service = importlib.util.module_from_spec(MODULE_SPEC)
+
+
+async def _require_authorized_account(request: Request) -> str:
+    return request.headers.get("X-Account-ID", "test-account")
+
+
+oms_service.require_authorized_account = _require_authorized_account  # type: ignore[attr-defined]
+sys.modules.setdefault("services.oms.oms_service", oms_service)
+MODULE_SPEC.loader.exec_module(oms_service)
+
+from services.oms.oms_service import (  # type: ignore[no-redef]
     AccountContext,
     CredentialLoadError,
     CredentialWatcher,
     OMSPlaceRequest,
 )
+from services.oms.kraken_ws import OrderAck
 
 
 @pytest.mark.asyncio
@@ -136,3 +161,311 @@ async def test_account_context_start_reports_missing_credentials(
         "credential load error" in message.lower()
         for message in caplog.text.splitlines()
     )
+
+
+class _StubCredentialWatcher:
+    _instances: Dict[str, "_StubCredentialWatcher"] = {}
+
+    def __init__(self, account_id: str) -> None:
+        self.account_id = account_id
+
+    @classmethod
+    def instance(cls, account_id: str) -> "_StubCredentialWatcher":
+        existing = cls._instances.get(account_id)
+        if existing is None:
+            existing = cls(account_id)
+            cls._instances[account_id] = existing
+        return existing
+
+    async def start(self) -> None:
+        return None
+
+    async def get_credentials(self) -> Dict[str, str]:
+        return {
+            "api_key": "stub-key",
+            "api_secret": "stub-secret",
+            "ws_token": "stub-token",
+        }
+
+    async def get_metadata(self) -> Dict[str, Any]:
+        return {
+            "BTC/USD": {
+                "lot_step": "0.1",
+                "price_increment": "0.5",
+                "ordermin": "0.1",
+            }
+        }
+
+
+class _StubLatencyRouter:
+    def __init__(self, account_id: str) -> None:
+        self.account_id = account_id
+        self._preferred = "websocket"
+
+    async def start(self, ws_client: Any = None, rest_client: Any = None) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    @property
+    def preferred_path(self) -> str:
+        return self._preferred
+
+    def update_probe_template(self, payload: Dict[str, Any]) -> None:
+        return None
+
+    def record_latency(self, path: str, latency_ms: float) -> None:
+        return None
+
+    def status(self) -> Dict[str, Any]:  # pragma: no cover - helper for completeness
+        return {"ws_latency": None, "rest_latency": None, "preferred_path": self._preferred}
+
+
+class _StubImpactStore:
+    async def record_fill(self, **_: Any) -> None:
+        return None
+
+    async def impact_curve(self, **_: Any) -> List[Dict[str, Any]]:
+        return []
+
+
+class _StubWSClient:
+    def __init__(
+        self,
+        *,
+        credential_getter: Any,
+        stream_update_cb: Any,
+        heartbeat: Optional[float] = None,
+    ) -> None:
+        self._credential_getter = credential_getter
+        self._stream_update_cb = stream_update_cb
+        self._heartbeat_age = heartbeat
+        self.add_calls: List[Dict[str, Any]] = []
+
+    async def ensure_connected(self) -> None:
+        return None
+
+    async def subscribe_private(self, channels: List[str]) -> None:
+        del channels
+        return None
+
+    async def stream_handler(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def add_order(self, payload: Dict[str, Any]) -> OrderAck:
+        self.add_calls.append(dict(payload))
+        return OrderAck(
+            exchange_order_id="WS-1",
+            status="accepted",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+
+    def heartbeat_age(self) -> Optional[float]:
+        return self._heartbeat_age
+
+    def set_heartbeat_age(self, value: Optional[float]) -> None:
+        self._heartbeat_age = value
+
+
+class _StubRESTClient:
+    def __init__(self, *, credential_getter: Any) -> None:
+        self._credential_getter = credential_getter
+        self.submissions: List[Dict[str, Any]] = []
+
+    async def add_order(self, payload: Dict[str, Any]) -> OrderAck:
+        self.submissions.append(dict(payload))
+        return OrderAck(
+            exchange_order_id="REST-1",
+            status="accepted",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+
+    async def close(self) -> None:
+        return None
+
+    async def cancel_order(self, payload: Dict[str, Any]) -> OrderAck:
+        return OrderAck(
+            exchange_order_id=str(payload.get("txid") or "REST-1"),
+            status="cancelled",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+
+
+class _TestPlaceRequest(OMSPlaceRequest):
+    shadow: bool = False
+
+
+@pytest.mark.asyncio
+async def test_place_order_rejects_when_public_book_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _StubCredentialWatcher._instances = {}
+    monkeypatch.setattr(oms_service, "CredentialWatcher", _StubCredentialWatcher)
+    monkeypatch.setattr(oms_service, "LatencyRouter", _StubLatencyRouter)
+    monkeypatch.setattr(oms_service, "impact_store", _StubImpactStore())
+
+    ws_instances: List[_StubWSClient] = []
+
+    def _ws_factory(**kwargs: Any) -> _StubWSClient:
+        client = _StubWSClient(**kwargs)
+        client.set_heartbeat_age(0.1)
+        ws_instances.append(client)
+        return client
+
+    monkeypatch.setattr(oms_service, "KrakenWSClient", _ws_factory)
+    monkeypatch.setattr(oms_service, "KrakenRESTClient", lambda **kwargs: _StubRESTClient(**kwargs))
+    monkeypatch.setattr(oms_service, "increment_oms_child_orders_total", lambda *_, **__: None)
+    monkeypatch.setattr(oms_service, "record_oms_latency", lambda *_, **__: None)
+
+    metrics_calls: List[tuple[str, str, str, str, Optional[str]]] = []
+
+    def _record_metric(
+        account: str,
+        symbol: str,
+        *,
+        source: str,
+        action: str,
+        service: Optional[str] = None,
+    ) -> None:
+        metrics_calls.append((account, symbol, source, action, service))
+
+    monkeypatch.setattr(oms_service, "increment_oms_stale_feed", _record_metric)
+
+    class _StaleBook:
+        async def is_stale(self, threshold: float) -> bool:
+            assert threshold >= 0
+            return True
+
+        async def depth(self, side: str, levels: int = 10) -> Decimal:  # pragma: no cover - defensive
+            raise AssertionError("depth should not be queried for stale books")
+
+        async def last_update(self) -> float:
+            return time.time() - 5.0
+
+    class _BookStore:
+        def __init__(self, book: Any) -> None:
+            self.book = book
+
+        async def ensure_book(self, symbol: str) -> Any:
+            assert symbol == "BTC/USD"
+            return self.book
+
+    monkeypatch.setattr(oms_service, "order_book_store", _BookStore(_StaleBook()))
+
+    account = AccountContext("ACC-STALE")
+    request = _TestPlaceRequest(
+        account_id="ACC-STALE",
+        client_id="CID-STALE",
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        qty=Decimal("0.5"),
+        limit_px=Decimal("30000"),
+    )
+    request.shadow = False  # type: ignore[attr-defined]
+
+    with pytest.raises(HTTPException) as exc:
+        await account.place_order(request)
+
+    assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert metrics_calls == [("ACC-STALE", "BTC/USD", "public_order_book", "rejected", None)]
+    assert ws_instances and not ws_instances[0].add_calls
+
+    await account.close()
+
+
+@pytest.mark.asyncio
+async def test_place_order_reroutes_when_private_stream_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _StubCredentialWatcher._instances = {}
+    monkeypatch.setattr(oms_service, "CredentialWatcher", _StubCredentialWatcher)
+    monkeypatch.setattr(oms_service, "LatencyRouter", _StubLatencyRouter)
+    monkeypatch.setattr(oms_service, "impact_store", _StubImpactStore())
+
+    ws_instances: List[_StubWSClient] = []
+
+    def _ws_factory(**kwargs: Any) -> _StubWSClient:
+        client = _StubWSClient(**kwargs)
+        client.set_heartbeat_age(5.0)
+        ws_instances.append(client)
+        return client
+
+    rest_instances: List[_StubRESTClient] = []
+
+    def _rest_factory(**kwargs: Any) -> _StubRESTClient:
+        client = _StubRESTClient(**kwargs)
+        rest_instances.append(client)
+        return client
+
+    monkeypatch.setattr(oms_service, "KrakenWSClient", _ws_factory)
+    monkeypatch.setattr(oms_service, "KrakenRESTClient", _rest_factory)
+    monkeypatch.setattr(oms_service, "increment_oms_child_orders_total", lambda *_, **__: None)
+    monkeypatch.setattr(oms_service, "record_oms_latency", lambda *_, **__: None)
+
+    metrics_calls: List[tuple[str, str, str, str, Optional[str]]] = []
+
+    def _record_metric(
+        account: str,
+        symbol: str,
+        *,
+        source: str,
+        action: str,
+        service: Optional[str] = None,
+    ) -> None:
+        metrics_calls.append((account, symbol, source, action, service))
+
+    monkeypatch.setattr(oms_service, "increment_oms_stale_feed", _record_metric)
+
+    class _FreshBook:
+        async def is_stale(self, threshold: float) -> bool:
+            assert threshold >= 0
+            return False
+
+        async def depth(self, side: str, levels: int = 10) -> Decimal:
+            assert side in {"buy", "sell"}
+            return Decimal("1")
+
+        async def last_update(self) -> float:
+            return time.time()
+
+    class _BookStore:
+        def __init__(self, book: Any) -> None:
+            self.book = book
+
+        async def ensure_book(self, symbol: str) -> Any:
+            assert symbol == "BTC/USD"
+            return self.book
+
+    monkeypatch.setattr(oms_service, "order_book_store", _BookStore(_FreshBook()))
+
+    account = AccountContext("ACC-REST")
+    request = _TestPlaceRequest(
+        account_id="ACC-REST",
+        client_id="CID-REST",
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        qty=Decimal("0.25"),
+        limit_px=Decimal("30500"),
+    )
+    request.shadow = False  # type: ignore[attr-defined]
+
+    response = await account.place_order(request)
+
+    assert response.transport == "rest"
+    assert rest_instances and rest_instances[0].submissions
+    assert ws_instances and not ws_instances[0].add_calls
+    assert metrics_calls == [("ACC-REST", "BTC/USD", "private_stream", "rerouted", None)]
+
+    await account.close()

--- a/tests/unit/services/test_oms_kraken_reconciliation.py
+++ b/tests/unit/services/test_oms_kraken_reconciliation.py
@@ -478,6 +478,9 @@ class StubWSClient(_BaseKrakenStub):
             await self._stream_update_cb(state)
         return ack
 
+    def heartbeat_age(self) -> float:
+        return 0.0
+
 
 class StubRESTClient(_BaseKrakenStub):
     def __init__(self, *, credential_getter: Any, stream_update_cb: Any | None = None, server: Any, userrefs: Dict[str, str], **_: Any) -> None:


### PR DESCRIPTION
## Summary
- add `is_stale` helper to the public order book cache and enforce feed freshness before slicing orders while forcing REST routing when private heartbeats lag
- record private-stream heartbeats in `KrakenWSClient`, expose `heartbeat_age()`, and emit a new `oms_stale_feed_total` counter for stale data events
- extend websocket stubs and add async unit coverage for stale public books and private heartbeats

## Testing
- `pytest tests/unit/services/test_oms_credentials.py::test_place_order_rejects_when_public_book_stale tests/unit/services/test_oms_credentials.py::test_place_order_reroutes_when_private_stream_stale`


------
https://chatgpt.com/codex/tasks/task_e_68dee721c3c88321853fd4800ced70be