### PR TITLE
Cache Kraken websocket tokens

### DIFF
--- a/tests/unit/services/test_oms_kraken_ws.py
+++ b/tests/unit/services/test_oms_kraken_ws.py
@@ -2,11 +2,27 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import time
 import types
 
 import pytest
 
 _websockets_stub = types.ModuleType("websockets")
+
+_fastapi_stub = types.ModuleType("fastapi")
+
+
+class _DummyFastAPI:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+class _DummyRequest:
+    pass
+
+
+class _DummyResponse:
+    pass
 
 
 class _DummyWebSocketProtocol:
@@ -29,23 +45,57 @@ _websocket_exceptions.WebSocketException = _DummyWebSocketException
 
 sys.modules.setdefault("websockets", _websockets_stub)
 sys.modules.setdefault("websockets.exceptions", _websocket_exceptions)
+_fastapi_stub.FastAPI = _DummyFastAPI  # type: ignore[attr-defined]
+_fastapi_stub.Request = _DummyRequest  # type: ignore[attr-defined]
+_fastapi_stub.Response = _DummyResponse  # type: ignore[attr-defined]
+sys.modules.setdefault("fastapi", _fastapi_stub)
+_starlette_stub = types.ModuleType("starlette")
+_starlette_middleware_stub = types.ModuleType("starlette.middleware")
+_starlette_middleware_base_stub = types.ModuleType("starlette.middleware.base")
+
+
+class _DummyBaseHTTPMiddleware:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+_starlette_middleware_base_stub.BaseHTTPMiddleware = _DummyBaseHTTPMiddleware  # type: ignore[attr-defined]
+sys.modules.setdefault("starlette", _starlette_stub)
+sys.modules.setdefault("starlette.middleware", _starlette_middleware_stub)
+sys.modules.setdefault("starlette.middleware.base", _starlette_middleware_base_stub)
 
 from services.oms.kraken_ws import KrakenWSClient, KrakenWSError
 
 
 class _StubRestClient:
-    def __init__(self, token: str = "rest-token") -> None:
+    def __init__(self, token: str = "rest-token", expires: float = 900.0) -> None:
         self.token = token
+        self.expires = expires
         self.calls = 0
 
-    async def websocket_token(self) -> str:
+    async def websocket_token(self) -> tuple[str, float]:
         self.calls += 1
-        return self.token
+        return self.token, self.expires
 
 
 class _FailingRestClient:
-    async def websocket_token(self) -> str:
+    async def websocket_token(self) -> tuple[str, float]:
         raise RuntimeError("boom")
+
+
+class _StubGuard:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def acquire(
+        self,
+        account_id: str,
+        endpoint: str,
+        *,
+        transport: str = "rest",
+        urgent: bool = False,
+    ) -> None:
+        self.calls.append((account_id, endpoint, transport))
 
 
 def test_sign_auth_prefers_existing_token() -> None:
@@ -92,5 +142,38 @@ def test_sign_auth_rest_failure_raises() -> None:
     async def _run() -> None:
         with pytest.raises(KrakenWSError):
             await client._sign_auth()
+
+    asyncio.run(_run())
+
+
+def test_sign_auth_caches_rest_token_until_expiry() -> None:
+    async def _creds() -> dict[str, str]:
+        return {"api_key": "api", "api_secret": "secret"}
+
+    rest_client = _StubRestClient(token="rest-generated-token", expires=120.0)
+    guard = _StubGuard()
+    client = KrakenWSClient(
+        credential_getter=_creds,
+        rest_client=rest_client,
+        rate_limit_guard=guard,
+        account_id="acct-1",
+    )
+
+    async def _run() -> None:
+        first = await client._sign_auth()
+        assert first == "rest-generated-token"
+        assert rest_client.calls == 1
+        assert guard.calls == [("acct-1", "websocket_token", "rest")]
+
+        second = await client._sign_auth()
+        assert second == first
+        assert rest_client.calls == 1
+
+        client._ws_token_expiry = time.monotonic() - 1
+
+        third = await client._sign_auth()
+        assert third == first
+        assert rest_client.calls == 2
+        assert guard.calls[-1] == ("acct-1", "websocket_token", "rest")
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- cache Kraken websocket authentication tokens with expiry and reuse them until refresh is required
- guard REST token refreshes with the shared rate limit guard and plumb account identifiers through the OMS session
- expose REST token expiry metadata and cover token reuse behaviour in unit tests

## Testing
- pytest tests/unit/services/test_oms_kraken_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68deeca68c6483218fab665a7bfb1966