### PR TITLE
Handle invalid Kraken metadata entries

### DIFF
--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, InvalidOperation
 
 import time
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple

--- a/tests/oms/test_market_metadata_cache.py
+++ b/tests/oms/test_market_metadata_cache.py
@@ -1,0 +1,68 @@
+import sys
+import types
+
+import pytest
+
+if "aiohttp" not in sys.modules:
+    class _StubSession:
+        async def __aenter__(self) -> "_StubSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def post(self, *args, **kwargs):
+            raise RuntimeError("aiohttp stub invoked")
+
+        async def get(self, *args, **kwargs):
+            raise RuntimeError("aiohttp stub invoked")
+
+    class _ClientTimeout:
+        def __init__(self, total: float | None = None) -> None:
+            self.total = total
+
+    aiohttp_stub = types.SimpleNamespace(
+        ClientSession=lambda *args, **kwargs: _StubSession(),
+        ClientTimeout=_ClientTimeout,
+        ClientError=Exception,
+    )
+    sys.modules["aiohttp"] = aiohttp_stub
+
+from services.oms import main
+
+
+@pytest.mark.asyncio
+async def test_market_metadata_cache_skips_invalid_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "ETHUSD": {
+            "wsname": "ETH/USD",
+            "base": "XETH",
+            "quote": "ZUSD",
+            "tick_size": "0.10",
+            "lot_step": "0.01",
+        },
+        "FOOUSD": {
+            "wsname": "FOO/USD",
+            "base": "XFOO",
+            "quote": "ZUSD",
+            "tick_size": "not-a-number",
+            "pair_decimals": "bad",
+            "lot_step": "1",
+        },
+    }
+
+    async def _fake_fetch_asset_pairs() -> dict:
+        return payload
+
+    cache = main.MarketMetadataCache(refresh_interval=0.0)
+    monkeypatch.setattr(main, "_fetch_asset_pairs", _fake_fetch_asset_pairs)
+
+    await cache.refresh()
+
+    snapshot = await cache.snapshot()
+
+    assert snapshot == {"ETH-USD": {"tick": 0.1, "lot": 0.01}}
+    assert "FOO-USD" not in snapshot


### PR DESCRIPTION
## Summary
- import `InvalidOperation` to ensure invalid decimal strings in Kraken metadata are handled safely
- add regression test covering the metadata cache skipping malformed tick values

## Testing
- pytest tests/oms/test_market_metadata_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68e01bebf0208321940f6f7ab2a960f8