### PR TITLE
Add admin session tokens to Kraken adapter

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,22 @@
+from .routes import get_auth_service, router  # noqa: F401
+from .session_client import (  # noqa: F401
+    AdminSessionManager,
+    HttpSessionClient,
+    SessionClientProtocol,
+    SessionToken,
+    build_default_session_manager,
+    get_default_session_manager,
+    set_default_session_manager,
+)
+
+__all__ = [
+    "router",
+    "get_auth_service",
+    "AdminSessionManager",
+    "HttpSessionClient",
+    "SessionClientProtocol",
+    "SessionToken",
+    "build_default_session_manager",
+    "get_default_session_manager",
+    "set_default_session_manager",
+]

--- a/auth/session_client.py
+++ b/auth/session_client.py
@@ -1,0 +1,204 @@
+"""HTTP client and cache for administrator session tokens.
+
+The OMS exchange adapter requires an administrator session token that matches the
+``account_id`` of the request so the downstream OMS API can authorise the
+operation.  This module provides a small HTTP client for the authentication
+service's session endpoint along with a caching manager that keeps tokens fresh
+for repeated calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Mapping, Optional, Protocol
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SessionToken:
+    """Represents a bearer token issued by the session service."""
+
+    token: str
+    expires_at: Optional[float] = None
+
+    def is_valid(self, *, now: float, leeway: float) -> bool:
+        """Return ``True`` when the token is still considered valid."""
+
+        if not self.token:
+            return False
+        if self.expires_at is None:
+            return True
+        return (self.expires_at - leeway) > now
+
+
+class SessionClientProtocol(Protocol):
+    """Protocol describing a client capable of issuing admin session tokens."""
+
+    async def fetch_session(self, account_id: str) -> SessionToken:  # pragma: no cover - protocol
+        ...
+
+
+def _coerce_expires_at(payload: Mapping[str, Any], *, now: float) -> Optional[float]:
+    raw_expires = payload.get("expires_at") or payload.get("expiry")
+    if raw_expires is not None:
+        if isinstance(raw_expires, (int, float)):
+            return float(raw_expires)
+        if isinstance(raw_expires, str):
+            try:
+                parsed = datetime.fromisoformat(raw_expires.replace("Z", "+00:00"))
+            except ValueError:
+                try:
+                    return float(raw_expires)
+                except (TypeError, ValueError):
+                    return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
+
+    raw_ttl = payload.get("expires_in") or payload.get("ttl") or payload.get("ttl_seconds")
+    if raw_ttl is not None:
+        try:
+            ttl = float(raw_ttl)
+        except (TypeError, ValueError):
+            return None
+        return now + ttl
+    return None
+
+
+class HttpSessionClient(SessionClientProtocol):
+    """HTTP client that fetches administrator sessions from the auth service."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        endpoint_template: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        resolved_base = (base_url or os.getenv("SESSION_SERVICE_URL", "")).strip()
+        self._base_url = resolved_base.rstrip("/")
+        self._endpoint = (endpoint_template or os.getenv("SESSION_SERVICE_ENDPOINT") or "/sessions/admin/{account_id}").strip()
+        self._timeout = timeout if timeout is not None else float(os.getenv("SESSION_SERVICE_TIMEOUT", "2.0"))
+
+    def _build_url(self, account_id: str) -> str:
+        if not self._base_url:
+            raise RuntimeError("Session service URL is not configured (set SESSION_SERVICE_URL)")
+        path = self._endpoint.format(account_id=account_id)
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{self._base_url}{path}"
+
+    async def fetch_session(self, account_id: str) -> SessionToken:
+        url = self._build_url(account_id)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - passthrough for observability
+            logger.error("Session service request failed for %s: %s", account_id, exc)
+            raise
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RuntimeError("Session service returned non-JSON payload") from exc
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Session service returned unexpected payload type")
+
+        token_value = str(payload.get("token") or payload.get("session_token") or "").strip()
+        if not token_value:
+            raise RuntimeError("Session service response missing token value")
+        now = time.time()
+        expires_at = _coerce_expires_at(payload, now=now)
+        return SessionToken(token=token_value, expires_at=expires_at)
+
+
+class AdminSessionManager:
+    """Caches administrator session tokens and refreshes them as needed."""
+
+    def __init__(
+        self,
+        client: SessionClientProtocol,
+        *,
+        refresh_leeway: float = 30.0,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._client = client
+        self._refresh_leeway = max(refresh_leeway, 0.0)
+        self._clock = clock or time.time
+        self._cache: Dict[str, SessionToken] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    async def token_for_account(self, account_id: str) -> str:
+        normalized = account_id.strip()
+        if not normalized:
+            raise ValueError("account_id must be provided")
+
+        cached = self._cache.get(normalized)
+        now = self._clock()
+        if cached and cached.is_valid(now=now, leeway=self._refresh_leeway):
+            return cached.token
+
+        lock = self._locks.setdefault(normalized, asyncio.Lock())
+        async with lock:
+            now = self._clock()
+            cached = self._cache.get(normalized)
+            if cached and cached.is_valid(now=now, leeway=self._refresh_leeway):
+                return cached.token
+
+            fresh = await self._client.fetch_session(normalized)
+            if not fresh.token:
+                raise RuntimeError("Session service returned an empty token")
+            if fresh.expires_at is not None and fresh.expires_at <= now:
+                raise RuntimeError("Session service returned an already expired token")
+            self._cache[normalized] = fresh
+            logger.debug("Refreshed admin session token for %s", normalized)
+            return fresh.token
+
+    def invalidate(self, account_id: Optional[str] = None) -> None:
+        if account_id is None:
+            self._cache.clear()
+            return
+        self._cache.pop(account_id.strip(), None)
+
+
+_DEFAULT_MANAGER: Optional[AdminSessionManager] = None
+
+
+def build_default_session_manager() -> AdminSessionManager:
+    base_url = os.getenv("SESSION_SERVICE_URL") or os.getenv("AUTH_SESSION_URL")
+    if not base_url:
+        raise RuntimeError("Session service URL is not configured")
+    client = HttpSessionClient(base_url=base_url)
+    return AdminSessionManager(client)
+
+
+def get_default_session_manager() -> AdminSessionManager:
+    global _DEFAULT_MANAGER
+    if _DEFAULT_MANAGER is None:
+        _DEFAULT_MANAGER = build_default_session_manager()
+    return _DEFAULT_MANAGER
+
+
+def set_default_session_manager(manager: Optional[AdminSessionManager]) -> None:
+    global _DEFAULT_MANAGER
+    _DEFAULT_MANAGER = manager
+
+
+__all__ = [
+    "AdminSessionManager",
+    "HttpSessionClient",
+    "SessionClientProtocol",
+    "SessionToken",
+    "build_default_session_manager",
+    "get_default_session_manager",
+    "set_default_session_manager",
+]
+

--- a/exchange_adapter.py
+++ b/exchange_adapter.py
@@ -7,11 +7,23 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+)
 from uuid import uuid4
 
 
 import httpx
+
+from auth.session_client import AdminSessionManager, get_default_session_manager
 
 from metrics import get_request_id
 
@@ -97,9 +109,12 @@ def _join_url(base_url: str, path: str) -> str:
     return f"{base}{suffix}" if base else suffix
 
 
-def _account_headers(account_id: str) -> Dict[str, str]:
+def _account_headers(account_id: str, *, token: Optional[str] = None) -> Dict[str, str]:
     request_id = get_request_id() or str(uuid4())
-    return {"X-Account-ID": account_id, "X-Request-ID": request_id}
+    headers = {"X-Account-ID": account_id, "X-Request-ID": request_id}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 class KrakenAdapter(ExchangeAdapter):
@@ -111,6 +126,7 @@ class KrakenAdapter(ExchangeAdapter):
         primary_url: Optional[str] = None,
         paper_url: Optional[str] = None,
         timeout: Optional[float] = None,
+        session_manager: Optional[AdminSessionManager] = None,
     ) -> None:
         super().__init__(
             "kraken",
@@ -124,6 +140,7 @@ class KrakenAdapter(ExchangeAdapter):
         self._primary_url = (primary_url or _DEFAULT_PRIMARY_URL or "").strip()
         self._paper_url = (paper_url or _DEFAULT_PAPER_URL or "").strip()
         self._timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
+        self._session_manager = session_manager
 
     async def place_order(
         self,
@@ -142,11 +159,12 @@ class KrakenAdapter(ExchangeAdapter):
             return {}
 
         url = _join_url(base_url, "/oms/place")
+        headers = await self._request_headers(account_id)
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             response = await client.post(
                 url,
                 json=dict(payload),
-                headers=_account_headers(account_id),
+                headers=headers,
             )
             response.raise_for_status()
             try:
@@ -170,11 +188,12 @@ class KrakenAdapter(ExchangeAdapter):
         }
         if exchange_order_id:
             payload["exchange_order_id"] = exchange_order_id
+        headers = await self._request_headers(account_id)
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             response = await client.post(
                 url,
                 json=payload,
-                headers=_account_headers(account_id),
+                headers=headers,
             )
             response.raise_for_status()
             try:
@@ -213,7 +232,7 @@ class KrakenAdapter(ExchangeAdapter):
             raise RuntimeError("Kraken OMS URL is not configured")
 
         url = _join_url(self._primary_url, path)
-        headers = {"X-Account-ID": account_id}
+        headers = await self._request_headers(account_id)
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             response = await client.get(url, params=dict(params or {}), headers=headers)
             response.raise_for_status()
@@ -226,6 +245,21 @@ class KrakenAdapter(ExchangeAdapter):
             if isinstance(payload, list):
                 return {"result": payload}
             return {}
+
+    async def _request_headers(self, account_id: str) -> Dict[str, str]:
+        token = await self._resolve_session_token(account_id)
+        return _account_headers(account_id, token=token)
+
+    async def _resolve_session_token(self, account_id: str) -> str:
+        manager = self._ensure_session_manager()
+        return await manager.token_for_account(account_id)
+
+    def _ensure_session_manager(self) -> AdminSessionManager:
+        manager = self._session_manager
+        if manager is None:
+            manager = get_default_session_manager()
+            self._session_manager = manager
+        return manager
 
     @staticmethod
     def _normalize_balances(account_id: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/tests/integration/test_exchange_adapter_oms.py
+++ b/tests/integration/test_exchange_adapter_oms.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import asynccontextmanager
+import sys
+import types
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlsplit
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+import exchange_adapter
+from auth.service import InMemorySessionStore
+from services.common import security
+
+if "aiohttp" not in sys.modules:
+    class _StubSession:
+        async def __aenter__(self) -> "_StubSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def post(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("aiohttp stub invoked")
+
+        async def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("aiohttp stub invoked")
+
+    class _ClientTimeout:
+        def __init__(self, total: float | None = None) -> None:
+            self.total = total
+
+    aiohttp_stub = types.SimpleNamespace(
+        ClientSession=lambda *args, **kwargs: _StubSession(),
+        ClientTimeout=_ClientTimeout,
+        ClientError=Exception,
+    )
+    sys.modules["aiohttp"] = aiohttp_stub
+
+
+@asynccontextmanager
+async def _noop_clients(oms_main):
+    async def _credentials() -> dict[str, Any]:
+        return {
+            "api_key": "demo",
+            "api_secret": "demo-secret",
+            "metadata": {"rotated_at": datetime.now(timezone.utc).isoformat()},
+        }
+
+    class _Stub:
+        async def close(self) -> None:
+            return None
+
+    stub = _Stub()
+    yield oms_main.KrakenClientBundle(
+        credential_getter=_credentials,
+        ws_client=stub,
+        rest_client=stub,
+    )
+
+
+class _AdapterResponse:
+    def __init__(self, response) -> None:  # type: ignore[no-untyped-def]
+        self._response = response
+        self.status_code = response.status_code
+
+    def raise_for_status(self) -> None:
+        self._response.raise_for_status()
+
+    def json(self) -> Any:
+        return self._response.json()
+
+
+def _extract_path(url: str) -> str:
+    parsed = urlsplit(url)
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return path
+
+
+@pytest.mark.asyncio
+async def test_kraken_adapter_round_trip_through_oms(monkeypatch: pytest.MonkeyPatch) -> None:
+    oms_main = importlib.reload(importlib.import_module("services.oms.main"))
+
+    class _NoopKafka:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        def publish(self, *args, **kwargs) -> None:
+            return None
+
+        @classmethod
+        def flush_events(cls) -> dict[str, int]:
+            return {}
+
+        @classmethod
+        def reset(cls, account_id: str | None = None) -> None:
+            return None
+
+    class _NoopTimescale:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        def record_ack(self, *args, **kwargs) -> None:
+            return None
+
+        def record_usage(self, *args, **kwargs) -> None:
+            return None
+
+        def record_fill(self, *args, **kwargs) -> None:
+            return None
+
+        def record_shadow_fill(self, *args, **kwargs) -> None:
+            return None
+
+        @classmethod
+        def flush_event_buffers(cls) -> dict[str, int]:
+            return {}
+
+    oms_main.MARKET_METADATA = {"BTC-USD": {"tick": 0.01, "lot": 0.0001}}
+
+    monkeypatch.setattr(oms_main, "KafkaNATSAdapter", _NoopKafka)
+    monkeypatch.setattr(oms_main, "TimescaleAdapter", _NoopTimescale)
+    monkeypatch.setattr(oms_main, "_acquire_kraken_clients", lambda account_id: _noop_clients(oms_main))
+    monkeypatch.setattr(oms_main, "_ensure_credentials_valid", lambda credentials: None)
+
+    async def _fake_submit_order(*args, **kwargs):  # type: ignore[no-untyped-def]
+        ack = oms_main.OrderAck(
+            exchange_order_id="OID-1",
+            status="ok",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+        return ack, "websocket"
+
+    monkeypatch.setattr(oms_main, "_submit_order", _fake_submit_order)
+    async def _fake_fetch_open_orders(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return []
+
+    async def _fake_fetch_own_trades(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return []
+
+    monkeypatch.setattr(oms_main, "_fetch_open_orders", _fake_fetch_open_orders)
+    monkeypatch.setattr(oms_main, "_fetch_own_trades", _fake_fetch_own_trades)
+    monkeypatch.setattr(oms_main.shadow_oms, "record_real_fill", lambda *a, **k: None)
+    monkeypatch.setattr(oms_main.shadow_oms, "generate_shadow_fills", lambda *a, **k: [])
+
+    security.reload_admin_accounts(["company"])
+    store = InMemorySessionStore()
+    session = store.create("company")
+    oms_main.app.state.session_store = store
+
+    import shared.graceful_shutdown as graceful_shutdown
+
+    monkeypatch.setattr(graceful_shutdown, "install_sigterm_handler", lambda manager: None)
+    async def _noop_async(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(oms_main.market_metadata_cache, "start", _noop_async)
+    monkeypatch.setattr(oms_main.market_metadata_cache, "stop", _noop_async)
+
+    with TestClient(oms_main.app) as client:
+
+        class _AdapterClient:
+            def __init__(self, *args, **kwargs) -> None:
+                self._client = client
+
+            async def __aenter__(self) -> "_AdapterClient":
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb) -> None:
+                return None
+
+            async def post(self, url: str, json=None, headers=None):  # type: ignore[override]
+                response = self._client.post(_extract_path(url), json=json, headers=headers)
+                return _AdapterResponse(response)
+
+            async def get(self, url: str, params=None, headers=None):  # type: ignore[override]
+                response = self._client.get(_extract_path(url), params=params, headers=headers)
+                return _AdapterResponse(response)
+
+        monkeypatch.setattr(exchange_adapter.httpx, "AsyncClient", _AdapterClient)
+
+        class _StubSessionManager:
+            def __init__(self, token: str) -> None:
+                self.token = token
+                self.calls: list[str] = []
+
+            async def token_for_account(self, account_id: str) -> str:
+                self.calls.append(account_id)
+                return self.token
+
+        manager = _StubSessionManager(session.token)
+        adapter = exchange_adapter.KrakenAdapter(
+            primary_url=str(client.base_url),
+            session_manager=manager,
+        )
+
+        payload = {
+            "order_id": "CID-1",
+            "account_id": "company",
+            "instrument": "BTC-USD",
+            "side": "BUY",
+            "quantity": 1.0,
+            "price": 1000.0,
+            "fee": {"currency": "USD", "maker": 0.0, "taker": 0.0},
+        }
+
+        result = await adapter.place_order("company", payload)
+
+    assert result["accepted"] is True
+    assert manager.calls == ["company"]

--- a/tests/unit/test_exchange_adapter.py
+++ b/tests/unit/test_exchange_adapter.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+import exchange_adapter
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return dict(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_place_order_includes_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[tuple[str, str, dict[str, object] | None, dict[str, str]]] = []
+
+    class _DummyAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        async def __aenter__(self) -> "_DummyAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, json=None, headers=None):  # type: ignore[override]
+            recorded.append(("POST", url, json, dict(headers or {})))
+            return _DummyResponse({"status": "ok"})
+
+        async def get(self, url: str, params=None, headers=None):  # type: ignore[override]
+            recorded.append(("GET", url, params, dict(headers or {})))
+            return _DummyResponse({})
+
+    monkeypatch.setattr(exchange_adapter.httpx, "AsyncClient", _DummyAsyncClient)
+
+    class _StubSessionManager:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def token_for_account(self, account_id: str) -> str:
+            self.calls.append(account_id)
+            return "session-token"
+
+    manager = _StubSessionManager()
+    adapter = exchange_adapter.KrakenAdapter(primary_url="http://oms", session_manager=manager)
+
+    result = await adapter.place_order("alpha", {"order": "payload"})
+
+    assert result == {"status": "ok"}
+    assert manager.calls == ["alpha"]
+    assert recorded, "Expected the adapter to perform a POST request"
+    method, url, payload, headers = recorded[0]
+    assert method == "POST"
+    assert url.endswith("/oms/place")
+    assert headers["Authorization"] == "Bearer session-token"
+    assert headers["X-Account-ID"] == "alpha"
+    assert "X-Request-ID" in headers
+
+
+@pytest.mark.asyncio
+async def test_get_balance_uses_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[tuple[str, str, dict[str, object] | None, dict[str, str]]] = []
+
+    class _DummyAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        async def __aenter__(self) -> "_DummyAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def get(self, url: str, params=None, headers=None):  # type: ignore[override]
+            recorded.append(("GET", url, params, dict(headers or {})))
+            payload = {"result": {"balances": {"USD": "10"}}}
+            return _DummyResponse(payload)
+
+        async def post(self, url: str, json=None, headers=None):  # type: ignore[override]
+            recorded.append(("POST", url, json, dict(headers or {})))
+            return _DummyResponse({})
+
+    monkeypatch.setattr(exchange_adapter.httpx, "AsyncClient", _DummyAsyncClient)
+
+    class _StubSessionManager:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def token_for_account(self, account_id: str) -> str:
+            self.calls.append(account_id)
+            return "balance-token"
+
+    manager = _StubSessionManager()
+    adapter = exchange_adapter.KrakenAdapter(primary_url="http://oms", session_manager=manager)
+
+    result = await adapter.get_balance("beta")
+
+    assert result["account_id"] == "beta"
+    assert manager.calls == ["beta"]
+    assert recorded, "Expected the adapter to issue a GET request"
+    method, url, params, headers = recorded[0]
+    assert method == "GET"
+    assert url.endswith("/oms/accounts/beta/balances")
+    assert headers["Authorization"] == "Bearer balance-token"
+    assert headers["X-Account-ID"] == "beta"
+

--- a/tests/unit/test_session_client.py
+++ b/tests/unit/test_session_client.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from auth.session_client import AdminSessionManager, SessionToken
+
+
+@pytest.mark.asyncio
+async def test_session_manager_caches_until_expired() -> None:
+    now = {"value": 1000.0}
+
+    def _clock() -> float:
+        return now["value"]
+
+    class _StubClient:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def fetch_session(self, account_id: str) -> SessionToken:
+            self.calls.append(account_id)
+            return SessionToken(token=f"token-{len(self.calls)}", expires_at=_clock() + 30.0)
+
+    client = _StubClient()
+    manager = AdminSessionManager(client, clock=_clock, refresh_leeway=5.0)
+
+    token_one = await manager.token_for_account("delta")
+    token_two = await manager.token_for_account("delta")
+
+    assert token_one == token_two
+    assert client.calls == ["delta"]
+
+    now["value"] += 30.0
+
+    token_three = await manager.token_for_account("delta")
+    assert token_three != token_one
+    assert client.calls == ["delta", "delta"]
+
+
+@pytest.mark.asyncio
+async def test_session_manager_requires_account_id() -> None:
+    class _StubClient:
+        async def fetch_session(self, account_id: str) -> SessionToken:
+            return SessionToken(token="noop")
+
+    manager = AdminSessionManager(_StubClient())
+
+    with pytest.raises(ValueError):
+        await manager.token_for_account("   ")
+


### PR DESCRIPTION
## Summary
- add an auth session client module and expose helpers in auth.__init__
- inject admin session manager into KrakenAdapter to attach bearer tokens on OMS requests
- cover the new behavior with unit tests and an OMS integration test

## Testing
- pytest tests/unit/test_exchange_adapter.py tests/unit/test_session_client.py tests/integration/test_exchange_adapter_oms.py

------
https://chatgpt.com/codex/tasks/task_e_68e0064b768c83219ba709b769b7bbf5