### PR TITLE
Add reusable daily return helper for portfolio service

### DIFF
--- a/portfolio_service.py
+++ b/portfolio_service.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import csv
 import io
+import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Sequence
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -34,6 +35,9 @@ except Exception:  # pragma: no cover - executed when psycopg is unavailable
 
 
 DEFAULT_DSN = "postgresql://timescale:password@localhost:5432/aether"
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AccountScopeMiddleware(BaseHTTPMiddleware):
@@ -403,4 +407,145 @@ def query_fills(
 
     query = "SELECT * FROM fills ORDER BY fill_time DESC LIMIT %(limit)s"
     return _execute_scoped_query(account_scopes, query, {"limit": limit})
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return None
+
+
+def _extract_nav_pair(row: Mapping[str, Any]) -> tuple[float, float] | None:
+    if not isinstance(row, Mapping):
+        return None
+
+    str_keys = {str(key).lower(): key for key in row.keys() if isinstance(key, str)}
+    candidates: list[tuple[float, float, tuple[int, int, str]]] = []
+
+    for lower_key, original_key in str_keys.items():
+        if "nav" not in lower_key or "open" not in lower_key:
+            continue
+        close_lower = lower_key.replace("open", "close", 1)
+        close_key = str_keys.get(close_lower)
+        if close_key is None:
+            continue
+
+        open_val = _coerce_float(row.get(original_key))
+        close_val = _coerce_float(row.get(close_key))
+        if open_val is None or close_val is None:
+            continue
+
+        usd_priority = 0 if "usd" in lower_key else 1
+        if "mid" in lower_key:
+            source_priority = 0
+        elif "mark" in lower_key:
+            source_priority = 1
+        else:
+            source_priority = 2
+        priority = (usd_priority, source_priority, lower_key)
+        candidates.append((open_val, close_val, priority))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[2])
+    open_val, close_val, _ = candidates[0]
+    return float(open_val), float(close_val)
+
+
+def _nav_value_from_row(row: Mapping[str, Any]) -> float | None:
+    if not isinstance(row, Mapping):
+        return None
+
+    preferred_keys = (
+        "nav_usd_mid",
+        "nav_usd",
+        "nav",
+        "net_asset_value_usd",
+        "net_asset_value",
+        "equity",
+        "balance",
+        "total_value",
+    )
+
+    lower_map = {str(key).lower(): key for key in row.keys() if isinstance(key, str)}
+    for key in preferred_keys:
+        actual = lower_map.get(key)
+        if actual is None:
+            continue
+        value = _coerce_float(row.get(actual))
+        if value is not None:
+            return value
+
+    for lower_key, original_key in lower_map.items():
+        if "nav" in lower_key or "value" in lower_key or "equity" in lower_key:
+            value = _coerce_float(row.get(original_key))
+            if value is not None:
+                return value
+    return None
+
+
+def compute_daily_return_pct(account_id: str, ts_now: datetime | None = None) -> float:
+    """Return the intraday NAV change in percentage for *account_id*."""
+
+    ts_now = _as_utc(ts_now or datetime.now(timezone.utc))
+    session_start = datetime(ts_now.year, ts_now.month, ts_now.day, tzinfo=timezone.utc)
+
+    query = """
+        SELECT *
+        FROM pnl_curves
+        WHERE account_id = %(account_id)s
+          AND COALESCE(curve_ts, valuation_ts, ts, created_at) >= %(start)s
+          AND COALESCE(curve_ts, valuation_ts, ts, created_at) <= %(end)s
+        ORDER BY COALESCE(curve_ts, valuation_ts, ts, created_at)
+    """
+
+    with _connect() as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                query,
+                {"account_id": account_id, "start": session_start, "end": ts_now},
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+
+    nav_pair: tuple[float, float] | None = None
+    nav_values: list[float] = []
+
+    for row in rows:
+        if nav_pair is None:
+            nav_pair = _extract_nav_pair(row)
+            if nav_pair is not None:
+                break
+        value = _nav_value_from_row(row)
+        if value is not None:
+            nav_values.append(value)
+
+    if nav_pair is not None:
+        nav_open, nav_close = nav_pair
+    elif nav_values:
+        nav_open = nav_values[0]
+        nav_close = nav_values[-1]
+    else:
+        return 0.0
+
+    if nav_open <= 0:
+        LOGGER.warning(
+            "Daily return computation for account %s has nav_open_usd=%s; returning 0.0%%",
+            account_id,
+            nav_open,
+        )
+        return 0.0
+
+    return ((nav_close - nav_open) / nav_open) * 100.0
 

--- a/tests/unit/test_portfolio_service.py
+++ b/tests/unit/test_portfolio_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+import pytest
+
+
+def _connection_stub(rows: Iterable[Mapping[str, Any]]):
+    class _CursorStub:
+        def __init__(self, items: Iterable[Mapping[str, Any]]) -> None:
+            self._rows = [dict(row) for row in items]
+
+        def __enter__(self) -> "_CursorStub":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
+            return False
+
+        def execute(self, query: str, params: Mapping[str, Any]) -> None:
+            self.query = query
+            self.params = params
+
+        def fetchall(self) -> list[Mapping[str, Any]]:
+            return [dict(row) for row in self._rows]
+
+    class _ConnectionStub:
+        def __init__(self, items: Iterable[Mapping[str, Any]]) -> None:
+            self._rows = [dict(row) for row in items]
+
+        def __enter__(self) -> "_ConnectionStub":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
+            return False
+
+        def cursor(self) -> _CursorStub:
+            return _CursorStub(self._rows)
+
+    return _ConnectionStub(rows)
+
+
+def test_compute_daily_return_pct_prefers_mid_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    portfolio_rows = [
+        {
+            "nav_open_usd_mark": 1_000_000.0,
+            "nav_close_usd_mark": 1_020_000.0,
+            "nav_open_usd_mid": 1_000_000.0,
+            "nav_close_usd_mid": 1_050_000.0,
+            "curve_ts": datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+
+    import portfolio_service
+
+    monkeypatch.setattr(portfolio_service, "_connect", lambda: _connection_stub(portfolio_rows))
+
+    pct = portfolio_service.compute_daily_return_pct(
+        "acct-123", datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    )
+    assert pct == pytest.approx(5.0)
+
+
+def test_compute_daily_return_pct_zero_nav_open_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    portfolio_rows = [
+        {
+            "nav_open_usd": 0.0,
+            "nav_close_usd": 1_000_000.0,
+            "curve_ts": datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+
+    import portfolio_service
+
+    monkeypatch.setattr(portfolio_service, "_connect", lambda: _connection_stub(portfolio_rows))
+
+    with caplog.at_level("WARNING"):
+        pct = portfolio_service.compute_daily_return_pct(
+            "acct-456", datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc)
+        )
+
+    assert pct == 0.0
+    assert any("nav_open_usd" in record.message for record in caplog.records)
+
+
+def test_compute_daily_return_pct_uses_nav_series(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {
+            "nav": 1_000_000.0,
+            "curve_ts": datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc),
+        },
+        {
+            "nav": 1_040_000.0,
+            "curve_ts": datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        },
+    ]
+
+    import portfolio_service
+
+    monkeypatch.setattr(portfolio_service, "_connect", lambda: _connection_stub(rows))
+
+    pct = portfolio_service.compute_daily_return_pct(
+        "acct-789", datetime(2024, 1, 1, 23, 59, tzinfo=timezone.utc)
+    )
+    assert pct == pytest.approx(4.0)
+


### PR DESCRIPTION
## Summary
- add a reusable compute_daily_return_pct helper that sources matching USD mid-price data from pnl_curves
- emit a warning and return 0 when the opening NAV is non-positive to keep callers resilient
- cover the helper with unit tests for mid-price selection, zero NAV handling, and NAV series fallback

## Testing
- pytest tests/unit/test_portfolio_service.py

------
https://chatgpt.com/codex/tasks/task_e_68defec072c48321bc9815ad8e8bd170