### PR TITLE
Switch safe mode persistence to Redis and add restart regression test

### DIFF
--- a/tests/integration/test_full_loop.py
+++ b/tests/integration/test_full_loop.py
@@ -22,6 +22,7 @@ from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter
 from services.oms.warm_start import WarmStartCoordinator
 from services.common.schemas import PolicyDecisionResponse
 from tests import factories
+from tests.fixtures.backends import MemoryRedis
 from tests.fixtures.mock_kraken import MockKrakenServer
 
 
@@ -123,9 +124,10 @@ def test_full_loop_across_accounts(
 
     metrics_module.init_metrics("sequencer")
 
+    backend = MemoryRedis()
+    safe_mode.controller._state_store = safe_mode.SafeModeStateStore(redis_client=backend)  # type: ignore[attr-defined]
     safe_mode.controller.reset()
     safe_mode.clear_safe_mode_log()
-    safe_mode.controller._state_store = safe_mode.SafeModeStateStore(tmp_path / "safe_mode_state.json")  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
     # Configure audit logging to use deterministic local artefacts.

--- a/tests/integration/test_safe_mode.py
+++ b/tests/integration/test_safe_mode.py
@@ -9,6 +9,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 import safe_mode
+from tests.fixtures.backends import MemoryRedis
 
 
 class DummyTradingEngine:
@@ -41,6 +42,8 @@ class DummyTradingEngine:
 @pytest.mark.integration
 def test_safe_mode_blocks_intents_but_allows_hedging_orders() -> None:
     controller = safe_mode.controller
+    backend = MemoryRedis()
+    controller._state_store = safe_mode.SafeModeStateStore(redis_client=backend)
     controller.reset()
     safe_mode.clear_safe_mode_log()
 


### PR DESCRIPTION
## Summary
- replace the file-based safe mode state store with a Redis-backed implementation and persist new activations under lock
- maintain backwards compatibility for order controls and wire tests to use an in-memory Redis stub
- add regression coverage that confirms safe mode remains active after a controller restart and update integration setup

## Testing
- pytest tests/services/test_safe_mode.py
- pytest tests/integration/test_safe_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68e02183f7ec832196954c054f5916c6