### PR TITLE
Persist OMS circuit breaker halts across restarts

### DIFF
--- a/services/oms/circuit_breaker_store.py
+++ b/services/oms/circuit_breaker_store.py
@@ -1,0 +1,157 @@
+"""Persistence helpers for sharing circuit breaker state across replicas."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Dict, Optional
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CircuitBreakerPersistedState:
+    """Serializable representation of a halted instrument."""
+
+    instrument: str
+    reason: str
+    expires_at: Optional[float]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "instrument": self.instrument,
+            "reason": self.reason,
+            "expires_at": self.expires_at,
+        }
+
+    @staticmethod
+    def from_dict(payload: Dict[str, object]) -> Optional["CircuitBreakerPersistedState"]:
+        instrument = payload.get("instrument")
+        reason = payload.get("reason")
+        expires_raw = payload.get("expires_at")
+
+        if not isinstance(instrument, str) or not instrument:
+            return None
+        if not isinstance(reason, str) or not reason:
+            return None
+
+        expires_at: Optional[float]
+        if isinstance(expires_raw, (int, float)):
+            expires_at = float(expires_raw)
+        else:
+            expires_at = None
+
+        return CircuitBreakerPersistedState(
+            instrument=instrument,
+            reason=reason,
+            expires_at=expires_at,
+        )
+
+
+class CircuitBreakerStateStore:
+    """Persist circuit breaker halts in Redis for crash recovery."""
+
+    _DEFAULT_KEY = "oms:circuit-breakers:halts"
+
+    def __init__(
+        self,
+        redis_client: Optional[Any] = None,
+        *,
+        key: str = _DEFAULT_KEY,
+    ) -> None:
+        self._lock = Lock()
+        self._key = key
+        self._redis = redis_client or self._create_default_client()
+
+    @staticmethod
+    def _create_default_client() -> Any:
+        redis_url = os.getenv("OMS_CIRCUIT_BREAKER_REDIS_URL", "redis://localhost:6379/0")
+        try:  # pragma: no cover - dependency managed at runtime
+            import redis  # type: ignore[import-not-found]
+        except Exception as exc:  # pragma: no cover - defensive guard when Redis is unavailable
+            raise RuntimeError("redis package is required for circuit breaker persistence") from exc
+        return redis.Redis.from_url(redis_url, decode_responses=True)
+
+    def _load_payload(self) -> Dict[str, Dict[str, object]]:
+        try:
+            raw_state = self._redis.get(self._key)
+        except Exception as exc:  # pragma: no cover - operational resilience
+            LOGGER.warning("Failed to load circuit breaker state: %s", exc)
+            return {}
+
+        if raw_state is None:
+            return {}
+
+        if isinstance(raw_state, bytes):
+            try:
+                raw_state = raw_state.decode("utf-8")
+            except UnicodeDecodeError:
+                return {}
+
+        try:
+            payload = json.loads(raw_state)
+        except (TypeError, json.JSONDecodeError):
+            return {}
+
+        if not isinstance(payload, dict):
+            return {}
+
+        normalized: Dict[str, Dict[str, object]] = {}
+        for instrument, entry in payload.items():
+            if isinstance(instrument, str) and isinstance(entry, dict):
+                normalized[instrument] = dict(entry)
+        return normalized
+
+    def _persist_payload(self, payload: Dict[str, Dict[str, object]]) -> None:
+        try:
+            if payload:
+                serialized = json.dumps(payload)
+                self._redis.set(self._key, serialized)
+            else:
+                self._redis.delete(self._key)
+        except Exception as exc:  # pragma: no cover - operational resilience
+            LOGGER.warning("Failed to persist circuit breaker state: %s", exc)
+
+    def load_all(self) -> Dict[str, CircuitBreakerPersistedState]:
+        with self._lock:
+            payload = self._load_payload()
+
+        result: Dict[str, CircuitBreakerPersistedState] = {}
+        for instrument, raw_state in payload.items():
+            persisted = CircuitBreakerPersistedState.from_dict({
+                "instrument": instrument,
+                **raw_state,
+            })
+            if persisted is not None:
+                result[instrument] = persisted
+        return result
+
+    def save(self, state: CircuitBreakerPersistedState) -> None:
+        with self._lock:
+            payload = self._load_payload()
+            payload[state.instrument] = state.to_dict()
+            self._persist_payload(payload)
+
+    def delete(self, instrument: str) -> None:
+        with self._lock:
+            payload = self._load_payload()
+            if instrument in payload:
+                payload.pop(instrument, None)
+                self._persist_payload(payload)
+
+    def clear(self) -> None:
+        with self._lock:
+            try:
+                self._redis.delete(self._key)
+            except Exception as exc:  # pragma: no cover - operational resilience
+                LOGGER.warning("Failed to clear circuit breaker state: %s", exc)
+
+
+__all__ = [
+    "CircuitBreakerPersistedState",
+    "CircuitBreakerStateStore",
+]

--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -54,6 +54,8 @@ from services.oms.rate_limit_guard import rate_limit_guard
 from services.oms.shadow_oms import shadow_oms
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
 
+from services.oms.circuit_breaker_store import CircuitBreakerStateStore, CircuitBreakerPersistedState
+
 try:  # pragma: no cover - optional dependency during tests
     import websockets
     from websockets import WebSocketClientProtocol
@@ -253,6 +255,7 @@ async def _await_background_tasks(timeout: float) -> None:
 @app.on_event("startup")
 async def _on_startup_initialize_metadata() -> None:
     await market_metadata_cache.start()
+    CircuitBreaker.reload_from_store()
 
 
 @app.on_event("shutdown")
@@ -263,29 +266,62 @@ async def _on_shutdown_complete() -> None:
 
 
 class CircuitBreaker:
-    _halts: Dict[str, Dict[str, float | str]] = {}
+    _halts: Dict[str, Dict[str, object]] = {}
+    _store: CircuitBreakerStateStore | None = None
+
+    @classmethod
+    def use_store(cls, store: CircuitBreakerStateStore | None) -> None:
+        cls._store = store
+
+    @classmethod
+    def reload_from_store(cls) -> None:
+        if cls._store is None:
+            return
+        persisted = cls._store.load_all()
+        cls._halts.clear()
+        now = time.time()
+        for instrument, state in persisted.items():
+            expires_at = state.expires_at
+            if expires_at is not None and expires_at <= now:
+                cls._store.delete(instrument)
+                continue
+            cls._halts[instrument] = {"reason": state.reason, "expires": expires_at}
 
     @classmethod
     def halt(cls, instrument: str, reason: str, ttl_seconds: float | None = None) -> None:
-        expires = float("inf") if ttl_seconds is None else time.time() + ttl_seconds
+        expires = None if ttl_seconds is None else time.time() + ttl_seconds
         cls._halts[instrument] = {"reason": reason, "expires": expires}
+        if cls._store is not None:
+            cls._store.save(
+                CircuitBreakerPersistedState(
+                    instrument=instrument,
+                    reason=reason,
+                    expires_at=expires,
+                )
+            )
 
     @classmethod
     def resume(cls, instrument: str) -> None:
         cls._halts.pop(instrument, None)
+        if cls._store is not None:
+            cls._store.delete(instrument)
 
     @classmethod
     def reset(cls) -> None:
         cls._halts.clear()
+        if cls._store is not None:
+            cls._store.clear()
 
     @classmethod
     def is_halted(cls, instrument: str) -> bool:
         data = cls._halts.get(instrument)
         if not data:
             return False
-        expires = data.get("expires", float("inf"))
-        if expires != float("inf") and expires < time.time():
+        expires = data.get("expires")
+        if isinstance(expires, (int, float)) and expires < time.time():
             cls._halts.pop(instrument, None)
+            if cls._store is not None:
+                cls._store.delete(instrument)
             return False
         return True
 
@@ -293,6 +329,17 @@ class CircuitBreaker:
     def reason(cls, instrument: str) -> str | None:
         data = cls._halts.get(instrument)
         return None if not data else str(data.get("reason"))
+
+
+try:  # pragma: no cover - default store wiring best-effort for production deployments
+    _DEFAULT_CIRCUIT_BREAKER_STORE = CircuitBreakerStateStore()
+except RuntimeError as exc:  # pragma: no cover - redis optional in test environments
+    logger.warning(
+        "Circuit breaker persistence disabled: %s", exc,
+    )
+    _DEFAULT_CIRCUIT_BREAKER_STORE = None
+
+CircuitBreaker.use_store(_DEFAULT_CIRCUIT_BREAKER_STORE)
 
 
 _BASE_ALIASES: Dict[str, str] = {

--- a/tests/services/oms/test_circuit_breaker_persistence.py
+++ b/tests/services/oms/test_circuit_breaker_persistence.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+
+import sys
+import types
+
+if "aiohttp" not in sys.modules:
+    class _StubSession:
+        async def __aenter__(self) -> "_StubSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def post(self, *args: object, **kwargs: object) -> object:
+            raise RuntimeError("aiohttp stub invoked")
+
+        async def get(self, *args: object, **kwargs: object) -> object:
+            raise RuntimeError("aiohttp stub invoked")
+
+    class _ClientTimeout:
+        def __init__(self, total: float | None = None) -> None:
+            self.total = total
+
+    aiohttp_stub = types.SimpleNamespace(
+        ClientSession=lambda *args, **kwargs: _StubSession(),
+        ClientTimeout=_ClientTimeout,
+        ClientError=Exception,
+    )
+    sys.modules.setdefault("aiohttp", aiohttp_stub)
+
+from services.oms import main
+from services.oms.circuit_breaker_store import CircuitBreakerStateStore
+from tests.fixtures.backends import MemoryRedis
+
+
+@pytest.fixture
+def memory_store() -> Dict[str, object]:
+    backend = MemoryRedis()
+    store = CircuitBreakerStateStore(redis_client=backend)
+    original_store = main.CircuitBreaker._store  # type: ignore[attr-defined]
+    main.CircuitBreaker.use_store(store)
+    main.CircuitBreaker.reset()
+    yield {"backend": backend, "store": store, "original": original_store}
+    main.CircuitBreaker.reset()
+    main.CircuitBreaker.use_store(original_store)  # type: ignore[arg-type]
+    if original_store is not None:
+        main.CircuitBreaker.reload_from_store()
+    else:
+        main.CircuitBreaker._halts.clear()
+
+
+def test_circuit_breaker_state_survives_restart(memory_store: Dict[str, object], monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = {"now": 1_000_000.0}
+
+    def fake_time() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(main.time, "time", fake_time)
+
+    main.CircuitBreaker.halt("BTC-USD", reason="volatility spike", ttl_seconds=120)
+    assert main.CircuitBreaker.is_halted("BTC-USD") is True
+
+    # Simulate process restart by clearing in-memory cache and reloading from the shared store
+    main.CircuitBreaker._halts.clear()
+    main.CircuitBreaker.reload_from_store()
+    assert main.CircuitBreaker.is_halted("BTC-USD") is True
+
+    # Advance to just before expiration; the halt should still be active
+    clock["now"] += 110
+    assert main.CircuitBreaker.is_halted("BTC-USD") is True
+
+    # Once the expiry time elapses the halt should disappear and be pruned from persistence
+    clock["now"] += 20
+    assert main.CircuitBreaker.is_halted("BTC-USD") is False
+
+    # Reloading after expiration should not reintroduce stale state
+    main.CircuitBreaker._halts.clear()
+    main.CircuitBreaker.reload_from_store()
+    assert main.CircuitBreaker.is_halted("BTC-USD") is False
+
+    backend = memory_store["backend"]
+    assert backend.get(CircuitBreakerStateStore._DEFAULT_KEY) is None


### PR DESCRIPTION
## Summary
- add a Redis-backed circuit breaker state store used to persist instrument halts
- reload circuit breaker state on OMS startup and keep the durable store in sync on halt/resume/reset
- cover restart scenarios with a pytest ensuring halts survive process restarts until expiry

## Testing
- pytest tests/services/oms/test_circuit_breaker_persistence.py


------
https://chatgpt.com/codex/tasks/task_e_68e045e4ef448321a89782dfbad190b4