### PR TITLE
Add integration tests for diversification allocator safeguards

### DIFF
--- a/services/risk/portfolio_risk.py
+++ b/services/risk/portfolio_risk.py
@@ -232,7 +232,7 @@ class PortfolioRiskAggregator:
                 PORTFOLIO_LOGGER.warning(
                     "Portfolio constraint breached",
                     extra={
-                        "constraint": breach.constraint,
+                        "constraint": breach.name,
                         "value": breach.value,
                         "limit": breach.limit,
                         "detail": breach.detail,

--- a/tests/integration/test_diversification_allocator.py
+++ b/tests/integration/test_diversification_allocator.py
@@ -1,0 +1,145 @@
+"""Integration tests for the portfolio diversification allocator safeguards."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Mapping
+
+import pytest
+
+from services.risk.portfolio_risk import PortfolioRiskAggregator
+
+
+class _StubTimescaleAdapter:
+    """Deterministic stand-in for the Timescale adapter used by the aggregator."""
+
+    def __init__(
+        self,
+        *,
+        exposures: Mapping[str, float],
+        correlation_matrix: Mapping[str, Mapping[str, float]] | None = None,
+        var95: float = 100_000.0,
+        cvar95: float | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        self._exposures = {str(symbol): float(value) for symbol, value in exposures.items()}
+        self._correlation_matrix = {
+            str(symbol): {str(other): float(val) for other, val in row.items()}
+            for symbol, row in (correlation_matrix or {}).items()
+        }
+        self._var95 = float(var95)
+        self._cvar95 = float(cvar95 if cvar95 is not None else var95)
+        self._timestamp = timestamp or datetime.now(timezone.utc)
+
+    # The production adapter exposes these three methods which the aggregator relies on.
+    def open_positions(self) -> Dict[str, float]:
+        return dict(self._exposures)
+
+    def load_risk_config(self) -> Dict[str, object]:
+        return {"var_limit": self._var95, "correlation_matrix": self._correlation_matrix}
+
+    def cvar_results(self):
+        return [
+            {
+                "var95": self._var95,
+                "cvar95": self._cvar95,
+                "ts": self._timestamp,
+            }
+        ]
+
+
+@pytest.fixture()
+def adapter_factory():
+    """Factory to provide per-account stub adapters to the aggregator."""
+
+    registry: Dict[str, _StubTimescaleAdapter] = {}
+
+    def register(account_id: str, adapter: _StubTimescaleAdapter) -> None:
+        registry[account_id] = adapter
+
+    def factory(account_id: str) -> _StubTimescaleAdapter:
+        try:
+            return registry[account_id]
+        except KeyError as exc:  # pragma: no cover - defensive for unexpected accounts
+            raise AssertionError(f"Unexpected account requested: {account_id}") from exc
+
+    return register, factory
+
+
+def test_overweight_btc_triggers_cluster_downscale(adapter_factory) -> None:
+    register, factory = adapter_factory
+
+    register(
+        "alpha",
+        _StubTimescaleAdapter(
+            exposures={"BTC-USD": 400_000.0, "ETH-USD": 100_000.0},
+            correlation_matrix={},
+            var95=120_000.0,
+            cvar95=150_000.0,
+        ),
+    )
+
+    allocator = PortfolioRiskAggregator(
+        accounts=("alpha",),
+        cluster_limits={"BTC": 300_000.0, "ETH": 1_000_000.0},
+        instrument_clusters={"BTC-USD": "BTC", "ETH-USD": "ETH"},
+        instrument_betas={"BTC-USD": 1.0, "ETH-USD": 0.8},
+        beta_limit=2.0,
+        correlation_limit=0.99,
+        adapter_factory=factory,
+    )
+
+    response = allocator.portfolio_status()
+
+    assert response.constraints_ok is False
+    assert response.totals.cluster_exposure["BTC"] == pytest.approx(400_000.0)
+
+    breach_details = {breach.constraint: breach.detail for breach in response.breaches}
+    assert "max_cluster_exposure" in breach_details
+    assert breach_details["max_cluster_exposure"]["cluster"] == "BTC"
+
+    # Downscale factor should reflect the BTC limit versus projected exposure.
+    assert response.risk_adjustment == pytest.approx(300_000.0 / 400_000.0, rel=1e-6)
+
+
+def test_correlation_cap_enforces_highly_correlated_exposures(adapter_factory) -> None:
+    register, factory = adapter_factory
+
+    correlation_matrix = {
+        "BTC-USD": {"WBTC-USD": 0.95},
+        "WBTC-USD": {"BTC-USD": 0.95},
+    }
+
+    register(
+        "gamma",
+        _StubTimescaleAdapter(
+            exposures={"BTC-USD": 200_000.0, "WBTC-USD": 180_000.0},
+            correlation_matrix=correlation_matrix,
+            var95=110_000.0,
+            cvar95=140_000.0,
+        ),
+    )
+
+    allocator = PortfolioRiskAggregator(
+        accounts=("gamma",),
+        cluster_limits={"BTC": 1_000_000.0},
+        instrument_clusters={"BTC-USD": "BTC", "WBTC-USD": "BTC"},
+        instrument_betas={"BTC-USD": 1.0, "WBTC-USD": 1.0},
+        beta_limit=2.0,
+        correlation_limit=0.8,
+        adapter_factory=factory,
+    )
+
+    response = allocator.portfolio_status()
+
+    assert response.constraints_ok is False
+    assert response.totals.max_correlation == pytest.approx(0.95, rel=1e-6)
+
+    breach_map = {breach.constraint: breach for breach in response.breaches}
+    assert "max_correlation_risk" in breach_map
+    correlation_breach = breach_map["max_correlation_risk"]
+    assert correlation_breach.limit == pytest.approx(0.8)
+    assert correlation_breach.value == pytest.approx(0.95)
+
+    expected_adjustment = 0.8 / 0.95
+    assert response.risk_adjustment == pytest.approx(expected_adjustment, rel=1e-6)


### PR DESCRIPTION
## Summary
- add integration coverage that stresses BTC cluster limits and correlation caps using the portfolio risk allocator
- create a stub timescale adapter fixture so tests can control exposures and correlation inputs
- fix the portfolio risk logger to reference the constraint name when emitting breach telemetry

## Testing
- pytest tests/integration/test_diversification_allocator.py

------
https://chatgpt.com/codex/tasks/task_e_68deff707c848321a42b34e2ebc39972