### PR TITLE
Add risk management configuration sections

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -24,3 +24,26 @@ stablecoin_monitor:
   trusted_feeds:
     - nyfed_fx
     - bloomberg_fx
+
+simulation:
+  enabled: true
+  slippage_bps_base: 2
+  vol_multiplier: 1.0
+
+sizing:
+  max_trade_risk_pct_nav: 0.5
+  max_trade_risk_pct_cash: 0.7
+  volatility_floor: 0.005
+  safety_margin_bps: 3
+
+diversification:
+  max_concentration_pct_per_asset: 35
+  max_sector_pct: 60
+  rebalance_threshold_pct: 3
+  buckets:
+    core: ["BTC/USD"]
+    top_caps: ["ETH/USD", "SOL/USD"]
+    growth: ["..."]
+
+fees:
+  drift_alert_bps: 2


### PR DESCRIPTION
## Summary
- add simulation configuration defaults including slippage and volatility multiplier
- define sizing and diversification parameters for portfolio management
- include drift alert fees threshold in system configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deff8c1b70832191741dc4ff720e76