### PR TITLE
Expose Kraken order metadata in placement response

### DIFF
--- a/services/common/schemas.py
+++ b/services/common/schemas.py
@@ -389,6 +389,18 @@ class OrderPlacementResponse(BaseModel):
     accepted: bool = Field(..., description="Whether the order was accepted by OMS")
     routed_venue: str = Field(..., description="Venue to which the order is routed")
     fee: FeeBreakdown = Field(..., description="Final fees for the order")
+    exchange_order_id: Optional[str] = Field(
+        None,
+        description="Identifier assigned by the exchange for the order",
+    )
+    kraken_status: Optional[str] = Field(
+        None,
+        description="Raw status string returned from Kraken for the order",
+    )
+    errors: Optional[List[str]] = Field(
+        None,
+        description="Any error messages returned from Kraken during placement",
+    )
 
 
 class FeeScheduleResponse(BaseModel):

--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -1373,7 +1373,14 @@ async def place_order(
 
     accepted = (not status_value) or status_value in _SUCCESS_STATUSES
     venue = "kraken"
-    return OrderPlacementResponse(accepted=accepted, routed_venue=venue, fee=request.fee)
+    return OrderPlacementResponse(
+        accepted=accepted,
+        routed_venue=venue,
+        fee=request.fee,
+        exchange_order_id=ack.exchange_order_id,
+        kraken_status=ack_payload.get("status"),
+        errors=ack_payload.get("errors"),
+    )
 
 
 @app.post("/oms/cancel", response_model=CancelOrderResponse)

--- a/tests/integration/test_secrets_rotation.py
+++ b/tests/integration/test_secrets_rotation.py
@@ -248,6 +248,9 @@ def test_rotate_secret_triggers_oms_reload(monkeypatch: pytest.MonkeyPatch, capl
         order_payload = order_response.json()
         assert order_payload["accepted"] is True
         assert order_payload["routed_venue"] == "kraken"
+        assert order_payload["exchange_order_id"] == "SIM-ROTATE"
+        assert order_payload["kraken_status"] == "ok"
+        assert order_payload["errors"] is None
 
         recorded = _RecordingKrakenWSClient.last_session_credentials or {}
         assert recorded.get("api_key") == new_key

--- a/tests/oms/test_endpoints.py
+++ b/tests/oms/test_endpoints.py
@@ -308,6 +308,9 @@ def test_place_order_allows_admin_accounts(client: TestClient, account_id: str) 
         "accepted": True,
         "routed_venue": "kraken",
         "fee": payload["fee"],
+        "exchange_order_id": "SIM-123",
+        "kraken_status": "ok",
+        "errors": None,
     }
 
 
@@ -346,7 +349,7 @@ def test_place_order_rejected_ack_sets_accepted_false(
                     status="rejected",
                     filled_qty=None,
                     avg_price=None,
-                    errors=None,
+                    errors=["EOrder:post only"]
                 )
 
             async def fetch_open_orders_snapshot(self) -> list[Dict[str, Any]]:
@@ -365,7 +368,7 @@ def test_place_order_rejected_ack_sets_accepted_false(
                     status="rejected",
                     filled_qty=None,
                     avg_price=None,
-                    errors=None,
+                    errors=["EOrder:post only"]
                 )
 
             async def open_orders(self) -> Dict[str, Any]:
@@ -410,6 +413,9 @@ def test_place_order_rejected_ack_sets_accepted_false(
         "accepted": False,
         "routed_venue": "kraken",
         "fee": payload["fee"],
+        "exchange_order_id": "SIM-REJECT",
+        "kraken_status": "rejected",
+        "errors": ["EOrder:post only"],
     }
 
 

--- a/tests/oms/test_oms.py
+++ b/tests/oms/test_oms.py
@@ -141,8 +141,18 @@ def test_oms_place_authorized_accounts(client: TestClient) -> None:
         response = client.post("/oms/place", json=payload, headers={"X-Account-ID": account})
         assert response.status_code == 200
         data = response.json()
-        assert set(data.keys()) == {"accepted", "routed_venue", "fee"}
+        assert set(data.keys()) == {
+            "accepted",
+            "routed_venue",
+            "fee",
+            "exchange_order_id",
+            "kraken_status",
+            "errors",
+        }
         assert data["fee"] == payload["fee"]
+        assert data["exchange_order_id"] == "SIM-123"
+        assert data["kraken_status"] == "ok"
+        assert data["errors"] is None
 
 
 def test_oms_place_rejects_non_admin_account(client: TestClient) -> None:

--- a/tests/oms/test_place_order.py
+++ b/tests/oms/test_place_order.py
@@ -94,7 +94,11 @@ def test_precision_snapping_buy_never_exceeds(
 
     response = client.post("/oms/place", json=payload, headers={"X-Account-ID": "company"})
     assert response.status_code == 200
-    assert response.json()["accepted"] is True
+    body = response.json()
+    assert body["accepted"] is True
+    assert body["exchange_order_id"] == "ABC123"
+    assert body["kraken_status"] == "ok"
+    assert body["errors"] is None
 
     assert records, "Kraken client was not invoked"
     snapped_payload = records[0].requests[0]
@@ -145,7 +149,11 @@ def test_precision_snapping_sell_never_falls_short(
 
     response = client.post("/oms/place", json=payload, headers={"X-Account-ID": "company"})
     assert response.status_code == 200
-    assert response.json()["accepted"] is True
+    body = response.json()
+    assert body["accepted"] is True
+    assert body["exchange_order_id"] == "ABC123"
+    assert body["kraken_status"] == "ok"
+    assert body["errors"] is None
 
     assert records, "Kraken client was not invoked"
     snapped_payload = records[0].requests[0]


### PR DESCRIPTION
## Summary
- extend the OMS order placement response schema to expose the Kraken txid, status, and any reported errors
- plumb the exchange ack details through `place_order` so clients receive identifiers and rejection metadata
- update OMS FastAPI tests to assert the richer payload on success and rejection flows

## Testing
- `pytest tests/oms/test_endpoints.py tests/oms/test_oms.py tests/oms/test_place_order.py tests/integration/test_secrets_rotation.py` *(fails: NameError importing services.common.adapters due to missing main symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68e041ebd1b48321aef683d140cc3dfd