### PR TITLE
Enhance system health endpoint with portfolio metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,7 @@ def create_app(
     _maybe_include_router(app, "multiformat_export", "router")
     _maybe_include_router(app, "compliance_pack", "router")
     _maybe_include_router(app, "pack_exporter", "router")
+    _maybe_include_router(app, "services.system.health_service", "router")
 
 
     scaling_controller = build_scaling_controller_from_env()

--- a/services/system/__init__.py
+++ b/services/system/__init__.py
@@ -1,0 +1,3 @@
+"""System-level FastAPI services and utilities."""
+
+__all__ = ["health_service"]

--- a/tests/reports/test_report_service_helpers.py
+++ b/tests/reports/test_report_service_helpers.py
@@ -1,0 +1,48 @@
+import pytest
+
+from services.reports import report_service
+
+
+class _ReportStub:
+    def __init__(self, nav: float, realized: float, unrealized: float, fees: float) -> None:
+        self.nav = nav
+        self.realized_pnl = realized
+        self.unrealized_pnl = unrealized
+        self.fees = fees
+
+
+class _ServiceStub:
+    def __init__(self, report: _ReportStub) -> None:
+        self._report = report
+
+    def build_daily_report(self, account_id=None):  # pragma: no cover - interface shim
+        return self._report
+
+
+def test_compute_daily_return_pct(monkeypatch: pytest.MonkeyPatch) -> None:
+    report = _ReportStub(nav=1000.0, realized=50.0, unrealized=-10.0, fees=5.0)
+    service = _ServiceStub(report)
+    monkeypatch.setattr(report_service, "get_daily_report_service", lambda: service)
+
+    result = report_service.compute_daily_return_pct(account_id="alpha")
+    assert result == pytest.approx(((50.0 - 10.0 - 5.0) / 1000.0) * 100.0)
+
+
+def test_compute_daily_return_pct_handles_missing_nav(monkeypatch: pytest.MonkeyPatch) -> None:
+    report = _ReportStub(nav=0.0, realized=10.0, unrealized=0.0, fees=0.0)
+    service = _ServiceStub(report)
+    monkeypatch.setattr(report_service, "get_daily_report_service", lambda: service)
+
+    result = report_service.compute_daily_return_pct(account_id="alpha")
+    assert result is None
+
+
+def test_compute_daily_return_pct_handles_service_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FailingService:
+        def build_daily_report(self, account_id=None):  # pragma: no cover - exercised via exception path
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(report_service, "get_daily_report_service", lambda: _FailingService())
+
+    result = report_service.compute_daily_return_pct(account_id="alpha")
+    assert result is None

--- a/tests/services/test_system_health_service.py
+++ b/tests/services/test_system_health_service.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from services.system import health_service
+
+
+def test_build_health_snapshot(monkeypatch):
+    class _Totals:
+        instrument_exposure = {"BTC-USD": 1500.0, "ETH-USD": 500.0}
+        max_correlation = 0.9
+
+    class _Response:
+        totals = _Totals()
+        breaches = [
+            SimpleNamespace(
+                constraint="max_cluster_exposure",
+                value=1_200.0,
+                limit=1_000.0,
+                detail={"cluster": "BTC"},
+            )
+        ]
+
+    class _Aggregator:
+        correlation_limit = 0.8
+
+        def portfolio_status(self):  # pragma: no cover - simple passthrough
+            return _Response()
+
+    monkeypatch.setattr(health_service, "portfolio_aggregator", _Aggregator())
+    monkeypatch.setattr(health_service, "compute_daily_return_pct", lambda account_id=None: 1.25)
+    monkeypatch.setattr(
+        health_service,
+        "_simulation_status",
+        lambda: {"active": True, "reason": "training"},
+    )
+
+    snapshot = health_service.build_health_snapshot(account_id="alpha")
+
+    assert snapshot["daily_return_pct"] == 1.25
+    diversification = snapshot["diversification"]
+    assert diversification["top_assets"][0] == {"instrument": "BTC-USD", "exposure": 1500.0}
+    assert diversification["flags"][0]["constraint"] == "max_cluster_exposure"
+    assert diversification["correlation_note"] == "elevated"
+    assert snapshot["simulation"] == {"active": True, "reason": "training"}


### PR DESCRIPTION
## Summary
- add a system health router that exposes diversification, daily return and simulation status metadata
- extend the report service with a helper to compute daily return percentage for reuse by other services
- cover the new helpers with focused unit tests

## Testing
- pytest tests/reports/test_report_service_helpers.py tests/services/test_system_health_service.py

------
https://chatgpt.com/codex/tasks/task_e_68deff42aa448321aa5800a5df81cd5c