### PR TITLE
Add Redis-backed order acknowledgement cache

### DIFF
--- a/services/common/adapters.py
+++ b/services/common/adapters.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import tempfile
 import json
 import logging
 
 import os
 
 import uuid
+import sqlite3
+import threading
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
+from weakref import WeakSet
 
 
 from datetime import datetime, timedelta, timezone
@@ -26,8 +30,14 @@ from services.secrets.secure_secrets import (
     EnvelopeEncryptor,
 )
 
-from services.common.config import get_feast_client, get_redis_client
-main
+from services.common.config import (
+    TimescaleSession,
+    get_feast_client,
+    get_redis_client,
+    get_kafka_producer,
+    get_nats_producer,
+    get_timescale_session,
+)
 from services.universe.repository import UniverseRepository
 
 try:

--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -50,6 +50,7 @@ from services.oms.kraken_ws import (
     _WebsocketTransport,
 )
 from services.oms.oms_kraken import KrakenCredentialWatcher
+from services.oms.order_ack_cache import get_order_ack_cache
 from services.oms.rate_limit_guard import rate_limit_guard
 from services.oms.shadow_oms import shadow_oms
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
@@ -513,6 +514,10 @@ MARKET_METADATA: MarketMetadataDict = {}
 
 
 _SUCCESS_STATUSES = {"ok", "accepted", "open"}
+
+ACK_CACHE_TTL_SECONDS = max(
+    0.0, float(os.getenv("OMS_ACK_CACHE_TTL_SECONDS", os.getenv("OMS_ACK_CACHE_TTL", "30")))
+)
 
 
 @dataclass
@@ -1180,6 +1185,27 @@ async def place_order(
             detail="Snapped price/quantity must be positive.",
         )
 
+    ack_cache = None
+    if ACK_CACHE_TTL_SECONDS > 0:
+        ack_cache = get_order_ack_cache(account_id)
+        cached_ack = await ack_cache.get(request.order_id)
+        if cached_ack is not None:
+            status_value = str(cached_ack.payload.get("status", "")).lower()
+            accepted = (not status_value) or status_value in _SUCCESS_STATUSES
+            logger.info(
+                "Reusing cached Kraken acknowledgement",
+                extra={
+                    "account_id": account_id,
+                    "order_id": request.order_id,
+                    "cached_at": cached_ack.stored_at.isoformat(),
+                },
+            )
+            return OrderPlacementResponse(
+                accepted=accepted,
+                routed_venue="kraken",
+                fee=request.fee,
+            )
+
     kafka = KafkaNATSAdapter(account_id=account_id)
     timescale = TimescaleAdapter(account_id=account_id)
 
@@ -1370,6 +1396,9 @@ async def place_order(
         shadow_fills = []
     for shadow_fill in shadow_fills:
         timescale.record_shadow_fill(shadow_fill)
+
+    if ack_cache is not None:
+        await ack_cache.store(request.order_id, ack_payload, ACK_CACHE_TTL_SECONDS)
 
     accepted = (not status_value) or status_value in _SUCCESS_STATUSES
     venue = "kraken"

--- a/services/oms/order_ack_cache.py
+++ b/services/oms/order_ack_cache.py
@@ -1,0 +1,177 @@
+"""Idempotency cache for order acknowledgements backed by Redis."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Any, Protocol
+
+from services.common.config import get_redis_client
+
+
+logger = logging.getLogger(__name__)
+
+
+class SupportsRedis(Protocol):
+    async def get(self, key: str) -> bytes | str | None:
+        ...
+
+    async def set(
+        self,
+        key: str,
+        value: bytes,
+        *,
+        ex: float | int | None = None,
+    ) -> Any:
+        ...
+
+
+@dataclass(frozen=True)
+class CachedOrderAck:
+    """Represents a cached Kraken acknowledgement."""
+
+    payload: dict[str, Any]
+    stored_at: datetime
+
+
+class OrderAckCache(Protocol):
+    async def get(self, order_id: str) -> CachedOrderAck | None:
+        ...
+
+    async def store(
+        self, order_id: str, payload: dict[str, Any], ttl_seconds: float
+    ) -> None:
+        ...
+
+
+class RedisOrderAckCache:
+    """Persist acknowledgements in Redis for idempotency reuse."""
+
+    def __init__(
+        self,
+        redis: SupportsRedis,
+        account_id: str,
+        *,
+        namespace: str = "oms:ack-cache",
+    ) -> None:
+        self._redis = redis
+        self._account_id = account_id
+        self._namespace = namespace.rstrip(":")
+
+    def _key(self, order_id: str) -> str:
+        return f"{self._namespace}:{self._account_id}:{order_id}"
+
+    async def get(self, order_id: str) -> CachedOrderAck | None:
+        payload = await self._redis.get(self._key(order_id))
+        if payload is None:
+            return None
+
+        if isinstance(payload, bytes):
+            raw = payload.decode("utf-8", errors="ignore")
+        else:
+            raw = str(payload)
+
+        try:
+            encoded = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Failed to decode cached ack payload", extra={"key": order_id})
+            return None
+
+        cached_payload = encoded.get("payload")
+        stored_at_raw = encoded.get("stored_at")
+        if not isinstance(cached_payload, dict) or not isinstance(stored_at_raw, str):
+            logger.debug(
+                "Invalid cached ack structure", extra={"key": order_id, "payload": encoded}
+            )
+            return None
+
+        try:
+            stored_at = datetime.fromisoformat(stored_at_raw)
+        except ValueError:
+            logger.debug("Invalid cached ack timestamp", extra={"stored_at": stored_at_raw})
+            return None
+
+        if stored_at.tzinfo is None:
+            stored_at = stored_at.replace(tzinfo=timezone.utc)
+
+        return CachedOrderAck(payload=dict(cached_payload), stored_at=stored_at)
+
+    async def store(
+        self, order_id: str, payload: dict[str, Any], ttl_seconds: float
+    ) -> None:
+        if ttl_seconds <= 0:
+            return
+
+        entry = {
+            "payload": payload,
+            "stored_at": datetime.now(timezone.utc).isoformat(),
+        }
+        data = json.dumps(entry, separators=(",", ":")).encode("utf-8")
+        await self._redis.set(self._key(order_id), data, ex=max(ttl_seconds, 0.001))
+
+
+class InMemoryOrderAckCache:
+    """Fallback cache used in test environments when Redis is unavailable."""
+
+    def __init__(self, account_id: str) -> None:
+        self._account_id = account_id
+        self._entries: dict[str, tuple[dict[str, Any], datetime, float]] = {}
+        self._lock = asyncio.Lock()
+
+    def _key(self, order_id: str) -> str:
+        return f"{self._account_id}:{order_id}"
+
+    async def get(self, order_id: str) -> CachedOrderAck | None:
+        async with self._lock:
+            entry = self._entries.get(self._key(order_id))
+            if not entry:
+                return None
+            payload, stored_at, expiry = entry
+            if expiry <= time.monotonic():
+                self._entries.pop(self._key(order_id), None)
+                return None
+            return CachedOrderAck(payload=dict(payload), stored_at=stored_at)
+
+    async def store(
+        self, order_id: str, payload: dict[str, Any], ttl_seconds: float
+    ) -> None:
+        if ttl_seconds <= 0:
+            return
+        async with self._lock:
+            expiry = time.monotonic() + ttl_seconds
+            self._entries[self._key(order_id)] = (
+                dict(payload),
+                datetime.now(timezone.utc),
+                expiry,
+            )
+
+
+@lru_cache(maxsize=None)
+def get_order_ack_cache(account_id: str) -> OrderAckCache:
+    """Return the configured cache for the provided account."""
+
+    try:  # pragma: no cover - executed when redis is available
+        from redis.asyncio import Redis  # type: ignore[import-not-found]
+    except ImportError:  # pragma: no cover - fallback for local tests
+        logger.debug(
+            "redis.asyncio unavailable; using in-memory ack cache", extra={"account": account_id}
+        )
+        return InMemoryOrderAckCache(account_id)
+
+    client = get_redis_client(account_id)
+    redis = Redis.from_url(client.dsn, decode_responses=False)
+    return RedisOrderAckCache(redis, account_id)
+
+
+__all__ = [
+    "CachedOrderAck",
+    "OrderAckCache",
+    "RedisOrderAckCache",
+    "InMemoryOrderAckCache",
+    "get_order_ack_cache",
+]
+

--- a/tests/integration/test_exchange_adapter_oms.py
+++ b/tests/integration/test_exchange_adapter_oms.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib
 from contextlib import asynccontextmanager
+from pathlib import Path
+import importlib.util
 import sys
 import types
 from datetime import datetime, timezone
@@ -9,13 +11,165 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import pytest
+import httpx
+
+_REAL_HTTPX_ASYNC_CLIENT = httpx.AsyncClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+if "redis.asyncio" not in sys.modules:
+    redis_stub = types.ModuleType("redis")
+    redis_stub.__path__ = []  # type: ignore[attr-defined]
+    redis_asyncio_stub = types.ModuleType("redis.asyncio")
+    sys.modules["redis"] = redis_stub
+    sys.modules["redis.asyncio"] = redis_asyncio_stub
+
+if "services.common" not in sys.modules:
+    common_pkg = importlib.import_module("services.common")
+else:
+    common_pkg = sys.modules["services.common"]
+
+if "services.common.config" not in sys.modules:
+    config_stub = types.ModuleType("services.common.config")
+
+    class _StubTimescaleSession:
+        def __init__(self, account_id: str) -> None:
+            self.dsn = f"postgresql://stub/{account_id}"
+            self.account_schema = f"acct_{account_id}"
+
+    def _stub_get_redis_client(account_id: str) -> types.SimpleNamespace:
+        return types.SimpleNamespace(dsn=f"redis://stub/{account_id}")
+
+    def _stub_get_feast_client(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def _stub_get_kafka_producer(account_id: str) -> types.SimpleNamespace:
+        return types.SimpleNamespace(account_id=account_id)
+
+    def _stub_get_nats_producer(account_id: str) -> types.SimpleNamespace:
+        return types.SimpleNamespace(account_id=account_id)
+
+    def _stub_get_timescale_session(account_id: str) -> _StubTimescaleSession:
+        return _StubTimescaleSession(account_id)
+
+    config_stub.get_redis_client = _stub_get_redis_client  # type: ignore[attr-defined]
+    config_stub.get_feast_client = _stub_get_feast_client  # type: ignore[attr-defined]
+    config_stub.get_kafka_producer = _stub_get_kafka_producer  # type: ignore[attr-defined]
+    config_stub.get_nats_producer = _stub_get_nats_producer  # type: ignore[attr-defined]
+    config_stub.get_timescale_session = _stub_get_timescale_session  # type: ignore[attr-defined]
+    config_stub.TimescaleSession = _StubTimescaleSession  # type: ignore[attr-defined]
+    sys.modules["services.common.config"] = config_stub
+    setattr(sys.modules["services.common"], "config", config_stub)
+
+if "services.universe" not in sys.modules:
+    universe_pkg = types.ModuleType("services.universe")
+    universe_pkg.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["services.universe"] = universe_pkg
+
+if "services.universe.repository" not in sys.modules:
+    repo_stub = types.ModuleType("services.universe.repository")
+
+    class _StubUniverseRepository:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+    repo_stub.UniverseRepository = _StubUniverseRepository  # type: ignore[attr-defined]
+    sys.modules["services.universe.repository"] = repo_stub
+    setattr(sys.modules["services.universe"], "repository", repo_stub)
+
+if "services.common.schemas" not in sys.modules:
+    schemas_spec = importlib.util.spec_from_file_location(
+        "services.common.schemas", ROOT / "services" / "common" / "schemas.py"
+    )
+    if schemas_spec is None or schemas_spec.loader is None:
+        raise RuntimeError("Unable to load services.common.schemas module")
+    schemas_module = importlib.util.module_from_spec(schemas_spec)
+    sys.modules["services.common.schemas"] = schemas_module
+    schemas_spec.loader.exec_module(schemas_module)
+
+if "services.secrets" not in sys.modules:
+    secrets_pkg = types.ModuleType("services.secrets")
+    sys.modules["services.secrets"] = secrets_pkg
+
+if "services.secrets.secure_secrets" not in sys.modules:
+    secure_secrets = types.ModuleType("services.secrets.secure_secrets")
+
+    class _StubEnvelope:
+        def __init__(self, api_key: str = "", api_secret: str = "") -> None:
+            self.api_key = api_key
+            self.api_secret = api_secret
+            self.kms_key_id = "stub-kms-key"
+
+        @classmethod
+        def from_secret_data(cls, data: dict[str, Any]) -> "_StubEnvelope":
+            return cls(
+                api_key=str(data.get("api_key", "")),
+                api_secret=str(data.get("api_secret", "")),
+            )
+
+    class _StubEncryptor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        @classmethod
+        def from_kms(cls, *args: Any, **kwargs: Any) -> "_StubEncryptor":
+            return cls()
+
+        def encrypt_credentials(
+            self,
+            account_id: str,
+            *,
+            api_key: str,
+            api_secret: str,
+        ) -> _StubEnvelope:
+            return _StubEnvelope(api_key=api_key, api_secret=api_secret)
+
+        def decrypt_credentials(
+            self, account_id: str, envelope: _StubEnvelope
+        ) -> types.SimpleNamespace:
+            return types.SimpleNamespace(
+                api_key=envelope.api_key,
+                api_secret=envelope.api_secret,
+            )
+
+    secure_secrets.EncryptedSecretEnvelope = _StubEnvelope  # type: ignore[attr-defined]
+    secure_secrets.EnvelopeEncryptor = _StubEncryptor  # type: ignore[attr-defined]
+    sys.modules["services.secrets.secure_secrets"] = secure_secrets
+    setattr(sys.modules["services.secrets"], "secure_secrets", secure_secrets)
+
+_security_path = ROOT / "services" / "common" / "security.py"
+_security_spec = importlib.util.spec_from_file_location(
+    "services.common.security", _security_path
+)
+if _security_spec is not None and _security_spec.loader is not None:
+    _security_module = importlib.util.module_from_spec(_security_spec)
+    sys.modules["services.common.security"] = _security_module
+    _security_spec.loader.exec_module(_security_module)
+
+_adapters_path = ROOT / "services" / "common" / "adapters.py"
+_adapters_spec = importlib.util.spec_from_file_location(
+    "services.common.adapters", _adapters_path
+)
+if _adapters_spec is not None and _adapters_spec.loader is not None:
+    _adapters_module = importlib.util.module_from_spec(_adapters_spec)
+    sys.modules["services.common.adapters"] = _adapters_module
+    _adapters_spec.loader.exec_module(_adapters_module)
+
+_oms_init_path = ROOT / "services" / "oms" / "__init__.py"
+_oms_spec = importlib.util.spec_from_file_location("services.oms", _oms_init_path)
+if _oms_spec is not None and _oms_spec.loader is not None:
+    _oms_module = importlib.util.module_from_spec(_oms_spec)
+    sys.modules["services.oms"] = _oms_module
+    _oms_spec.loader.exec_module(_oms_module)
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 import exchange_adapter
 from auth.service import InMemorySessionStore
-from services.common import security
+import services.common.security as security
 
 if "aiohttp" not in sys.modules:
     class _StubSession:
@@ -90,6 +244,23 @@ def _extract_path(url: str) -> str:
 @pytest.mark.asyncio
 async def test_kraken_adapter_round_trip_through_oms(monkeypatch: pytest.MonkeyPatch) -> None:
     oms_main = importlib.reload(importlib.import_module("services.oms.main"))
+    order_ack_cache = importlib.import_module("services.oms.order_ack_cache")
+    order_ack_cache.get_order_ack_cache.cache_clear()
+
+    _ack_caches: dict[str, order_ack_cache.InMemoryOrderAckCache] = {}
+
+    def _in_memory_backend(account_id: str) -> order_ack_cache.InMemoryOrderAckCache:
+        if account_id not in _ack_caches:
+            _ack_caches[account_id] = order_ack_cache.InMemoryOrderAckCache(account_id)
+        return _ack_caches[account_id]
+
+    def _clear_backend() -> None:
+        _ack_caches.clear()
+
+    _in_memory_backend.cache_clear = _clear_backend  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(order_ack_cache, "get_order_ack_cache", _in_memory_backend)
+    monkeypatch.setattr(oms_main, "get_order_ack_cache", _in_memory_backend)
 
     class _NoopKafka:
         def __init__(self, *args, **kwargs) -> None:
@@ -155,6 +326,24 @@ async def test_kraken_adapter_round_trip_through_oms(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(oms_main.shadow_oms, "record_real_fill", lambda *a, **k: None)
     monkeypatch.setattr(oms_main.shadow_oms, "generate_shadow_fills", lambda *a, **k: [])
 
+    class _MetadataCache:
+        async def get(self, instrument: str) -> dict[str, Any] | None:
+            if instrument == "BTC-USD":
+                return {"tick": 0.01, "lot": 0.0001}
+            return None
+
+        async def refresh(self) -> None:
+            return None
+
+        async def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(oms_main, "market_metadata_cache", _MetadataCache())
+    oms_main.app.state.market_metadata_cache = _MetadataCache()
+
     security.reload_admin_accounts(["company"])
     store = InMemorySessionStore()
     session = store.create("company")
@@ -169,54 +358,199 @@ async def test_kraken_adapter_round_trip_through_oms(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(oms_main.market_metadata_cache, "start", _noop_async)
     monkeypatch.setattr(oms_main.market_metadata_cache, "stop", _noop_async)
 
-    with TestClient(oms_main.app) as client:
+    transport = httpx.ASGITransport(app=oms_main.app)
 
-        class _AdapterClient:
-            def __init__(self, *args, **kwargs) -> None:
-                self._client = client
+    class _AdapterClient:
+        def __init__(self, *args, **kwargs) -> None:
+            params = dict(kwargs)
+            params.setdefault("transport", transport)
+            params.setdefault("base_url", "http://testserver")
+            self._client = _REAL_HTTPX_ASYNC_CLIENT(*args, **params)
 
-            async def __aenter__(self) -> "_AdapterClient":
-                return self
+        async def __aenter__(self) -> httpx.AsyncClient:
+            return await self._client.__aenter__()
 
-            async def __aexit__(self, exc_type, exc, tb) -> None:
-                return None
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            await self._client.__aexit__(exc_type, exc, tb)
 
-            async def post(self, url: str, json=None, headers=None):  # type: ignore[override]
-                response = self._client.post(_extract_path(url), json=json, headers=headers)
-                return _AdapterResponse(response)
+    monkeypatch.setattr(exchange_adapter.httpx, "AsyncClient", _AdapterClient)
 
-            async def get(self, url: str, params=None, headers=None):  # type: ignore[override]
-                response = self._client.get(_extract_path(url), params=params, headers=headers)
-                return _AdapterResponse(response)
+    class _StubSessionManager:
+        def __init__(self, token: str) -> None:
+            self.token = token
+            self.calls: list[str] = []
 
-        monkeypatch.setattr(exchange_adapter.httpx, "AsyncClient", _AdapterClient)
+        async def token_for_account(self, account_id: str) -> str:
+            self.calls.append(account_id)
+            return self.token
 
-        class _StubSessionManager:
-            def __init__(self, token: str) -> None:
-                self.token = token
-                self.calls: list[str] = []
+    manager = _StubSessionManager(session.token)
+    adapter = exchange_adapter.KrakenAdapter(
+        primary_url="http://testserver",
+        session_manager=manager,
+    )
 
-            async def token_for_account(self, account_id: str) -> str:
-                self.calls.append(account_id)
-                return self.token
+    payload = {
+        "order_id": "CID-1",
+        "account_id": "company",
+        "instrument": "BTC-USD",
+        "side": "BUY",
+        "quantity": 1.0,
+        "price": 1000.0,
+        "fee": {"currency": "USD", "maker": 0.0, "taker": 0.0},
+    }
 
-        manager = _StubSessionManager(session.token)
-        adapter = exchange_adapter.KrakenAdapter(
-            primary_url=str(client.base_url),
-            session_manager=manager,
-        )
-
-        payload = {
-            "order_id": "CID-1",
-            "account_id": "company",
-            "instrument": "BTC-USD",
-            "side": "BUY",
-            "quantity": 1.0,
-            "price": 1000.0,
-            "fee": {"currency": "USD", "maker": 0.0, "taker": 0.0},
-        }
-
-        result = await adapter.place_order("company", payload)
+    result = await adapter.place_order("company", payload)
 
     assert result["accepted"] is True
     assert manager.calls == ["company"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_orders_reuse_cached_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    oms_main = importlib.reload(importlib.import_module("services.oms.main"))
+    order_ack_cache = importlib.import_module("services.oms.order_ack_cache")
+    schemas = importlib.import_module("services.common.schemas")
+
+    order_ack_cache.get_order_ack_cache.cache_clear()
+    _ack_caches: dict[str, order_ack_cache.InMemoryOrderAckCache] = {}
+
+    def _in_memory_backend(account_id: str) -> order_ack_cache.InMemoryOrderAckCache:
+        if account_id not in _ack_caches:
+            _ack_caches[account_id] = order_ack_cache.InMemoryOrderAckCache(account_id)
+        return _ack_caches[account_id]
+
+    def _clear_backend() -> None:
+        _ack_caches.clear()
+
+    _in_memory_backend.cache_clear = _clear_backend  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(order_ack_cache, "get_order_ack_cache", _in_memory_backend)
+    monkeypatch.setattr(oms_main, "get_order_ack_cache", _in_memory_backend)
+
+    class _RecordingKafka:
+        def __init__(self, account_id: str) -> None:
+            self.account_id = account_id
+            self.messages: list[dict[str, Any]] = []
+
+        def publish(self, *, topic: str, payload: dict[str, Any]) -> None:
+            self.messages.append({"topic": topic, "payload": dict(payload)})
+
+        @classmethod
+        def flush_events(cls) -> dict[str, int]:
+            return {}
+
+        @classmethod
+        def reset(cls, account_id: str | None = None) -> None:
+            return None
+
+    class _RecordingTimescale:
+        def __init__(self, account_id: str) -> None:
+            self.account_id = account_id
+            self.acks: list[dict[str, Any]] = []
+
+        def record_ack(self, payload: dict[str, Any]) -> None:
+            self.acks.append(dict(payload))
+
+        def record_usage(self, notional: float) -> None:
+            return None
+
+        def record_fill(self, payload: dict[str, Any]) -> None:
+            return None
+
+        def record_shadow_fill(self, payload: dict[str, Any]) -> None:
+            return None
+
+        @classmethod
+        async def flush_event_buffers(cls) -> dict[str, int]:
+            return {}
+
+    metadata = {"BTC-USD": {"tick": 0.1, "lot": 0.01, "native_pair": "XBT/USD"}}
+
+    class _MetadataCache:
+        async def get(self, instrument: str) -> dict[str, Any] | None:
+            entry = metadata.get(instrument)
+            return dict(entry) if entry is not None else None
+
+        async def refresh(self) -> None:
+            return None
+
+    submit_calls: list[dict[str, Any]] = []
+
+    async def _stub_submit_order(
+        ws_client: Any, rest_client: Any, payload: dict[str, Any]
+    ) -> tuple[oms_main.OrderAck, str]:
+        submit_calls.append(dict(payload))
+        ack = oms_main.OrderAck(
+            exchange_order_id=f"EX-{payload['clientOrderId']}",
+            status="ok",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+        return ack, "websocket"
+
+    async def _stub_fetch_open_orders(*_: Any, **__: Any) -> list[dict[str, Any]]:
+        return []
+
+    async def _stub_fetch_trades(*_: Any, **__: Any) -> list[dict[str, Any]]:
+        return []
+
+    @asynccontextmanager
+    async def _stub_clients(_: str):
+        async def _credentials() -> dict[str, Any]:
+            return {
+                "api_key": "key",
+                "api_secret": "secret",
+                "metadata": {"rotated_at": datetime.now(timezone.utc).isoformat()},
+            }
+
+        bundle = oms_main.KrakenClientBundle(
+            credential_getter=_credentials,
+            ws_client=object(),
+            rest_client=object(),
+        )
+        yield bundle
+
+    monkeypatch.setattr(oms_main, "KafkaNATSAdapter", _RecordingKafka)
+    monkeypatch.setattr(oms_main, "TimescaleAdapter", _RecordingTimescale)
+    monkeypatch.setattr(oms_main, "_submit_order", _stub_submit_order)
+    monkeypatch.setattr(oms_main, "_fetch_open_orders", _stub_fetch_open_orders)
+    monkeypatch.setattr(oms_main, "_fetch_own_trades", _stub_fetch_trades)
+    monkeypatch.setattr(oms_main, "_acquire_kraken_clients", _stub_clients)
+    monkeypatch.setattr(oms_main, "_ensure_credentials_valid", lambda credentials: None)
+    monkeypatch.setattr(oms_main, "market_metadata_cache", _MetadataCache())
+    oms_main.app.state.market_metadata_cache = _MetadataCache()
+    monkeypatch.setattr(oms_main, "ACK_CACHE_TTL_SECONDS", 120.0)
+
+    FeeBreakdown = schemas.FeeBreakdown
+    OrderPlacementRequest = schemas.OrderPlacementRequest
+
+    request = OrderPlacementRequest(
+        account_id="company",
+        order_id="OID-1",
+        instrument="BTC-USD",
+        side="BUY",
+        quantity=0.5,
+        price=20000.0,
+        fee=FeeBreakdown(currency="USD", maker=0.0, taker=0.0),
+    )
+
+    first = await oms_main.place_order(request, account_id="company")
+    assert first.accepted is True
+    assert len(submit_calls) == 1
+
+    cache = order_ack_cache.get_order_ack_cache("company")
+    cached_entry = await cache.get(request.order_id)
+    assert cached_entry is not None
+    assert cached_entry.payload["txid"] == "EX-OID-1"
+
+    second = await oms_main.place_order(request, account_id="company")
+    assert second.accepted is True
+    assert len(submit_calls) == 1
+
+    follow_up = request.model_copy(update={"order_id": "OID-2"})
+    third = await oms_main.place_order(follow_up, account_id="company")
+    assert third.accepted is True
+    assert len(submit_calls) == 2

--- a/tests/integration/test_oms_ack_cache.py
+++ b/tests/integration/test_oms_ack_cache.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import ModuleType, SimpleNamespace
+from typing import Any, Dict, List
+
+from pathlib import Path
+import importlib
+import sys
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+if "redis.asyncio" not in sys.modules:
+    redis_stub = ModuleType("redis")
+    redis_stub.__path__ = []  # type: ignore[attr-defined]
+    redis_asyncio_stub = ModuleType("redis.asyncio")
+
+    # No Redis attribute is exposed so that importing redis.asyncio.Redis raises ImportError
+    sys.modules["redis"] = redis_stub
+    sys.modules["redis.asyncio"] = redis_asyncio_stub
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = ModuleType("aiohttp")
+
+    class _StubSession:
+        async def __aenter__(self) -> "_StubSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def get(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("aiohttp GET invoked in stub")
+
+        async def post(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("aiohttp POST invoked in stub")
+
+    class _ClientTimeout:
+        def __init__(self, total: float | None = None) -> None:
+            self.total = total
+
+    aiohttp_stub.ClientSession = lambda *args, **kwargs: _StubSession()
+    aiohttp_stub.ClientTimeout = _ClientTimeout
+    aiohttp_stub.ClientError = Exception
+    sys.modules["aiohttp"] = aiohttp_stub
+
+services_spec = importlib.util.spec_from_file_location(
+    "services", ROOT / "services" / "__init__.py"
+)
+if services_spec is None or services_spec.loader is None:
+    raise RuntimeError("Unable to load services package")
+services_module = importlib.util.module_from_spec(services_spec)
+sys.modules["services"] = services_module
+services_spec.loader.exec_module(services_module)
+
+common_spec = importlib.util.spec_from_file_location(
+    "services.common", ROOT / "services" / "common" / "__init__.py"
+)
+if common_spec is None or common_spec.loader is None:
+    raise RuntimeError("Unable to load services.common package")
+common_pkg = importlib.util.module_from_spec(common_spec)
+sys.modules["services.common"] = common_pkg
+services_module.common = common_pkg  # type: ignore[attr-defined]
+common_spec.loader.exec_module(common_pkg)
+
+security_stub = ModuleType("services.common.security")
+
+def set_default_session_store(store: Any) -> None:
+    return None
+
+
+def require_admin_account() -> Any:
+    def _dependency() -> str:
+        return "company"
+
+    return _dependency
+
+
+security_stub.set_default_session_store = set_default_session_store  # type: ignore[attr-defined]
+security_stub.require_admin_account = require_admin_account  # type: ignore[attr-defined]
+sys.modules["services.common.security"] = security_stub
+common_pkg.security = security_stub  # type: ignore[attr-defined]
+
+config_stub = ModuleType("services.common.config")
+
+
+def get_redis_client(account_id: str) -> SimpleNamespace:
+    return SimpleNamespace(dsn="redis://localhost/0")
+
+
+config_stub.get_redis_client = get_redis_client  # type: ignore[attr-defined]
+sys.modules["services.common.config"] = config_stub
+common_pkg.config = config_stub  # type: ignore[attr-defined]
+
+adapters_stub = ModuleType("services.common.adapters")
+
+
+class _StubKafka:
+    def __init__(self, account_id: str) -> None:
+        self.account_id = account_id
+        self.messages: List[Dict[str, Any]] = []
+
+    def publish(self, *, topic: str, payload: Dict[str, Any]) -> None:
+        self.messages.append({"topic": topic, "payload": dict(payload)})
+
+    @classmethod
+    def flush_events(cls) -> Dict[str, int]:
+        return {}
+
+    @classmethod
+    def reset(cls, account_id: str | None = None) -> None:
+        return None
+
+
+class _StubTimescale:
+    def __init__(self, account_id: str) -> None:
+        self.account_id = account_id
+        self.acks: List[Dict[str, Any]] = []
+
+    def record_ack(self, payload: Dict[str, Any]) -> None:
+        self.acks.append(dict(payload))
+
+    def record_usage(self, notional: float) -> None:
+        return None
+
+    def record_fill(self, payload: Dict[str, Any]) -> None:
+        return None
+
+    def record_shadow_fill(self, payload: Dict[str, Any]) -> None:
+        return None
+
+    @classmethod
+    async def flush_event_buffers(cls) -> Dict[str, int]:
+        return {}
+
+
+adapters_stub.KafkaNATSAdapter = _StubKafka  # type: ignore[attr-defined]
+adapters_stub.TimescaleAdapter = _StubTimescale  # type: ignore[attr-defined]
+class _StubKrakenSecretManager:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def get_credentials(self) -> Dict[str, Any]:
+        return {
+            "api_key": "key",
+            "api_secret": "secret",
+            "metadata": {"rotated_at": datetime.now(timezone.utc).isoformat()},
+        }
+
+
+adapters_stub.KrakenSecretManager = _StubKrakenSecretManager  # type: ignore[attr-defined]
+services_module.common.adapters = adapters_stub  # type: ignore[attr-defined]
+sys.modules["services.common.adapters"] = adapters_stub
+
+oms_init_path = ROOT / "services" / "oms" / "__init__.py"
+oms_spec = importlib.util.spec_from_file_location("services.oms", oms_init_path)
+if oms_spec is None or oms_spec.loader is None:
+    raise RuntimeError("Unable to load services.oms package")
+oms_module = importlib.util.module_from_spec(oms_spec)
+services_module.oms = oms_module  # type: ignore[attr-defined]
+sys.modules["services.oms"] = oms_module
+oms_spec.loader.exec_module(oms_module)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_orders_use_cached_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    oms_main = importlib.reload(importlib.import_module("services.oms.main"))
+    order_ack_cache = importlib.import_module("services.oms.order_ack_cache")
+    schemas = importlib.import_module("services.common.schemas")
+
+    order_ack_cache.get_order_ack_cache.cache_clear()
+    _ack_caches: dict[str, order_ack_cache.InMemoryOrderAckCache] = {}
+
+    def _in_memory_backend(account_id: str) -> order_ack_cache.InMemoryOrderAckCache:
+        if account_id not in _ack_caches:
+            _ack_caches[account_id] = order_ack_cache.InMemoryOrderAckCache(account_id)
+        return _ack_caches[account_id]
+
+    def _clear_backend() -> None:
+        _ack_caches.clear()
+
+    _in_memory_backend.cache_clear = _clear_backend  # type: ignore[attr-defined]
+    monkeypatch.setattr(order_ack_cache, "get_order_ack_cache", _in_memory_backend)
+    monkeypatch.setattr(oms_main, "get_order_ack_cache", _in_memory_backend)
+
+    metadata = {"BTC-USD": {"tick": 0.1, "lot": 0.01, "native_pair": "XBT/USD"}}
+
+    class _MetadataCache:
+        async def get(self, instrument: str) -> Dict[str, Any] | None:
+            entry = metadata.get(instrument)
+            return dict(entry) if entry is not None else None
+
+        async def refresh(self) -> None:
+            return None
+
+    submit_payloads: List[Dict[str, Any]] = []
+
+    async def _stub_submit_order(
+        ws_client: Any, rest_client: Any, payload: Dict[str, Any]
+    ) -> tuple[oms_main.OrderAck, str]:
+        submit_payloads.append(dict(payload))
+        ack = oms_main.OrderAck(
+            exchange_order_id=f"EX-{payload['clientOrderId']}",
+            status="ok",
+            filled_qty=None,
+            avg_price=None,
+            errors=None,
+        )
+        return ack, "websocket"
+
+    async def _stub_fetch_open_orders(*_: Any, **__: Any) -> List[Dict[str, Any]]:
+        return []
+
+    async def _stub_fetch_trades(*_: Any, **__: Any) -> List[Dict[str, Any]]:
+        return []
+
+    @asynccontextmanager
+    async def _stub_clients(_: str):
+        async def _credentials() -> Dict[str, Any]:
+            return {
+                "api_key": "key",
+                "api_secret": "secret",
+                "metadata": {"rotated_at": datetime.now(timezone.utc).isoformat()},
+            }
+
+        bundle = oms_main.KrakenClientBundle(
+            credential_getter=_credentials,
+            ws_client=object(),
+            rest_client=object(),
+        )
+        yield bundle
+
+    monkeypatch.setattr(oms_main, "KafkaNATSAdapter", _StubKafka)
+    monkeypatch.setattr(oms_main, "TimescaleAdapter", _StubTimescale)
+    monkeypatch.setattr(oms_main, "_submit_order", _stub_submit_order)
+    monkeypatch.setattr(oms_main, "_fetch_open_orders", _stub_fetch_open_orders)
+    monkeypatch.setattr(oms_main, "_fetch_own_trades", _stub_fetch_trades)
+    monkeypatch.setattr(oms_main, "_acquire_kraken_clients", _stub_clients)
+    monkeypatch.setattr(oms_main, "_ensure_credentials_valid", lambda credentials: None)
+    monkeypatch.setattr(oms_main, "market_metadata_cache", _MetadataCache())
+    oms_main.app.state.market_metadata_cache = _MetadataCache()
+    monkeypatch.setattr(oms_main, "ACK_CACHE_TTL_SECONDS", 120.0)
+
+    FeeBreakdown = schemas.FeeBreakdown
+    OrderPlacementRequest = schemas.OrderPlacementRequest
+
+    request = OrderPlacementRequest(
+        account_id="company",
+        order_id="OID-1",
+        instrument="BTC-USD",
+        side="BUY",
+        quantity=0.5,
+        price=20000.0,
+        fee=FeeBreakdown(currency="USD", maker=0.0, taker=0.0),
+    )
+
+    first = await oms_main.place_order(request, account_id="company")
+    assert first.accepted is True
+    assert len(submit_payloads) == 1
+
+    cache = order_ack_cache.get_order_ack_cache("company")
+    cached_entry = await cache.get(request.order_id)
+    assert cached_entry is not None
+    assert cached_entry.payload["txid"] == "EX-OID-1"
+
+    second = await oms_main.place_order(request, account_id="company")
+    assert second.accepted is True
+    assert len(submit_payloads) == 1
+
+    follow_up = request.model_copy(update={"order_id": "OID-2"})
+    third = await oms_main.place_order(follow_up, account_id="company")
+    assert third.accepted is True
+    assert len(submit_payloads) == 2


### PR DESCRIPTION
## Summary
- add a Redis-backed order acknowledgement idempotency cache with an in-memory fallback
- update the OMS place_order flow to reuse cached acknowledgements and persist fresh ones
- expand OMS integration tests with stubs that exercise duplicate-order caching and ensure the cache is cleared between tests

## Testing
- pytest tests/integration/test_oms_ack_cache.py
- pytest tests/integration/test_exchange_adapter_oms.py

------
https://chatgpt.com/codex/tasks/task_e_68e041ec06488321b3830d6b5b5d78e2