### PR TITLE
Handle Kraken decimals for OMS payloads

### DIFF
--- a/oms_service.py
+++ b/oms_service.py
@@ -725,12 +725,13 @@ class OMSService:
 
         pair_meta: Optional[Dict[str, Any]] = None
         if metadata:
+            pair_meta = _resolve_pair_metadata(request.symbol, metadata)
             try:
                 snapped_qty, snapped_limit = _PrecisionValidator.validate(
                     request.symbol,
                     request.qty,
                     request.limit_px,
-                    metadata,
+                    pair_meta or metadata,
                 )
             except HTTPException:
                 raise
@@ -740,7 +741,6 @@ class OMSService:
                 )
                 snapped_qty = request.qty
                 snapped_limit = request.limit_px
-            pair_meta = _resolve_pair_metadata(request.symbol, metadata)
 
         price_step: Optional[Decimal] = None
         if pair_meta:

--- a/oms_service.py
+++ b/oms_service.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import FastAPI, HTTPException, Query
@@ -29,6 +31,11 @@ from services.oms.kraken_ws import (
     OrderState,
 )
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
+from services.oms.oms_service import (  # type: ignore  # pragma: no cover - shared helpers
+    _PrecisionValidator,
+    _normalize_symbol,
+    _resolve_pair_metadata,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -70,11 +77,33 @@ def _flush_oms_event_buffers() -> None:
 shutdown_manager.register_flush_callback(_flush_oms_event_buffers)
 
 
-def _format_decimal(value: float) -> str:
-    text = f"{value:.16f}"
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    return text or "0"
+def _coerce_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, str)):
+        candidate = str(value)
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Non-finite numeric values are not supported")
+        candidate = repr(value)
+    else:
+        candidate = str(value)
+    try:
+        return Decimal(candidate)
+    except (InvalidOperation, TypeError) as exc:
+        raise ValueError(f"Invalid decimal value: {value}") from exc
+
+
+def _coerce_optional_decimal(value: Any) -> Optional[Decimal]:
+    if value is None:
+        return None
+    return _coerce_decimal(value)
+
+
+def _format_decimal(value: Decimal) -> str:
+    normalized = value.normalize()
+    # Ensure we always render in fixed-point form to match Kraken expectations
+    return format(normalized, "f")
 
 
 def oms_log(order_id: Optional[str], account_id: str, status: str, ts: datetime | None = None) -> None:
@@ -91,24 +120,40 @@ class PlaceOrderRequest(BaseModel):
     client_id: str = Field(..., description="Client supplied idempotency key")
     symbol: str = Field(..., description="Trading symbol e.g. BTC/USD")
     side: str = Field(..., description="BUY or SELL")
-    order_type: str = Field(..., alias="type", description="Order type (limit, market, stop)" )
-    qty: float = Field(..., gt=0, description="Quantity to trade")
-    limit_px: Optional[float] = Field(None, gt=0, description="Limit price when applicable")
+    order_type: str = Field(..., alias="type", description="Order type (limit, market, stop)")
+    qty: Decimal = Field(..., gt=Decimal("0"), description="Quantity to trade")
+    limit_px: Optional[Decimal] = Field(
+        None,
+        gt=Decimal("0"),
+        description="Limit price when applicable",
+    )
     tif: Optional[str] = Field(None, description="Time in force (GTC, IOC, FOK)")
-    tp: Optional[float] = Field(None, gt=0, description="Take profit price")
-    sl: Optional[float] = Field(None, gt=0, description="Stop loss price")
-    trailing: Optional[float] = Field(None, gt=0, description="Trailing stop offset")
+    tp: Optional[Decimal] = Field(
+        None,
+        gt=Decimal("0"),
+        description="Take profit price",
+    )
+    sl: Optional[Decimal] = Field(
+        None,
+        gt=Decimal("0"),
+        description="Stop loss price",
+    )
+    trailing: Optional[Decimal] = Field(
+        None,
+        gt=Decimal("0"),
+        description="Trailing stop offset",
+    )
     flags: List[str] = Field(default_factory=list, description="Additional Kraken oflags")
     post_only: bool = Field(False, description="Whether the order is post-only")
     reduce_only: bool = Field(False, description="Whether the order is reduce-only")
-    expected_fee_bps: Optional[float] = Field(
+    expected_fee_bps: Optional[Decimal] = Field(
         None,
-        ge=0.0,
+        ge=Decimal("0"),
         description="Fee estimate in basis points provided by the caller",
     )
-    expected_slippage_bps: Optional[float] = Field(
+    expected_slippage_bps: Optional[Decimal] = Field(
         None,
-        ge=0.0,
+        ge=Decimal("0"),
         description="Slippage estimate in basis points provided by the caller",
     )
 
@@ -142,6 +187,21 @@ class PlaceOrderRequest(BaseModel):
         if isinstance(value, (set, tuple)):
             return list(value)
         raise ValueError("flags must be a list of strings")
+
+    @field_validator("qty", mode="before")
+    @classmethod
+    def parse_qty(cls, value: Any) -> Decimal:
+        return _coerce_decimal(value)
+
+    @field_validator("limit_px", "tp", "sl", "trailing", mode="before")
+    @classmethod
+    def parse_optional_price(cls, value: Any) -> Optional[Decimal]:
+        return _coerce_optional_decimal(value)
+
+    @field_validator("expected_fee_bps", "expected_slippage_bps", mode="before")
+    @classmethod
+    def parse_optional_bps(cls, value: Any) -> Optional[Decimal]:
+        return _coerce_optional_decimal(value)
 
 
 class CancelOrderRequest(BaseModel):
@@ -243,16 +303,25 @@ class OrderContext:
     account_id: str
     symbol: str
     side: str
-    qty: float
+    qty: Decimal
     client_id: str
     post_only: bool
     reduce_only: bool
     tif: Optional[str]
-    price: Optional[float] = None
-    expected_fee_bps: float = 0.0
-    expected_slippage_bps: float = 0.0
-    last_filled: float = 0.0
-    last_fee: float = 0.0
+    price: Optional[Decimal] = None
+    expected_fee_bps: Decimal = Decimal("0")
+    expected_slippage_bps: Decimal = Decimal("0")
+    last_filled: Decimal = Decimal("0")
+    last_fee: Decimal = Decimal("0")
+
+
+@dataclass
+class _SnappedOrderFields:
+    qty: Decimal
+    limit_px: Optional[Decimal]
+    take_profit: Optional[Decimal]
+    stop_loss: Optional[Decimal]
+    trailing: Optional[Decimal]
 
 
 @dataclass
@@ -284,6 +353,8 @@ class KrakenSession:
         self._contexts: Dict[str, OrderContext] = {}
         self._client_lookup: Dict[str, str] = {}
         self._kafka = KafkaNATSAdapter(account_id=self.account_id)
+        self._metadata: Optional[Dict[str, Any]] = None
+        self._metadata_lock = asyncio.Lock()
 
     async def ensure_started(self) -> None:
         if self._ready.is_set():
@@ -306,6 +377,7 @@ class KrakenSession:
         await self._ws_client.close()
         await self._rest_client.close()
         self._ready.clear()
+        self._metadata = None
 
     async def place_order(self, payload: Dict[str, Any], context: OrderContext) -> Tuple[OrderAck, str]:
         await self.ensure_started()
@@ -358,6 +430,34 @@ class KrakenSession:
 
     def get_order(self, order_id: str) -> Optional[OrderRecord]:
         return self._orders.get(order_id)
+
+    async def get_metadata(self) -> Optional[Dict[str, Any]]:
+        if self._metadata is not None:
+            return self._metadata
+
+        async with self._metadata_lock:
+            if self._metadata is not None:
+                return self._metadata
+
+            fetcher = getattr(self._rest_client, "asset_pairs", None)
+            if fetcher is None:
+                logger.debug(
+                    "Kraken REST client missing asset_pairs() method; skipping metadata preload",
+                )
+                self._metadata = None
+                return None
+
+            try:
+                result = await fetcher()
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.warning(
+                    "Failed to load Kraken metadata for %s: %s", self.account_id, exc
+                )
+                self._metadata = None
+            else:
+                self._metadata = result if isinstance(result, dict) else None
+
+        return self._metadata
 
     def resolve_order_id(self, client_id: str) -> Optional[str]:
         return self._client_lookup.get(client_id)
@@ -414,25 +514,27 @@ class KrakenSession:
         oms_log(exchange_id, self.account_id, self._orders[exchange_id].status, updated_at)
 
     def _maybe_publish_fill(self, exchange_id: str, context: OrderContext, state: OrderState) -> None:
-        filled = state.filled_qty
-        if filled is None:
+        filled_decimal = _coerce_optional_decimal(state.filled_qty)
+        if filled_decimal is None:
             return
-        if filled <= context.last_filled:
+        if filled_decimal <= context.last_filled:
             return
-        delta = filled - context.last_filled
-        context.last_filled = filled
-        fee = 0.0
+        delta = filled_decimal - context.last_filled
+        context.last_filled = filled_decimal
+        fee = Decimal("0")
         liquidity = "maker" if context.post_only else "taker"
         own_trades = getattr(self._ws_client, "_own_trades", {})
         trade = own_trades.get(exchange_id)
         if isinstance(trade, dict):
             fee_value = trade.get("fee") or trade.get("fee_paid")
             try:
-                total_fee = float(fee_value)
-            except (TypeError, ValueError):
+                total_fee = _coerce_decimal(fee_value)
+            except ValueError:
                 total_fee = context.last_fee
-            fee = max(total_fee - context.last_fee, 0.0)
-            context.last_fee = max(total_fee, context.last_fee)
+            fee_delta = total_fee - context.last_fee
+            fee = fee_delta if fee_delta > 0 else Decimal("0")
+            if total_fee > context.last_fee:
+                context.last_fee = total_fee
             liquidity_hint = trade.get("liquidity") or trade.get("type")
             if isinstance(liquidity_hint, str):
                 liquidity_hint = liquidity_hint.lower()
@@ -440,12 +542,22 @@ class KrakenSession:
                     liquidity = "maker"
                 elif liquidity_hint in {"taker", "t"}:
                     liquidity = "taker"
-        avg_price = state.avg_price if state.avg_price is not None else context.price or 0.0
-        notional = max(delta * float(avg_price), 0.0)
-        estimated_fee_bps = max(context.expected_fee_bps, 0.0)
-        estimated_fee_usd = notional * (estimated_fee_bps / 10_000) if notional > 0 else 0.0
-        actual_fee_usd = max(fee, 0.0)
-        actual_fee_bps = (actual_fee_usd / notional * 10_000) if notional > 0 else 0.0
+        avg_price_decimal = _coerce_optional_decimal(state.avg_price) or context.price or Decimal("0")
+        notional = delta * avg_price_decimal
+        if notional < 0:
+            notional = -notional
+        estimated_fee_bps = context.expected_fee_bps if context.expected_fee_bps > 0 else Decimal("0")
+        estimated_fee_usd = (
+            notional * (estimated_fee_bps / Decimal("10000"))
+            if notional > 0
+            else Decimal("0")
+        )
+        actual_fee_usd = fee if fee > 0 else Decimal("0")
+        actual_fee_bps = (
+            actual_fee_usd / notional * Decimal("10000")
+            if notional > 0
+            else Decimal("0")
+        )
         discrepancy_bps = actual_fee_bps - estimated_fee_bps
         logger.info(
             "oms_fee_reconciliation",
@@ -454,21 +566,21 @@ class KrakenSession:
                 "account_id": self.account_id,
                 "symbol": context.symbol,
                 "liquidity": liquidity,
-                "notional_usd": notional,
-                "estimated_fee_bps": estimated_fee_bps,
-                "actual_fee_bps": actual_fee_bps,
-                "estimated_fee_usd": estimated_fee_usd,
-                "actual_fee_usd": actual_fee_usd,
-                "expected_slippage_bps": context.expected_slippage_bps,
-                "discrepancy_bps": discrepancy_bps,
+                "notional_usd": float(notional),
+                "estimated_fee_bps": float(estimated_fee_bps),
+                "actual_fee_bps": float(actual_fee_bps),
+                "estimated_fee_usd": float(estimated_fee_usd),
+                "actual_fee_usd": float(actual_fee_usd),
+                "expected_slippage_bps": float(context.expected_slippage_bps),
+                "discrepancy_bps": float(discrepancy_bps),
             },
         )
         event = FillEvent(
             account_id=self.account_id,
             symbol=context.symbol,
-            qty=delta,
-            price=state.avg_price or 0.0,
-            fee=fee,
+            qty=float(delta),
+            price=float(avg_price_decimal),
+            fee=float(actual_fee_usd),
             liquidity=liquidity,
             ts=datetime.now(timezone.utc),
         )
@@ -500,19 +612,21 @@ class OMSService:
 
     async def place_order(self, request: PlaceOrderRequest) -> PlaceOrderResponse:
         session = await self._session(request.account_id)
-        payload = self._build_payload(request)
+        metadata = await session.get_metadata()
+        snapped = self._snap_order_fields(request, metadata)
+        payload = self._build_payload(request, snapped)
         context = OrderContext(
             account_id=request.account_id,
             symbol=request.symbol,
             side=request.side,
-            qty=request.qty,
+            qty=snapped.qty,
             client_id=request.client_id,
             post_only=request.post_only,
             reduce_only=request.reduce_only,
             tif=request.tif,
-            price=request.limit_px,
-            expected_fee_bps=float(request.expected_fee_bps or 0.0),
-            expected_slippage_bps=float(request.expected_slippage_bps or 0.0),
+            price=snapped.limit_px,
+            expected_fee_bps=request.expected_fee_bps or Decimal("0"),
+            expected_slippage_bps=request.expected_slippage_bps or Decimal("0"),
         )
         cache_key = f"place:{request.account_id}:{request.client_id}"
 
@@ -598,16 +712,70 @@ class OMSService:
             updated_at=record.updated_at,
         )
 
-    def _build_payload(self, request: PlaceOrderRequest) -> Dict[str, Any]:
+    def _snap_order_fields(
+        self,
+        request: PlaceOrderRequest,
+        metadata: Optional[Dict[str, Any]],
+    ) -> _SnappedOrderFields:
+        snapped_qty = request.qty
+        snapped_limit = request.limit_px
+        snapped_tp = request.tp
+        snapped_sl = request.sl
+        snapped_trailing = request.trailing
+
+        pair_meta: Optional[Dict[str, Any]] = None
+        if metadata:
+            try:
+                snapped_qty, snapped_limit = _PrecisionValidator.validate(
+                    request.symbol,
+                    request.qty,
+                    request.limit_px,
+                    metadata,
+                )
+            except HTTPException:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "Precision validation failed for %s: %s", request.symbol, exc
+                )
+                snapped_qty = request.qty
+                snapped_limit = request.limit_px
+            pair_meta = _resolve_pair_metadata(request.symbol, metadata)
+
+        price_step: Optional[Decimal] = None
+        if pair_meta:
+            price_step = _PrecisionValidator._step(  # type: ignore[attr-defined]
+                pair_meta,
+                ["price_increment", "pair_decimals", "tick_size"],
+            )
+        if price_step:
+            if snapped_tp is not None:
+                snapped_tp = _PrecisionValidator._snap(snapped_tp, price_step)
+            if snapped_sl is not None:
+                snapped_sl = _PrecisionValidator._snap(snapped_sl, price_step)
+            if snapped_trailing is not None:
+                snapped_trailing = _PrecisionValidator._snap(snapped_trailing, price_step)
+
+        return _SnappedOrderFields(
+            qty=snapped_qty,
+            limit_px=snapped_limit,
+            take_profit=snapped_tp,
+            stop_loss=snapped_sl,
+            trailing=snapped_trailing,
+        )
+
+    def _build_payload(
+        self, request: PlaceOrderRequest, snapped: _SnappedOrderFields
+    ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "clientOrderId": request.client_id,
-            "pair": request.symbol,
+            "pair": _normalize_symbol(request.symbol),
             "type": request.side,
             "ordertype": request.order_type.lower(),
-            "volume": _format_decimal(request.qty),
+            "volume": _format_decimal(snapped.qty),
         }
-        if request.limit_px is not None:
-            payload["price"] = _format_decimal(request.limit_px)
+        if snapped.limit_px is not None:
+            payload["price"] = _format_decimal(snapped.limit_px)
 
         oflags = {flag.lower() for flag in request.flags}
         if request.post_only:
@@ -619,12 +787,12 @@ class OMSService:
 
         if request.tif:
             payload["timeInForce"] = request.tif.upper()
-        if request.tp is not None:
-            payload["takeProfit"] = _format_decimal(request.tp)
-        if request.sl is not None:
-            payload["stopLoss"] = _format_decimal(request.sl)
-        if request.trailing is not None:
-            payload["trailingStopOffset"] = _format_decimal(request.trailing)
+        if snapped.take_profit is not None:
+            payload["takeProfit"] = _format_decimal(snapped.take_profit)
+        if snapped.stop_loss is not None:
+            payload["stopLoss"] = _format_decimal(snapped.stop_loss)
+        if snapped.trailing is not None:
+            payload["trailingStopOffset"] = _format_decimal(snapped.trailing)
 
         return payload
 

--- a/tests/integration/test_ws_rest_fallback.py
+++ b/tests/integration/test_ws_rest_fallback.py
@@ -127,6 +127,9 @@ class _StubRESTClient:
         response = await self._exchange.place_order_rest(dict(payload))
         return _ack_from_exchange_response(response)
 
+    async def asset_pairs(self) -> Dict[str, Any]:
+        return {}
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio

--- a/tests/unit/test_oms_service_precision.py
+++ b/tests/unit/test_oms_service_precision.py
@@ -1,0 +1,260 @@
+from decimal import Decimal, ROUND_HALF_EVEN
+import sys
+import types
+from typing import Dict, List
+
+try:
+    import fastapi  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - test shim for missing optional dependency
+    stub = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str | None = None) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - minimal stub
+            self.routes = []
+
+        def on_event(self, *_args, **_kwargs):  # pragma: no cover - decorator stub
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def post(self, *_args, **_kwargs):  # pragma: no cover - decorator stub
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, *_args, **_kwargs):  # pragma: no cover - decorator stub
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def Query(default=None, *args, **kwargs):  # pragma: no cover - stubbed helper
+        return default
+
+    stub.FastAPI = FastAPI
+    stub.HTTPException = HTTPException
+    stub.Query = Query
+    sys.modules["fastapi"] = stub
+
+if "cryptography" not in sys.modules:
+    crypto_mod = types.ModuleType("cryptography")
+    hazmat_mod = types.ModuleType("cryptography.hazmat")
+    primitives_mod = types.ModuleType("cryptography.hazmat.primitives")
+    ciphers_mod = types.ModuleType("cryptography.hazmat.primitives.ciphers")
+    aead_mod = types.ModuleType("cryptography.hazmat.primitives.ciphers.aead")
+
+    class AESGCM:  # pragma: no cover - placeholder
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def encrypt(self, *args: object, **kwargs: object) -> bytes:
+            raise NotImplementedError
+
+        def decrypt(self, *args: object, **kwargs: object) -> bytes:
+            raise NotImplementedError
+
+    aead_mod.AESGCM = AESGCM
+
+    sys.modules["cryptography"] = crypto_mod
+    sys.modules["cryptography.hazmat"] = hazmat_mod
+    sys.modules["cryptography.hazmat.primitives"] = primitives_mod
+    sys.modules["cryptography.hazmat.primitives.ciphers"] = ciphers_mod
+    sys.modules["cryptography.hazmat.primitives.ciphers.aead"] = aead_mod
+
+if "metrics" not in sys.modules:
+    metrics_stub = types.ModuleType("metrics")
+
+    def _noop(*args: object, **kwargs: object) -> None:
+        return None
+
+    class _DummySpan:
+        def __enter__(self) -> "_DummySpan":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def traced_span(*args: object, **kwargs: object) -> _DummySpan:
+        return _DummySpan()
+
+    metrics_stub.increment_oms_error_count = _noop
+    metrics_stub.increment_oms_auth_failures = _noop
+    metrics_stub.increment_oms_child_orders_total = _noop
+    metrics_stub.record_oms_latency = _noop
+    metrics_stub.setup_metrics = _noop
+    metrics_stub.traced_span = traced_span
+    metrics_stub._REGISTRY = object()
+    sys.modules["metrics"] = metrics_stub
+
+if "services.oms.oms_service" not in sys.modules:
+    stub_module = types.ModuleType("services.oms.oms_service")
+
+    class _PrecisionValidator:
+        @staticmethod
+        def _snap(value: Decimal | None, step: Decimal | None) -> Decimal | None:
+            if value is None:
+                return None
+            if step is None or step <= 0:
+                return value
+            operand = value if isinstance(value, Decimal) else Decimal(str(value))
+            quant = step if isinstance(step, Decimal) else Decimal(str(step))
+            return (operand / quant).to_integral_value(rounding=ROUND_HALF_EVEN) * quant
+
+        @staticmethod
+        def _maybe_decimal(*values: object) -> Decimal | None:
+            for candidate in values:
+                if candidate is None:
+                    continue
+                if isinstance(candidate, Decimal):
+                    return candidate
+                try:
+                    return Decimal(str(candidate))
+                except Exception:
+                    continue
+            return None
+
+        @classmethod
+        def _step(cls, metadata: Dict[str, object], keys: List[str]) -> Decimal | None:
+            for key in keys:
+                if key not in metadata:
+                    continue
+                value = metadata[key]
+                if key.endswith("decimals"):
+                    try:
+                        decimals = int(value)
+                    except Exception:
+                        continue
+                    return Decimal("1") / (Decimal("10") ** decimals)
+                if isinstance(value, Decimal):
+                    return value
+                try:
+                    if isinstance(value, (int, float)):
+                        return Decimal(str(value))
+                    if isinstance(value, str):
+                        return Decimal(value)
+                except Exception:
+                    continue
+            return None
+
+        @classmethod
+        def validate(
+            cls,
+            symbol: str,
+            qty: Decimal,
+            price: Decimal | None,
+            metadata: Dict[str, Dict[str, object]] | None,
+        ) -> tuple[Decimal, Decimal | None]:
+            if not metadata:
+                return qty, price
+            pair_meta = _resolve_pair_metadata(symbol, metadata)
+            if pair_meta is None:
+                return qty, price
+            qty_step = cls._step(pair_meta, ["lot_step", "lot_decimals", "step_size"])
+            px_step = cls._step(pair_meta, ["price_increment", "pair_decimals", "tick_size"])
+            snapped_qty = cls._snap(qty, qty_step) or qty
+            snapped_px = cls._snap(price, px_step) if price is not None else None
+            min_qty = cls._maybe_decimal(
+                pair_meta.get("ordermin"), pair_meta.get("min_qty")
+            )
+            if min_qty is not None and snapped_qty < min_qty:
+                raise ValueError("quantity below minimum")
+            return snapped_qty, snapped_px
+
+    def _normalize_symbol(symbol: str) -> str:
+        return symbol.replace("-", "/").replace("_", "/").upper()
+
+    def _resolve_pair_metadata(
+        symbol: str, metadata: Dict[str, Dict[str, object]] | None
+    ) -> Dict[str, object] | None:
+        if not metadata:
+            return None
+        candidates = [symbol, _normalize_symbol(symbol), symbol.replace("/", ""), _normalize_symbol(symbol).replace("/", "")]
+        for candidate in candidates:
+            value = metadata.get(candidate)
+            if isinstance(value, dict):
+                return value
+        for value in metadata.values():
+            if isinstance(value, dict):
+                wsname = str(value.get("wsname") or "")
+                altname = str(value.get("altname") or "")
+                if wsname == _normalize_symbol(symbol) or altname == _normalize_symbol(symbol).replace("/", ""):
+                    return value
+        return None
+
+    stub_module._PrecisionValidator = _PrecisionValidator
+    stub_module._normalize_symbol = _normalize_symbol
+    stub_module._resolve_pair_metadata = _resolve_pair_metadata
+    sys.modules["services.oms.oms_service"] = stub_module
+
+import oms_service as legacy_oms_service
+
+
+def test_place_order_request_coerces_decimal_inputs() -> None:
+    request = legacy_oms_service.PlaceOrderRequest(
+        account_id="acct",
+        client_id="CID-DEC",
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        qty=0.5,
+        limit_px=30000.1234,
+        tp="31000.25",
+        sl=Decimal("29000.75"),
+        trailing=0.5,
+    )
+
+    assert isinstance(request.qty, Decimal)
+    assert isinstance(request.limit_px, Decimal)
+    assert isinstance(request.tp, Decimal)
+    assert isinstance(request.sl, Decimal)
+    assert isinstance(request.trailing, Decimal)
+
+
+def test_build_payload_snaps_metadata_precision() -> None:
+    service = legacy_oms_service.OMSService()
+    metadata = {
+        "BTC/USD": {
+            "lot_step": "0.0001",
+            "pair_decimals": 5,
+            "price_increment": "0.1",
+            "ordermin": "0.0001",
+            "wsname": "BTC/USD",
+        }
+    }
+    request = legacy_oms_service.PlaceOrderRequest(
+        account_id="acct",
+        client_id="CID-EDGE",
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        qty=Decimal("0.00010009"),
+        limit_px=Decimal("20100.12345"),
+        tp=Decimal("20500.9876"),
+        sl=Decimal("19000.4321"),
+        trailing=Decimal("15.5555"),
+    )
+
+    snapped = service._snap_order_fields(request, metadata)
+    payload = service._build_payload(request, snapped)
+
+    assert snapped.qty == Decimal("0.0001")
+    assert snapped.limit_px == Decimal("20100.1")
+    assert snapped.take_profit == Decimal("20501.0")
+    assert snapped.stop_loss == Decimal("19000.4")
+    assert snapped.trailing == Decimal("15.6")
+
+    assert payload["pair"] == "BTC/USD"
+    assert Decimal(payload["volume"]) == snapped.qty
+    assert Decimal(payload.get("price", "0")) == snapped.limit_px
+    assert Decimal(payload.get("takeProfit", "0")) == snapped.take_profit
+    assert Decimal(payload.get("stopLoss", "0")) == snapped.stop_loss
+    assert Decimal(payload.get("trailingStopOffset", "0")) == snapped.trailing


### PR DESCRIPTION
## Summary
- convert the synchronous OMS request/response workflow to use `Decimal` parsing for order inputs and context bookkeeping
- load Kraken asset metadata to quantize quantities, limits, and triggers before building order payloads
- retain decimal arithmetic through fee reconciliation and add unit coverage for Kraken lot/tick edge cases

## Testing
- pytest tests/unit/test_oms_service_precision.py


------
https://chatgpt.com/codex/tasks/task_e_68dee92ec1808321b072ccdb2b3de404