### PR TITLE
Ensure hedging orders respect market precision

### DIFF
--- a/tests/unit/test_hedging_service.py
+++ b/tests/unit/test_hedging_service.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+import hedging_service as hs
+
+
+class _StubMarketData:
+    def recent_bars(self, symbol: str, limit: int):  # pragma: no cover - helper stub
+        return []
+
+
+class _StubPnL:
+    def drawdown_pct(self) -> float:  # pragma: no cover - helper stub
+        return 0.0
+
+
+class _RecordingOMS:
+    def __init__(self) -> None:
+        self.orders: list[hs.HedgeOrder] = []
+
+    def submit_hedge_order(self, order: hs.HedgeOrder) -> None:
+        self.orders.append(order)
+
+
+class _StaticPrecisionProvider:
+    def __init__(self, precision: hs.InstrumentPrecision | None) -> None:
+        self._precision = precision
+
+    def get_precision(self, symbol: str) -> hs.InstrumentPrecision | None:
+        return self._precision
+
+
+class _StubTimescale:
+    def record_instrument_exposure(self, symbol: str, delta: float) -> None:  # pragma: no cover - helper stub
+        return None
+
+    def record_event(self, event_type: str, payload: dict) -> None:  # pragma: no cover - helper stub
+        return None
+
+
+@pytest.fixture()
+def hedging_config() -> hs.HedgeConfig:
+    return hs.HedgeConfig(
+        account_id="acct-1",
+        hedge_symbol="BTCUSD",
+        base_allocation_usd=1_000.0,
+        max_allocation_usd=10_000.0,
+        rebalance_tolerance_usd=0.0,
+    )
+
+
+@pytest.fixture()
+def precision_provider() -> _StaticPrecisionProvider:
+    precision = hs.InstrumentPrecision(
+        tick_size=Decimal("0.01"),
+        lot_size=Decimal("0.00000001"),
+    )
+    return _StaticPrecisionProvider(precision)
+
+
+@pytest.fixture()
+def hedging_service(
+    hedging_config: hs.HedgeConfig,
+    precision_provider: _StaticPrecisionProvider,
+) -> hs.HedgingService:
+    return hs.HedgingService(
+        hedging_config,
+        market_data=_StubMarketData(),
+        pnl_source=_StubPnL(),
+        oms_client=_RecordingOMS(),
+        timescale=_StubTimescale(),
+        precision_provider=precision_provider,
+    )
+
+
+def _desired_delta(price: float, quantity: Decimal) -> float:
+    return float(Decimal(str(price)) * quantity)
+
+
+def test_rebalance_quantizes_buy_with_high_precision(
+    hedging_service: hs.HedgingService,
+) -> None:
+    service = hedging_service
+    assert isinstance(service.oms, _RecordingOMS)
+    recording_oms = service.oms
+    price = 27_123.456789
+    quantity = Decimal("0.00000051")
+
+    target_allocation = service.state.current_allocation + _desired_delta(price, quantity)
+
+    service._rebalance(target_allocation, price, risk_score=2.5)
+
+    assert len(recording_oms.orders) == 1
+    order = recording_oms.orders[0]
+    assert order.side == "BUY"
+    assert order.order_type == "limit"
+    assert order.time_in_force == "GTC"
+    assert isinstance(order.quantity, Decimal)
+    assert isinstance(order.price, Decimal)
+    assert order.quantity == quantity
+    assert order.price == Decimal("27123.46")
+
+
+def test_rebalance_quantizes_sell_with_high_precision(
+    hedging_service: hs.HedgingService,
+) -> None:
+    service = hedging_service
+    assert isinstance(service.oms, _RecordingOMS)
+    recording_oms = service.oms
+    price = 27_123.456789
+    quantity = Decimal("0.00000051")
+
+    delta = _desired_delta(price, quantity)
+    service.state.current_allocation += delta
+    target_allocation = service.state.current_allocation - delta
+
+    service._rebalance(target_allocation, price, risk_score=3.0)
+
+    assert len(recording_oms.orders) == 1
+    order = recording_oms.orders[0]
+    assert order.side == "SELL"
+    assert order.order_type == "limit"
+    assert order.time_in_force == "IOC"
+    assert order.quantity == quantity
+    assert order.price == Decimal("27123.45")


### PR DESCRIPTION
## Summary
- use Decimal-backed HedgeOrder amounts and wire a market metadata precision provider into the hedging service
- quantize hedge price and quantity using tick/lot metadata before submitting OMS hedges
- add hedging unit tests covering high-precision quantities to ensure OMS payloads stay on increment

## Testing
- pytest tests/unit/test_hedging_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e04675f7f88321b184de027edca8f5