### PR TITLE
Add simulation mode API and reroute OMS orders to simulator

### DIFF
--- a/services/core/__init__.py
+++ b/services/core/__init__.py
@@ -7,6 +7,7 @@ from .backpressure import (
     backpressure_controller,
 )
 from .sequencer import SequencerResult, TradingSequencer
+from .sim_mode import router as sim_mode_router
 from .startup_manager import (
     StartupManager,
     StartupMode,
@@ -25,6 +26,7 @@ __all__ = [
 
     "SequencerResult",
     "TradingSequencer",
+    "sim_mode_router",
     "StartupManager",
     "StartupMode",
     "CacheWarmer",

--- a/services/core/sim_mode.py
+++ b/services/core/sim_mode.py
@@ -1,0 +1,159 @@
+"""Simulation mode toggle endpoints for the control plane."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from common.schemas.contracts import SimModeEvent
+from services.common.adapters import KafkaNATSAdapter
+from services.common.security import require_admin_account
+from shared.sim_mode import SimModeStatus, sim_mode_repository
+from shared.simulation import sim_mode_state
+
+
+LOGGER = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sim", tags=["Simulation Mode"])
+
+
+class SimModeStatusResponse(BaseModel):
+    """Representation of the persisted simulation mode status."""
+
+    active: bool
+    reason: Optional[str]
+    ts: datetime
+
+    @classmethod
+    def from_status(cls, status: SimModeStatus) -> "SimModeStatusResponse":
+        return cls(active=status.active, reason=status.reason, ts=status.ts)
+
+
+class SimModeEnterRequest(BaseModel):
+    """Payload required when entering simulation mode."""
+
+    reason: str = Field(..., min_length=1, description="Why simulation mode is being enabled")
+
+
+class SimModeTransitionResponse(SimModeStatusResponse):
+    """Status response that also includes the actor that performed the change."""
+
+    actor: str
+
+    @classmethod
+    def from_status(
+        cls, status: SimModeStatus, actor: str
+    ) -> "SimModeTransitionResponse":
+        payload = SimModeStatusResponse.from_status(status).model_dump()
+        payload["actor"] = actor
+        return cls.model_validate(payload)
+
+
+def _publish_event(status: SimModeStatus, actor: str) -> None:
+    adapter = KafkaNATSAdapter(account_id="platform")
+    event = SimModeEvent(active=status.active, reason=status.reason, ts=status.ts, actor=actor)
+    adapter.publish("platform.sim_mode", event.model_dump(mode="json"))
+
+
+async def _sync_runtime_state(active: bool) -> None:
+    if active:
+        await sim_mode_state.enable()
+    else:
+        await sim_mode_state.disable()
+
+
+def _audit_transition(
+    before: SimModeStatus, after: SimModeStatus, actor: str, request: Request
+) -> None:
+    try:  # pragma: no cover - optional audit dependency
+        from common.utils.audit_logger import hash_ip as audit_hash_ip, log_audit as log_audit_event
+    except Exception:  # pragma: no cover - optional dependency missing
+        return
+
+    try:
+        client = request.client.host if request.client else None
+        ip_hash = audit_hash_ip(client)
+        log_audit_event(
+            actor=actor,
+            action="sim_mode.transition",
+            entity="platform",
+            before={
+                "active": before.active,
+                "reason": before.reason,
+                "ts": before.ts.isoformat(),
+            },
+            after={
+                "active": after.active,
+                "reason": after.reason,
+                "ts": after.ts.isoformat(),
+            },
+            ip_hash=ip_hash,
+        )
+    except Exception:  # pragma: no cover - defensive logging only
+        LOGGER.exception("Failed to record audit log for simulation mode transition")
+
+
+@router.get("/status", response_model=SimModeStatusResponse)
+async def get_status() -> SimModeStatusResponse:
+    status_obj = await sim_mode_repository.get_status_async()
+    await _sync_runtime_state(status_obj.active)
+    return SimModeStatusResponse.from_status(status_obj)
+
+
+@router.post("/enter", response_model=SimModeTransitionResponse)
+async def enter_simulation_mode(
+    payload: SimModeEnterRequest = Body(...),
+    actor: str = Depends(require_admin_account),
+    request: Request = None,
+) -> SimModeTransitionResponse:
+    if request is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Request context unavailable",
+        )
+
+    before = await sim_mode_repository.get_status_async(use_cache=False)
+    if before.active:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Simulation mode already active",
+        )
+
+    after = await sim_mode_repository.set_status_async(True, payload.reason)
+    await _sync_runtime_state(True)
+    _publish_event(after, actor)
+    _audit_transition(before, after, actor, request)
+    return SimModeTransitionResponse.from_status(after, actor)
+
+
+@router.post("/exit", response_model=SimModeTransitionResponse)
+async def exit_simulation_mode(
+    actor: str = Depends(require_admin_account),
+    request: Request = None,
+) -> SimModeTransitionResponse:
+    if request is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Request context unavailable",
+        )
+
+    before = await sim_mode_repository.get_status_async(use_cache=False)
+    if not before.active:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Simulation mode already inactive",
+        )
+
+    after = await sim_mode_repository.set_status_async(False, None)
+    await _sync_runtime_state(False)
+    _publish_event(after, actor)
+    _audit_transition(before, after, actor, request)
+    return SimModeTransitionResponse.from_status(after, actor)
+
+
+__all__ = ["router"]
+


### PR DESCRIPTION
## Summary
- add a FastAPI router under the core services package to expose simulation mode status and transition endpoints
- export the new router for consumers of the core services bundle
- update the OMS service to honour the persisted simulation toggle when placing or cancelling orders

## Testing
- python -m compileall services/core/sim_mode.py services/oms/oms_service.py services/oms/sim_broker.py

------
https://chatgpt.com/codex/tasks/task_e_68e04a32d0108321b2c35841c1c23847