### PR TITLE
Ensure Kraken WS client imports uuid4

### DIFF
--- a/services/oms/kraken_ws.py
+++ b/services/oms/kraken_ws.py
@@ -7,10 +7,9 @@ import logging
 import random
 import time
 from dataclasses import dataclass
-from uuid import uuid4
-
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+from uuid import uuid4
 
 
 import websockets


### PR DESCRIPTION
## Summary
- import `uuid4` alongside the other Kraken websocket client dependencies so request IDs are available when connecting

## Testing
- pytest tests/unit/services/test_oms_kraken_ws.py::test_ensure_connected_uses_transport_factory -q

------
https://chatgpt.com/codex/tasks/task_e_68df028d01108321852d4b141bcbcd69