### PR TITLE
Use Decimal precision for impact analytics

### DIFF
--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -2081,16 +2081,16 @@ class AccountContext:
 
         direction = Decimal("1") if normalized_side == "buy" else Decimal("-1")
         impact_ratio = (avg_price - mid_px) / mid_px
-        impact_bps = float((impact_ratio * direction * Decimal("10000")))
+        impact_bps = impact_ratio * direction * Decimal("10000")
 
         await self._impact_store.record_fill(
             account_id=self.account_id,
             client_order_id=record.client_id,
             symbol=record.symbol,
             side=record.side,
-            filled_qty=float(filled_qty),
-            avg_price=float(avg_price),
-            pre_trade_mid=float(mid_px),
+            filled_qty=filled_qty,
+            avg_price=avg_price,
+            pre_trade_mid=mid_px,
             impact_bps=impact_bps,
             recorded_at=datetime.now(timezone.utc),
         )

--- a/tests/services/oms/test_impact_store.py
+++ b/tests/services/oms/test_impact_store.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from services.oms.impact_store import ImpactAnalyticsStore
+
+
+@pytest.mark.asyncio
+async def test_record_fill_preserves_decimal_precision() -> None:
+    store = ImpactAnalyticsStore()
+
+    now = datetime.now(timezone.utc)
+    qty = Decimal("0.00000051")
+    avg_px = Decimal("27123.123456789")
+    mid_px = Decimal("27123.123456788")
+    impact = Decimal("12.3456789")
+
+    await store.record_fill(
+        account_id="acct-123",
+        client_order_id="order-abc",
+        symbol="BTC/USD",
+        side="buy",
+        filled_qty=qty,
+        avg_price=avg_px,
+        pre_trade_mid=mid_px,
+        impact_bps=impact,
+        recorded_at=now,
+    )
+
+    fills = store._memory[("acct-123", "BTC/USD")]
+    assert fills, "expected fill to be stored in-memory"
+
+    fill = fills[-1]
+    assert fill.filled_qty == qty
+    assert fill.avg_price == avg_px
+    assert fill.pre_trade_mid == mid_px
+    assert fill.impact_bps == impact
+
+
+def test_build_curve_uses_decimal_averages() -> None:
+    store = ImpactAnalyticsStore()
+
+    rows = [
+        (Decimal("0.00000051"), Decimal("12.3456789")),
+        (Decimal("0.00000049"), Decimal("12.3456788")),
+    ]
+
+    points = store._build_curve(rows, bucket_count=1)
+
+    assert len(points) == 1
+    point = points[0]
+    assert point["size"] == pytest.approx(float(Decimal("0.0000005")))
+    assert point["impact_bps"] == pytest.approx(float(Decimal("12.34567885")))


### PR DESCRIPTION
## Summary
- store high precision trade impact values as Decimal in the impact analytics store
- remove float coercion when recording OMS trade impact and aggregate curves with Decimal math
- add tests covering high precision fills to verify Decimal preservation

## Testing
- pytest tests/services/oms/test_impact_store.py


------
https://chatgpt.com/codex/tasks/task_e_68def9e37da88321973053747ee2e981