### PR TITLE
Implement shared precision provider for Kraken metadata

### DIFF
--- a/services/common/precision.py
+++ b/services/common/precision.py
@@ -1,16 +1,230 @@
-"""Precision metadata for Kraken trading pairs."""
+"""Precision metadata client shared by services that snap Kraken orders."""
 
 from __future__ import annotations
 
-from typing import Dict
+import logging
+import threading
+import time
+from decimal import Decimal, InvalidOperation
+from typing import Any, Callable, Dict, Mapping, Optional
 
-# Representative subset of Kraken precision metadata. The defaults favour
-# conservative rounding so the policy service never exceeds venue limits.
-KRAKEN_PRECISION: Dict[str, Dict[str, float]] = {
-    "BTC-USD": {"tick": 0.1, "lot": 0.0001},
-    "ETH-USD": {"tick": 0.05, "lot": 0.0001},
-    "SOL-USD": {"tick": 0.01, "lot": 0.001},
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class PrecisionMetadataUnavailable(RuntimeError):
+    """Raised when precision metadata for a symbol cannot be resolved."""
+
+
+class PrecisionMetadataProvider:
+    """Fetch and cache Kraken precision metadata for reuse across services."""
+
+    def __init__(
+        self,
+        *,
+        fetcher: Callable[[], Mapping[str, Any]] | None = None,
+        refresh_interval: float = 300.0,
+        timeout: float = 2.5,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._fetcher = fetcher or self._default_fetcher
+        self._refresh_interval = max(float(refresh_interval), 0.0)
+        self._timeout = max(float(timeout), 0.0)
+        self._time_source = time_source
+        self._lock = threading.Lock()
+        self._cache: Dict[str, Dict[str, float]] = {}
+        self._last_refresh: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get(self, symbol: str) -> Optional[Dict[str, float]]:
+        """Return precision metadata for ``symbol`` if available."""
+
+        normalized = _normalize_symbol(symbol)
+        if not normalized:
+            return None
+        self._maybe_refresh()
+        with self._lock:
+            entry = self._cache.get(normalized)
+            return dict(entry) if entry else None
+
+    def require(self, symbol: str) -> Dict[str, float]:
+        """Return precision metadata for ``symbol`` or raise."""
+
+        metadata = self.get(symbol)
+        if metadata is None:
+            raise PrecisionMetadataUnavailable(f"Precision metadata unavailable for {symbol}")
+        return metadata
+
+    def refresh(self, *, force: bool = False) -> None:
+        """Force a metadata refresh regardless of cache age if requested."""
+
+        if not force and not self._needs_refresh():
+            return
+        try:
+            payload = self._fetcher()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to fetch Kraken precision metadata: %s", exc)
+            return
+
+        parsed = _parse_asset_pairs(payload)
+        if not parsed:
+            logger.warning("Received empty Kraken precision metadata payload")
+            return
+
+        with self._lock:
+            self._cache = parsed
+            self._last_refresh = self._time_source()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _needs_refresh(self) -> bool:
+        if not self._cache:
+            return True
+        age = self._time_source() - self._last_refresh
+        return age >= self._refresh_interval
+
+    def _maybe_refresh(self) -> None:
+        if self._needs_refresh():
+            self.refresh(force=True)
+
+    def _default_fetcher(self) -> Mapping[str, Any]:
+        url = "https://api.kraken.com/0/public/AssetPairs"
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            payload = response.json()
+        if isinstance(payload, Mapping):
+            result = payload.get("result")
+            if isinstance(result, Mapping):
+                return result
+        return {}
+
+
+def _normalize_symbol(symbol: str) -> str:
+    token = (symbol or "").replace("/", "-").strip().upper()
+    return token
+
+
+_BASE_ALIASES: Dict[str, str] = {
+    "XBT": "BTC",
+    "XXBT": "BTC",
+    "XXBTZ": "BTC",
+    "XETH": "ETH",
+    "XETC": "ETC",
+    "XXDG": "DOGE",
+    "XDG": "DOGE",
 }
+_QUOTE_ALIASES: Dict[str, str] = {"ZUSD": "USD", "USD": "USD"}
 
-__all__ = ["KRAKEN_PRECISION"]
+
+def _normalize_asset(symbol: str, *, is_quote: bool) -> str:
+    token = (symbol or "").strip().upper()
+    if not token:
+        return ""
+    aliases = _QUOTE_ALIASES if is_quote else _BASE_ALIASES
+    direct = aliases.get(token)
+    if direct:
+        return direct
+
+    trimmed = token
+    while len(trimmed) > 3 and trimmed.endswith(("X", "Z")):
+        trimmed = trimmed[:-1]
+    while len(trimmed) > 3 and trimmed.startswith(("X", "Z")):
+        trimmed = trimmed[1:]
+
+    return aliases.get(trimmed, trimmed)
+
+
+def _normalize_instrument(entry: Mapping[str, Any]) -> str:
+    wsname = entry.get("wsname")
+    if isinstance(wsname, str) and "/" in wsname:
+        base_part, quote_part = wsname.split("/", 1)
+        base = _normalize_asset(base_part, is_quote=False)
+        quote = _normalize_asset(quote_part, is_quote=True)
+        if base and quote == "USD":
+            return f"{base}-USD"
+
+    altname = entry.get("altname")
+    if isinstance(altname, str):
+        cleaned = altname.replace("/", "").upper()
+        if cleaned.endswith("USD") and len(cleaned) > 3:
+            base = _normalize_asset(cleaned[:-3], is_quote=False)
+            if base:
+                return f"{base}-USD"
+
+    base = _normalize_asset(str(entry.get("base") or ""), is_quote=False)
+    quote = _normalize_asset(str(entry.get("quote") or ""), is_quote=True)
+    if base and quote == "USD":
+        return f"{base}-USD"
+    return ""
+
+
+def _step_from_metadata(
+    metadata: Mapping[str, Any],
+    step_keys: tuple[str, ...],
+    decimal_keys: tuple[str, ...],
+) -> Optional[Decimal]:
+    for key in step_keys:
+        value = metadata.get(key)
+        if value is None:
+            continue
+        try:
+            step = Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            continue
+        if step > 0:
+            return step
+
+    for key in decimal_keys:
+        value = metadata.get(key)
+        if value is None:
+            continue
+        try:
+            decimals = int(value)
+        except (TypeError, ValueError):
+            continue
+        if decimals < 0:
+            continue
+        return Decimal("1") / (Decimal("10") ** decimals)
+    return None
+
+
+def _parse_asset_pairs(payload: Mapping[str, Any]) -> Dict[str, Dict[str, float]]:
+    if isinstance(payload.get("result"), Mapping):
+        payload = payload["result"]  # type: ignore[assignment]
+
+    parsed: Dict[str, Dict[str, float]] = {}
+    for entry in payload.values():
+        if not isinstance(entry, Mapping):
+            continue
+        instrument = _normalize_instrument(entry)
+        if not instrument:
+            continue
+        tick = _step_from_metadata(
+            entry,
+            ("tick_size", "price_increment"),
+            ("pair_decimals",),
+        )
+        lot = _step_from_metadata(
+            entry,
+            ("lot_step", "step_size"),
+            ("lot_decimals",),
+        )
+        if tick is None or lot is None:
+            continue
+        parsed[instrument] = {"tick": float(tick), "lot": float(lot)}
+    return parsed
+
+
+precision_provider = PrecisionMetadataProvider()
+
+__all__ = [
+    "PrecisionMetadataProvider",
+    "PrecisionMetadataUnavailable",
+    "precision_provider",
+]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,6 +339,51 @@ if _class_validators is not None:
     _class_validators.root_validator = _compat_root_validator  # type: ignore[assignment]
 
 
+def _precision_fixture_payload() -> Dict[str, Dict[str, str]]:
+    def _entry(base: str, tick: float, lot: float) -> Dict[str, str]:
+        return {
+            "wsname": f"{base}/USD",
+            "tick_size": str(tick),
+            "lot_step": str(lot),
+        }
+
+    return {
+        "BTCUSD": _entry("BTC", 0.1, 0.0001),
+        "ETHUSD": _entry("ETH", 0.05, 0.001),
+        "SOLUSD": _entry("SOL", 0.01, 0.1),
+        "USDTUSD": _entry("USDT", 0.001, 1.0),
+        "ADAUSD": _entry("ADA", 0.0001, 0.1),
+        "TSTUSD": _entry("TST", 1e-08, 1e-08),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _seed_precision_cache(monkeypatch: pytest.MonkeyPatch):
+    try:
+        from services.common import precision as precision_module
+    except Exception:  # pragma: no cover - precision module not available
+        yield
+        return
+
+    payload = _precision_fixture_payload()
+    provider = precision_module.PrecisionMetadataProvider(
+        fetcher=lambda: payload,
+        refresh_interval=0.0,
+    )
+    provider.refresh(force=True)
+    monkeypatch.setattr(precision_module, "precision_provider", provider)
+
+    policy_module = sys.modules.get("policy_service")
+    if policy_module is not None:
+        monkeypatch.setattr(policy_module, "precision_provider", provider, raising=False)
+
+    position_sizer_module = sys.modules.get("services.risk.position_sizer")
+    if position_sizer_module is not None:
+        monkeypatch.setattr(position_sizer_module, "precision_provider", provider, raising=False)
+
+    yield provider
+
+
 @pytest.fixture(autouse=True)
 def _configure_security_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     try:  # FastAPI is optional in some test environments

--- a/tests/integration/test_fee_enforcement.py
+++ b/tests/integration/test_fee_enforcement.py
@@ -27,6 +27,7 @@ def test_fee_enforcement_blocks_negative_edge(monkeypatch: pytest.MonkeyPatch) -
         traced_span=lambda *args, **kwargs: contextlib.nullcontext(),
         record_scaling_state=lambda *args, **kwargs: None,
         observe_scaling_evaluation=lambda *args, **kwargs: None,
+        get_request_id=lambda: None,
     )
     monkeypatch.setitem(sys.modules, "metrics", metrics_stub)
 

--- a/tests/integration/test_trading_pipeline.py
+++ b/tests/integration/test_trading_pipeline.py
@@ -100,7 +100,7 @@ class Sequencer:
 @pytest.mark.slow
 def test_trading_pipeline_emits_fill_event(monkeypatch: pytest.MonkeyPatch) -> None:
     metrics_stub = types.SimpleNamespace(
-        setup_metrics=lambda app: None,
+        setup_metrics=lambda *args, **kwargs: None,
         record_abstention_rate=lambda *args, **kwargs: None,
         record_drift_score=lambda *args, **kwargs: None,
         increment_trade_rejection=lambda *args, **kwargs: None,
@@ -112,6 +112,7 @@ def test_trading_pipeline_emits_fill_event(monkeypatch: pytest.MonkeyPatch) -> N
         record_oms_submit_ack=lambda *args, **kwargs: None,
         record_scaling_state=lambda *args, **kwargs: None,
         observe_scaling_evaluation=lambda *args, **kwargs: None,
+        get_request_id=lambda: None,
     )
     sys.modules["metrics"] = metrics_stub
 

--- a/tests/integration/test_warm_start.py
+++ b/tests/integration/test_warm_start.py
@@ -196,6 +196,7 @@ if "metrics" not in sys.modules:
     metrics_stub.record_drift_score = _noop
     metrics_stub.record_scaling_state = _noop
     metrics_stub.observe_scaling_evaluation = _noop
+    metrics_stub.get_request_id = lambda: None
     sys.modules["metrics"] = metrics_stub
 
 from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter

--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 if "metrics" not in sys.modules:
     metrics_stub = types.ModuleType("metrics")
-    def _setup_metrics(app):
+    def _setup_metrics(app, *args, **kwargs):
         if not any(route.path == "/metrics" for route in app.routes):
             @app.get("/metrics")  # pragma: no cover - simple stub endpoint
             def _metrics_endpoint():
@@ -22,6 +22,7 @@ if "metrics" not in sys.modules:
     metrics_stub.record_drift_score = lambda *args, **kwargs: None
     metrics_stub.record_scaling_state = lambda *args, **kwargs: None
     metrics_stub.observe_scaling_evaluation = lambda *args, **kwargs: None
+    metrics_stub.get_request_id = lambda: None
     sys.modules["metrics"] = metrics_stub
 
 from services.common.schemas import ActionTemplate, ConfidenceMetrics, PolicyDecisionResponse

--- a/tests/risk/test_position_sizer_precision.py
+++ b/tests/risk/test_position_sizer_precision.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from services.risk.position_sizer import PositionSizer
+
+
+@dataclass
+class _Limits:
+    max_nav_pct_per_trade: float = 0.5
+    notional_cap: float = 0.0
+
+
+class _StaticTimescale:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def load_risk_config(self) -> dict[str, float]:
+        return {}
+
+
+class _StaticFeatures:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def fetch_online_features(self, symbol: str) -> dict[str, float]:
+        return {}
+
+    def fee_override(self, symbol: str):  # pragma: no cover - simple stub
+        return None
+
+
+def test_position_sizer_quantizes_using_precision() -> None:
+    sizer = PositionSizer(
+        "acct-1",
+        limits=_Limits(),
+        timescale=_StaticTimescale(),
+        feature_store=_StaticFeatures(),
+    )
+
+    result = sizer.suggest_max_position(
+        "ADA-USD",
+        nav=2000.0,
+        available_balance=2000.0,
+        volatility=0.25,
+        expected_edge_bps=50.0,
+        fee_bps_estimate=1.0,
+        price=0.25973,
+        regime="trend",
+    )
+
+    assert result.reason == "sized"
+    multiple = result.size_units / 0.1
+    assert multiple == pytest.approx(round(multiple), abs=1e-9)
+    assert result.size_units > 0
+
+
+def test_position_sizer_halts_when_precision_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from services.common import precision as precision_module
+
+    provider = precision_module.PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
+    provider.refresh(force=True)
+
+    monkeypatch.setattr(precision_module, "precision_provider", provider)
+    monkeypatch.setattr("services.risk.position_sizer.precision_provider", provider)
+
+    sizer = PositionSizer(
+        "acct-2",
+        limits=_Limits(),
+        timescale=_StaticTimescale(),
+        feature_store=_StaticFeatures(),
+    )
+
+    result = sizer.suggest_max_position(
+        "MISSING-USD",
+        nav=1000.0,
+        available_balance=1000.0,
+        volatility=0.2,
+        expected_edge_bps=20.0,
+        fee_bps_estimate=1.0,
+        price=1.0,
+    )
+
+    assert result.reason == "precision_metadata_missing"
+    assert result.max_size_usd == pytest.approx(0.0)
+    assert result.size_units == pytest.approx(0.0)
+

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from services.common.precision import (
+    PrecisionMetadataProvider,
+    PrecisionMetadataUnavailable,
+)
+
+
+def _payload(tick: float, lot: float) -> dict[str, dict[str, str]]:
+    return {
+        "ADAUSD": {
+            "wsname": "ADA/USD",
+            "tick_size": str(tick),
+            "lot_step": str(lot),
+        }
+    }
+
+
+def test_precision_provider_refreshes_metadata() -> None:
+    payload_ref: dict[str, dict[str, dict[str, str]]] = {"data": _payload(0.0001, 0.1)}
+
+    def _fetch() -> dict[str, dict[str, str]]:
+        return payload_ref["data"]
+
+    provider = PrecisionMetadataProvider(fetcher=_fetch, refresh_interval=0.0)
+    provider.refresh(force=True)
+
+    first = provider.require("ADA-USD")
+    assert first["tick"] == pytest.approx(0.0001)
+    assert first["lot"] == pytest.approx(0.1)
+
+    payload_ref["data"] = _payload(0.001, 5.0)
+    provider.refresh(force=True)
+
+    updated = provider.require("ADA-USD")
+    assert updated["tick"] == pytest.approx(0.001)
+    assert updated["lot"] == pytest.approx(5.0)
+
+
+def test_precision_provider_missing_symbol_raises() -> None:
+    provider = PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
+    provider.refresh(force=True)
+
+    with pytest.raises(PrecisionMetadataUnavailable):
+        provider.require("UNKNOWN")
+

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -17,11 +17,12 @@ from fastapi.testclient import TestClient
 
 if "metrics" not in sys.modules:
     metrics_stub = types.ModuleType("metrics")
-    metrics_stub.setup_metrics = lambda app: None
+    metrics_stub.setup_metrics = lambda *args, **kwargs: None
     metrics_stub.record_abstention_rate = lambda *args, **kwargs: None
     metrics_stub.record_drift_score = lambda *args, **kwargs: None
     metrics_stub.record_scaling_state = lambda *args, **kwargs: None
     metrics_stub.observe_scaling_evaluation = lambda *args, **kwargs: None
+    metrics_stub.get_request_id = lambda: None
     sys.modules["metrics"] = metrics_stub
 
 import policy_service
@@ -47,6 +48,15 @@ def _client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     monkeypatch.setattr(policy_service.EXCHANGE_ADAPTER, "place_order", _noop_place_order)
     monkeypatch.setattr(policy_service.EXCHANGE_ADAPTER, "supports", lambda op: True)
+    monkeypatch.setattr(
+        "shared.graceful_shutdown.install_sigterm_handler",
+        lambda manager: None,
+    )
+
+    async def _healthy() -> bool:
+        return True
+
+    monkeypatch.setattr(policy_service, "_model_health_ok", _healthy)
     policy_service.app.dependency_overrides[policy_service.require_admin_account] = lambda: "company"
     with TestClient(policy_service.app) as client:
         yield client
@@ -216,12 +226,6 @@ def test_policy_decide_preserves_tick_precision(
         return {"maker": Decimal("1.2345"), "taker": Decimal("2.3456")}[liquidity]
 
     monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
-    monkeypatch.setitem(
-        policy_service.KRAKEN_PRECISION,
-        "TST-USD",
-        {"tick": 0.00000001, "lot": 0.00000001},
-    )
-
     payload = {
         "account_id": "company",
         "order_id": "precise-1",
@@ -243,6 +247,18 @@ def test_policy_decide_preserves_tick_precision(
     body = _validate_response(response.json())
     assert body.effective_fee.maker == pytest.approx(1.2345)
     assert body.effective_fee.taker == pytest.approx(2.3456)
+
+
+def test_policy_resolves_precision_for_ada_pair() -> None:
+    precision = policy_service._resolve_precision("ADA-USD")
+    assert precision["tick"] == pytest.approx(0.0001)
+    assert precision["lot"] == pytest.approx(0.1)
+
+    snapped_price = policy_service._snap(0.256789, precision["tick"])
+    snapped_qty = policy_service._snap(12.3456, precision["lot"])
+
+    assert snapped_price == pytest.approx(0.2568)
+    assert snapped_qty == pytest.approx(12.3)
 
 
 def test_policy_decide_rejects_when_slippage_erodes_edge(

--- a/tests/unit/services/test_oms_kraken_reconciliation.py
+++ b/tests/unit/services/test_oms_kraken_reconciliation.py
@@ -167,6 +167,7 @@ metrics_stub.record_oms_latency = _noop
 metrics_stub.setup_metrics = _noop
 metrics_stub.record_scaling_state = _noop
 metrics_stub.observe_scaling_evaluation = _noop
+metrics_stub.get_request_id = lambda: None
 metrics_stub._REGISTRY = object()
 sys.modules['metrics'] = metrics_stub
 

--- a/tests/unit/test_oms_service_precision.py
+++ b/tests/unit/test_oms_service_precision.py
@@ -92,6 +92,7 @@ if "metrics" not in sys.modules:
     metrics_stub.record_oms_latency = _noop
     metrics_stub.setup_metrics = _noop
     metrics_stub.traced_span = traced_span
+    metrics_stub.get_request_id = lambda: None
     metrics_stub._REGISTRY = object()
     sys.modules["metrics"] = metrics_stub
 


### PR DESCRIPTION
## Summary
- add a shared Kraken precision provider that fetches and caches asset pair metadata for tick and lot increments
- require live precision data in the policy service and position sizer, halting safely when metadata is missing
- extend the test suite with ADA-USD coverage, refresh regression cases, and updated stubs for metrics fixtures

## Testing
- pytest tests/services/common/test_precision_provider.py tests/test_policy_service_api.py::test_policy_resolves_precision_for_ada_pair tests/test_policy_service_api.py::test_policy_decide_preserves_tick_precision tests/risk/test_position_sizer_precision.py

------
https://chatgpt.com/codex/tasks/task_e_68e0448ab0208321917c2cfb335a844a