### PR TITLE
Add GTD expiry handling for OMS order placement

### DIFF
--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -1044,6 +1044,19 @@ async def place_order(
             detail="Market metadata unavailable; unable to quantize order safely.",
         )
 
+    expire_time_iso: str | None = None
+    if request.time_in_force == "GTD":
+        if request.expire_time is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="expire_time is required when time_in_force is GTD",
+            )
+        expire_time_iso = (
+            request.expire_time.astimezone(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
     snapped_price = _snap(request.price, tick_size, side=request.side)
     snapped_quantity = _snap(
         request.quantity, lot_size, side=request.side, floor_quantity=True
@@ -1070,6 +1083,8 @@ async def place_order(
     }
     if request.time_in_force:
         order_payload["timeInForce"] = request.time_in_force
+        if request.time_in_force == "GTD" and expire_time_iso is not None:
+            order_payload["expireTime"] = expire_time_iso
     if request.take_profit:
         order_payload["takeProfit"] = _snap(
             request.take_profit,


### PR DESCRIPTION
## Summary
- add an expire_time field to OrderPlacementRequest and validate it for GTD submissions
- ensure OMS place order requests forward Kraken expireTime values for GTD orders
- cover GTD expiry success and failure cases in the OMS endpoint tests

## Testing
- pytest tests/oms/test_place_order.py *(fails: NameError: name 'main' is not defined in services/common/adapters.py during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68e01d9cd6d88321b03d511120e55cf4