### PR TITLE
Fix uuid4 import placement in Kraken WS client

### DIFF
--- a/services/oms/kraken_ws.py
+++ b/services/oms/kraken_ws.py
@@ -7,10 +7,9 @@ import logging
 import random
 import time
 from dataclasses import dataclass
-from uuid import uuid4
-
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+from uuid import uuid4
 
 
 import websockets


### PR DESCRIPTION
## Summary
- ensure the Kraken websocket client imports `uuid4` alongside other dependencies

## Testing
- pytest tests/unit/services/test_oms_kraken_ws.py::test_ensure_connected_uses_transport_factory -q

------
https://chatgpt.com/codex/tasks/task_e_68df028fbd588321afbbea394326a682