### PR TITLE
Persist admin profiles and risk approvals via database

### DIFF
--- a/accounts/service.py
+++ b/accounts/service.py
@@ -1,12 +1,54 @@
 """Accounts service coordinating admin profiles and approval workflows."""
 from __future__ import annotations
 
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Callable, List, Optional, Sequence, Tuple
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, JSON, String, UniqueConstraint, create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship, sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.sql import func
 
 from shared.audit import SensitiveActionRecorder
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for the accounts service ORM models."""
+
+
+DEFAULT_DATABASE_URL = "sqlite:///./accounts.db"
+
+
+def _database_url() -> str:
+    url = (
+        os.getenv("ACCOUNTS_DATABASE_URL")
+        or os.getenv("TIMESCALE_DSN")
+        or os.getenv("DATABASE_URL")
+        or DEFAULT_DATABASE_URL
+    )
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg2://", 1)
+    return url
+
+
+def _engine_options(url: str) -> dict[str, object]:
+    options: dict[str, object] = {"future": True}
+    if url.startswith("sqlite://"):
+        options.setdefault("connect_args", {"check_same_thread": False})
+        if url.endswith(":memory:"):
+            options["poolclass"] = StaticPool
+    return options
+
+
+_DB_URL = _database_url()
+ENGINE: Engine = create_engine(_DB_URL, **_engine_options(_DB_URL))
+SessionLocal = sessionmaker(bind=ENGINE, autoflush=False, expire_on_commit=False, future=True)
 
 
 @dataclass
@@ -27,87 +69,293 @@ class RiskConfigurationChange:
     executed: bool = False
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
-    def approve(self, admin_id: str) -> None:
-        if admin_id in self.approvals:
-            raise PermissionError("duplicate_approval")
-        self.approvals.append(admin_id)
-
     @property
     def ready(self) -> bool:
         return len(self.approvals) >= 2 and not self.executed
 
 
+class AdminProfileRecord(Base):
+    """SQLAlchemy model backing persisted admin profiles."""
+
+    __tablename__ = "admin_profiles"
+
+    admin_id: Mapped[str] = mapped_column(String(length=64), primary_key=True)
+    email: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    kraken_credentials_linked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    last_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), server_default=func.now()
+    )
+
+
+class RiskConfigurationChangeRecord(Base):
+    """SQLAlchemy model for persisted risk configuration change requests."""
+
+    __tablename__ = "risk_configuration_changes"
+
+    request_id: Mapped[str] = mapped_column(String(length=64), primary_key=True)
+    requested_by: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON().with_variant(JSONB(none_as_null=True), "postgresql"), nullable=False)
+    executed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), server_default=func.now()
+    )
+
+    approvals: Mapped[List["RiskConfigurationApprovalRecord"]] = relationship(
+        back_populates="change",
+        cascade="all, delete-orphan",
+        order_by="RiskConfigurationApprovalRecord.approved_at",
+    )
+
+
+class RiskConfigurationApprovalRecord(Base):
+    """SQLAlchemy model tracking individual approvals for risk changes."""
+
+    __tablename__ = "risk_configuration_change_approvals"
+    __table_args__ = (UniqueConstraint("request_id", "admin_id", name="uq_risk_change_approval"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    request_id: Mapped[str] = mapped_column(
+        String(length=64), ForeignKey("risk_configuration_changes.request_id", ondelete="CASCADE"), nullable=False
+    )
+    admin_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    approved_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), server_default=func.now()
+    )
+
+    change: Mapped[RiskConfigurationChangeRecord] = relationship(back_populates="approvals")
+
+
+SessionFactory = Callable[[], Session]
+
+
+def _profile_from_record(record: AdminProfileRecord) -> AdminProfile:
+    return AdminProfile(
+        admin_id=record.admin_id,
+        email=record.email,
+        display_name=record.display_name,
+        kraken_credentials_linked=record.kraken_credentials_linked,
+        last_updated=record.last_updated,
+    )
+
+
+def _change_from_record(record: RiskConfigurationChangeRecord, approvals: Sequence[str]) -> RiskConfigurationChange:
+    return RiskConfigurationChange(
+        request_id=record.request_id,
+        requested_by=record.requested_by,
+        payload=dict(record.payload or {}),
+        approvals=list(approvals),
+        executed=record.executed,
+        created_at=record.created_at,
+    )
+
+
+class AccountsRepository:
+    """Persistence abstraction for admin profiles and risk configuration changes."""
+
+    def __init__(self, session_factory: SessionFactory) -> None:
+        self._session_factory = session_factory
+
+    def upsert_profile(self, profile: AdminProfile) -> Tuple[Optional[AdminProfile], AdminProfile]:
+        session = self._session_factory()
+        try:
+            record = session.get(AdminProfileRecord, profile.admin_id)
+            before = _profile_from_record(record) if record is not None else None
+            timestamp = datetime.now(timezone.utc)
+            if record is None:
+                record = AdminProfileRecord(
+                    admin_id=profile.admin_id,
+                    email=profile.email,
+                    display_name=profile.display_name,
+                    kraken_credentials_linked=profile.kraken_credentials_linked,
+                    last_updated=timestamp,
+                )
+                session.add(record)
+            else:
+                record.email = profile.email
+                record.display_name = profile.display_name
+                record.kraken_credentials_linked = profile.kraken_credentials_linked
+                record.last_updated = timestamp
+            session.commit()
+            session.refresh(record)
+            return before, _profile_from_record(record)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_profile(self, admin_id: str) -> Optional[AdminProfile]:
+        session = self._session_factory()
+        try:
+            record = session.get(AdminProfileRecord, admin_id)
+            if record is None:
+                return None
+            return _profile_from_record(record)
+        finally:
+            session.close()
+
+    def set_kraken_credentials_status(self, admin_id: str, linked: bool) -> Tuple[AdminProfile, AdminProfile]:
+        session = self._session_factory()
+        try:
+            record = session.get(AdminProfileRecord, admin_id)
+            if record is None:
+                raise KeyError("profile_missing")
+            before = _profile_from_record(record)
+            record.kraken_credentials_linked = linked
+            record.last_updated = datetime.now(timezone.utc)
+            session.commit()
+            session.refresh(record)
+            return before, _profile_from_record(record)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def request_risk_configuration_change(self, admin_id: str, payload: dict) -> RiskConfigurationChange:
+        session = self._session_factory()
+        try:
+            request_id = str(uuid.uuid4())
+            record = RiskConfigurationChangeRecord(
+                request_id=request_id,
+                requested_by=admin_id,
+                payload=dict(payload),
+                executed=False,
+            )
+            session.add(record)
+            session.commit()
+            session.refresh(record)
+            return _change_from_record(record, approvals=[])
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def approve_risk_change(
+        self, admin_id: str, request_id: str
+    ) -> Tuple[RiskConfigurationChange, List[str], bool]:
+        session = self._session_factory()
+        try:
+            stmt = select(RiskConfigurationChangeRecord).where(
+                RiskConfigurationChangeRecord.request_id == request_id
+            )
+            if session.bind and session.bind.dialect.name not in {"sqlite"}:
+                stmt = stmt.with_for_update()
+            record = session.execute(stmt).scalar_one_or_none()
+            if record is None:
+                raise KeyError("request_missing")
+            if record.executed:
+                raise PermissionError("already_executed")
+
+            approvals_before = (
+                session.execute(
+                    select(RiskConfigurationApprovalRecord.admin_id)
+                    .where(RiskConfigurationApprovalRecord.request_id == request_id)
+                    .order_by(RiskConfigurationApprovalRecord.approved_at)
+                )
+                .scalars()
+                .all()
+            )
+
+            if admin_id in approvals_before:
+                raise PermissionError("duplicate_approval")
+
+            executed_now = not record.executed and len(approvals_before) + 1 >= 2
+
+            approval = RiskConfigurationApprovalRecord(
+                request_id=request_id,
+                admin_id=admin_id,
+            )
+            session.add(approval)
+            try:
+                session.flush()
+            except IntegrityError as exc:
+                raise PermissionError("duplicate_approval") from exc
+
+            if executed_now:
+                record.executed = True
+
+            session.commit()
+
+            approvals_after = (
+                session.execute(
+                    select(RiskConfigurationApprovalRecord.admin_id)
+                    .where(RiskConfigurationApprovalRecord.request_id == request_id)
+                    .order_by(RiskConfigurationApprovalRecord.approved_at)
+                )
+                .scalars()
+                .all()
+            )
+            refreshed = session.get(RiskConfigurationChangeRecord, request_id)
+            assert refreshed is not None  # defensive, record must still exist
+            return _change_from_record(refreshed, approvals_after), approvals_before, executed_now
+        except PermissionError:
+            session.rollback()
+            raise
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
 class AccountsService:
     """Handles admin profile state, credential status, and risk workflows."""
 
-    def __init__(self, recorder: SensitiveActionRecorder) -> None:
+    def __init__(
+        self,
+        recorder: SensitiveActionRecorder,
+        repository: Optional[AccountsRepository] = None,
+    ) -> None:
         self._recorder = recorder
-        self._profiles: Dict[str, AdminProfile] = {}
-        self._risk_changes: Dict[str, RiskConfigurationChange] = {}
+        self._repository = repository or AccountsRepository(SessionLocal)
 
     def upsert_profile(self, profile: AdminProfile) -> AdminProfile:
-        before = self._profiles.get(profile.admin_id)
-        self._profiles[profile.admin_id] = profile
-        profile.last_updated = datetime.now(timezone.utc)
+        before, updated = self._repository.upsert_profile(profile)
         self._recorder.record(
             action="profile_update",
             actor_id=profile.admin_id,
             before=_profile_snapshot(before),
-            after=_profile_snapshot(profile),
+            after=_profile_snapshot(updated),
         )
-        return profile
+        return updated
 
     def get_profile(self, admin_id: str) -> Optional[AdminProfile]:
-        return self._profiles.get(admin_id)
+        return self._repository.get_profile(admin_id)
 
     def set_kraken_credentials_status(self, admin_id: str, linked: bool) -> AdminProfile:
-        profile = self._profiles.get(admin_id)
-        if not profile:
-            raise KeyError("profile_missing")
-        before = _profile_snapshot(profile)
-        profile.kraken_credentials_linked = linked
-        profile.last_updated = datetime.now(timezone.utc)
+        before, updated = self._repository.set_kraken_credentials_status(admin_id, linked)
         self._recorder.record(
             action="kraken_credentials_update",
             actor_id=admin_id,
-            before=before,
-            after=_profile_snapshot(profile),
+            before=_profile_snapshot(before),
+            after=_profile_snapshot(updated),
         )
-        return profile
+        return updated
 
     def request_risk_configuration_change(self, admin_id: str, payload: dict) -> RiskConfigurationChange:
-        request_id = str(uuid.uuid4())
-        change = RiskConfigurationChange(
-            request_id=request_id,
-            requested_by=admin_id,
-            payload=payload,
-        )
-        self._risk_changes[request_id] = change
+        change = self._repository.request_risk_configuration_change(admin_id, payload)
         self._recorder.record(
             action="risk_change_requested",
             actor_id=admin_id,
             before=None,
-            after={"request_id": request_id, "payload": payload},
+            after={"request_id": change.request_id, "payload": payload},
         )
         return change
 
     def approve_risk_change(self, admin_id: str, request_id: str) -> RiskConfigurationChange:
-        change = self._risk_changes.get(request_id)
-        if not change:
-            raise KeyError("request_missing")
-        if change.executed:
-            raise PermissionError("already_executed")
-        change.approve(admin_id)
-        if change.ready:
-            self._finalize_risk_change(change)
+        change, approvals_before, executed_now = self._repository.approve_risk_change(admin_id, request_id)
+        if executed_now:
+            self._finalize_risk_change(change, approvals_before)
         return change
 
-    def _finalize_risk_change(self, change: RiskConfigurationChange) -> None:
-        change.executed = True
+    def _finalize_risk_change(self, change: RiskConfigurationChange, approvals_before: Sequence[str]) -> None:
         self._recorder.record(
             action="risk_change_executed",
             actor_id=change.requested_by,
-            before={"payload": change.payload, "approvals": change.approvals[:-1]},
+            before={"payload": change.payload, "approvals": list(approvals_before)},
             after={"payload": change.payload, "approvals": change.approvals},
         )
 
@@ -144,4 +392,8 @@ __all__ = [
     "AdminProfile",
     "RiskConfigurationChange",
     "AccountsService",
+    "AccountsRepository",
+    "Base",
+    "ENGINE",
+    "SessionLocal",
 ]

--- a/data/migrations/versions/0004_create_accounts_tables.py
+++ b/data/migrations/versions/0004_create_accounts_tables.py
@@ -1,0 +1,51 @@
+"""Create tables for admin profiles and risk change approvals."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_profiles",
+        sa.Column("admin_id", sa.String(length=64), primary_key=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("kraken_credentials_linked", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("last_updated", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "risk_configuration_changes",
+        sa.Column("request_id", sa.String(length=64), primary_key=True),
+        sa.Column("requested_by", sa.String(length=64), nullable=False),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(none_as_null=True), "postgresql"),
+            nullable=False,
+        ),
+        sa.Column("executed", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "risk_configuration_change_approvals",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("request_id", sa.String(length=64), nullable=False),
+        sa.Column("admin_id", sa.String(length=64), nullable=False),
+        sa.Column("approved_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["request_id"], ["risk_configuration_changes.request_id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("request_id", "admin_id", name="uq_risk_change_approval"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("risk_configuration_change_approvals")
+    op.drop_table("risk_configuration_changes")
+    op.drop_table("admin_profiles")

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,32 +1,122 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, Iterable, Mapping
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 from shared.correlation import CorrelationContext
 
-from accounts.service import AccountsService
+from accounts.service import AccountsRepository, AccountsService, AdminProfile, Base
 
 
-def test_dual_approval_flow_requires_two_distinct_admins():
-    store = AuditLogStore()
+class _InMemoryAuditBackend:
+    def __init__(self) -> None:
+        self._records: list[Dict[str, Any]] = []
+
+    def record_audit_log(self, record: Mapping[str, Any]) -> None:
+        self._records.append(dict(record))
+
+    def audit_logs(self) -> Iterable[Mapping[str, Any]]:
+        return list(self._records)
+
+
+def _build_store() -> AuditLogStore:
+    return AuditLogStore(backend=_InMemoryAuditBackend())
+
+
+def _build_service(recorder: SensitiveActionRecorder, db_url: str) -> tuple[AccountsService, sessionmaker]:
+    engine = create_engine(db_url, future=True)
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+    repository = AccountsRepository(session_factory)
+    return AccountsService(recorder, repository=repository), session_factory
+
+
+def test_dual_approval_flow_requires_two_distinct_admins(tmp_path):
+    store = _build_store()
     logger = TimescaleAuditLogger(store)
     recorder = SensitiveActionRecorder(logger)
-    service = AccountsService(recorder)
+    db_url = f"sqlite:///{tmp_path/'accounts.db'}"
+    service, _ = _build_service(recorder, db_url)
 
     change = service.request_risk_configuration_change(
         "admin-a", {"max_drawdown": 0.5}
     )
-    service.approve_risk_change("admin-a", change.request_id)
-    assert not change.executed
+    result = service.approve_risk_change("admin-a", change.request_id)
+    assert not result.executed
 
     with CorrelationContext("corr-123"):
-        service.approve_risk_change("admin-b", change.request_id)
+        executed_change = service.approve_risk_change("admin-b", change.request_id)
 
-    assert change.executed
+    assert executed_change.executed
     entries = list(store.all())
     actions = [entry.action for entry in entries]
     assert "risk_change_requested" in actions
     assert "risk_change_executed" in actions
 
     executed_entry = next(entry for entry in entries if entry.action == "risk_change_executed")
-    assert executed_entry.after["approvals"] == change.approvals
+    assert executed_entry.after["approvals"] == executed_change.approvals
     assert executed_entry.correlation_id == "corr-123"
+
+
+def test_profiles_and_pending_approvals_survive_restart(tmp_path):
+    store = _build_store()
+    logger = TimescaleAuditLogger(store)
+    recorder = SensitiveActionRecorder(logger)
+    db_url = f"sqlite:///{tmp_path/'accounts_persist.db'}"
+
+    service_a, _ = _build_service(recorder, db_url)
+    profile = AdminProfile(admin_id="admin-a", email="admin@example.com", display_name="Admin A")
+    service_a.upsert_profile(profile)
+    updated_profile = service_a.set_kraken_credentials_status("admin-a", True)
+    assert updated_profile.kraken_credentials_linked is True
+
+    change = service_a.request_risk_configuration_change("admin-a", {"leverage": 3})
+    service_a.approve_risk_change("admin-a", change.request_id)
+
+    service_b, _ = _build_service(recorder, db_url)
+    persisted_profile = service_b.get_profile("admin-a")
+    assert persisted_profile is not None
+    assert persisted_profile.kraken_credentials_linked is True
+
+    finalized = service_b.approve_risk_change("admin-b", change.request_id)
+    assert finalized.executed
+    assert finalized.approvals.count("admin-a") == 1
+    assert finalized.approvals.count("admin-b") == 1
+
+
+def test_concurrent_approvals_enforce_two_person_rule(tmp_path):
+    store = _build_store()
+    logger = TimescaleAuditLogger(store)
+    recorder = SensitiveActionRecorder(logger)
+    db_url = f"sqlite:///{tmp_path/'accounts_concurrency.db'}"
+    service, _ = _build_service(recorder, db_url)
+
+    change = service.request_risk_configuration_change("admin-a", {"exposure_limit": 1000000})
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(service.approve_risk_change, "admin-a", change.request_id),
+            pool.submit(service.approve_risk_change, "admin-a", change.request_id),
+        ]
+
+    successes = 0
+    duplicates = 0
+    for future in futures:
+        try:
+            future.result()
+            successes += 1
+        except PermissionError as exc:
+            assert str(exc) == "duplicate_approval"
+            duplicates += 1
+
+    assert successes == 1
+    assert duplicates == 1
+
+    finalized = service.approve_risk_change("admin-b", change.request_id)
+    assert finalized.executed
+    assert finalized.approvals.count("admin-a") == 1
+    assert finalized.approvals.count("admin-b") == 1


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models and repository for admin profiles and risk configuration changes backed by the shared database
- refactor AccountsService to persist profiles, credential state, and risk approvals through the repository
- add an Alembic migration and tests that cover persistence across restarts and concurrent approvals

## Testing
- pytest tests/test_accounts.py

------
https://chatgpt.com/codex/tasks/task_e_68e02183cc8c8321b80cb19f70f50996