### PR TITLE
Ensure OMS snapping respects side-specific rounding

### DIFF
--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -522,20 +522,25 @@ def _snap(
     side: str,
     floor_quantity: bool = False,
 ) -> float:
-    if step <= 0:
-        return value
-
     try:
         quant = Decimal(str(step))
         decimal_value = Decimal(str(value))
     except Exception:
         return value
 
+    if quant <= 0:
+        return value
+
     rounding = ROUND_FLOOR
     if not floor_quantity and side.upper() == "SELL":
         rounding = ROUND_CEILING
 
-    snapped = decimal_value.quantize(quant, rounding=rounding)
+    try:
+        snapped_ratio = (decimal_value / quant).to_integral_value(rounding=rounding)
+    except Exception:
+        return value
+
+    snapped = snapped_ratio * quant
 
     if floor_quantity and snapped > decimal_value:
         snapped -= quant


### PR DESCRIPTION
## Summary
- update the OMS snapping helper to floor buy orders and ceil sell prices while reusing it for auxiliary triggers
- extend the FastAPI handler tests to cover conservative snapping for both buy and sell payloads
- let the SQLAlchemy test stub yield to the real package when available so integration tests can run

## Testing
- pytest tests/oms/test_place_order.py -k "precision_snapping"
- pytest tests/services/oms/test_place_order.py::test_place_order_snaps_take_profit_stop_loss_and_trailing


------
https://chatgpt.com/codex/tasks/task_e_68df96f96b188321b4e4ad2de6b899d2