### PR TITLE
Add account-tier aware fee estimates and drift monitoring

### DIFF
--- a/services/fees/models.py
+++ b/services/fees/models.py
@@ -30,6 +30,9 @@ class AccountVolume30d(Base):
     account_id = Column(String(64), primary_key=True)
     notional_usd_30d = Column(Numeric(20, 2), nullable=False, default=0)
     updated_at = Column(DateTime(timezone=True), nullable=False)
+    maker_fee_bps_estimate = Column(Numeric(10, 4), nullable=True)
+    taker_fee_bps_estimate = Column(Numeric(10, 4), nullable=True)
+    fee_estimate_updated_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class AccountFill(Base):


### PR DESCRIPTION
## Summary
- persist per-account 30d volume snapshots with maker/taker fee estimates for tier selection
- add a fee estimation endpoint that returns maker and taker basis points for an account/order hint
- reconcile realized fees against estimates, update moving averages, and alert when drift is detected

## Testing
- python -m compileall services/fees

------
https://chatgpt.com/codex/tasks/task_e_68deff04f1e0832193e54c18cc6aeeca