### PR TITLE
Add exit rule manager for automated risk exits

### DIFF
--- a/services/risk/exit_rules.py
+++ b/services/risk/exit_rules.py
@@ -1,0 +1,324 @@
+"""Exit order orchestration for bracketed risk management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Literal, Optional
+
+
+Side = Literal["buy", "sell"]
+ExitType = Literal["take_profit", "stop_loss", "trailing_stop"]
+ActionType = Literal["create", "cancel", "replace"]
+
+
+@dataclass(frozen=True)
+class OrderSnapshot:
+    """Immutable view of an entry order that may require exit automation."""
+
+    order_id: str
+    side: Side
+    quantity: float
+    price: float
+    take_profit: Optional[float] = None
+    stop_loss: Optional[float] = None
+    trailing_offset: Optional[float] = None
+    reduce_only: bool = False
+
+    def __post_init__(self) -> None:
+        if self.quantity <= 0:
+            raise ValueError("quantity must be positive")
+        if self.price <= 0:
+            raise ValueError("price must be positive")
+        if self.take_profit is not None and self.take_profit <= 0:
+            raise ValueError("take_profit must be positive when provided")
+        if self.stop_loss is not None and self.stop_loss <= 0:
+            raise ValueError("stop_loss must be positive when provided")
+        if self.trailing_offset is not None and self.trailing_offset <= 0:
+            raise ValueError("trailing_offset must be positive when provided")
+        if self.side not in ("buy", "sell"):
+            raise ValueError("side must be 'buy' or 'sell'")
+
+
+@dataclass(frozen=True)
+class ExitOrder:
+    """Representation of an automated exit order."""
+
+    order_id: str
+    parent_order_id: str
+    side: Side
+    quantity: float
+    trigger_price: float
+    exit_type: ExitType
+    reduce_only: bool = True
+
+    def __post_init__(self) -> None:
+        if self.quantity < 0:
+            raise ValueError("quantity must be non-negative")
+        if self.trigger_price <= 0:
+            raise ValueError("trigger_price must be positive")
+
+
+@dataclass(frozen=True)
+class ExitOrderAction:
+    """Action emitted by :class:`ExitRuleEngine` for downstream OMS handling."""
+
+    action: ActionType
+    order: Optional[ExitOrder]
+    cancel_order_id: Optional[str] = None
+
+
+@dataclass
+class _TrackedEntry:
+    order: OrderSnapshot
+    exit_orders: Dict[str, ExitOrder] = field(default_factory=dict)
+    versions: Dict[str, int] = field(default_factory=dict)
+    filled: float = 0.0
+    trailing_offset: Optional[float] = None
+    trailing_anchor: Optional[float] = None
+    trailing_stop_price: Optional[float] = None
+
+
+class ExitRuleEngine:
+    """Manage stop loss, take profit and trailing exit orchestration."""
+
+    def __init__(self, *, quantity_tolerance: float = 1e-9, price_tolerance: float = 1e-9) -> None:
+        self._entries: Dict[str, _TrackedEntry] = {}
+        self._qty_tol = quantity_tolerance
+        self._px_tol = price_tolerance
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+    def register(self, order: OrderSnapshot) -> List[ExitOrderAction]:
+        """Register *order* and emit required exit orders.
+
+        Returns a list of :class:`ExitOrderAction` objects describing the
+        stop-loss / take-profit child orders that should be placed.
+        """
+
+        if order.reduce_only:
+            return []
+        if order.order_id in self._entries:
+            raise ValueError(f"Order {order.order_id} already registered")
+
+        entry = _TrackedEntry(order=order)
+        actions: List[ExitOrderAction] = []
+
+        if order.take_profit is not None:
+            exit_tp = self._create_exit_order(entry, "take_profit", order.take_profit, "take_profit")
+            entry.exit_orders["take_profit"] = exit_tp
+            actions.append(ExitOrderAction(action="create", order=exit_tp))
+
+        if order.stop_loss is not None or order.trailing_offset is not None:
+            trailing = order.trailing_offset
+            stop_price = order.stop_loss
+            exit_type: ExitType = "stop_loss"
+
+            if trailing is not None:
+                exit_type = "trailing_stop"
+                entry.trailing_offset = trailing
+                if stop_price is None:
+                    stop_price = self._compute_initial_trailing_stop(order, trailing)
+                entry.trailing_anchor = self._initial_anchor(order, stop_price, trailing)
+                entry.trailing_stop_price = stop_price
+            if stop_price is None:
+                raise ValueError("stop_loss or trailing_offset required to compute stop price")
+
+            exit_sl = self._create_exit_order(entry, "stop_loss", stop_price, exit_type)
+            entry.exit_orders["stop_loss"] = exit_sl
+            actions.append(ExitOrderAction(action="create", order=exit_sl))
+
+        self._entries[order.order_id] = entry
+        return actions
+
+    # ------------------------------------------------------------------
+    # Market monitoring
+    # ------------------------------------------------------------------
+    def update_market(self, *, best_bid: Optional[float], best_ask: Optional[float]) -> List[ExitOrderAction]:
+        """Update trailing stops given market best bid/ask prices."""
+
+        actions: List[ExitOrderAction] = []
+        for entry in self._entries.values():
+            if entry.trailing_offset is None:
+                continue
+
+            order = entry.order
+            reference = best_bid if order.side == "buy" else best_ask
+            if reference is None:
+                continue
+
+            improved = False
+            if entry.trailing_anchor is None:
+                entry.trailing_anchor = reference
+                improved = True
+            elif order.side == "buy" and reference > entry.trailing_anchor + self._px_tol:
+                entry.trailing_anchor = reference
+                improved = True
+            elif order.side == "sell" and reference < entry.trailing_anchor - self._px_tol:
+                entry.trailing_anchor = reference
+                improved = True
+
+            if not improved:
+                continue
+
+            new_stop = (
+                entry.trailing_anchor - entry.trailing_offset
+                if order.side == "buy"
+                else entry.trailing_anchor + entry.trailing_offset
+            )
+            if entry.trailing_stop_price is not None:
+                if order.side == "buy" and new_stop <= entry.trailing_stop_price + self._px_tol:
+                    continue
+                if order.side == "sell" and new_stop >= entry.trailing_stop_price - self._px_tol:
+                    continue
+
+            exit_sl = entry.exit_orders.get("stop_loss")
+            if exit_sl is None:
+                continue
+
+            replacement = self._create_exit_order(
+                entry,
+                "stop_loss",
+                new_stop,
+                exit_sl.exit_type,
+                quantity=exit_sl.quantity,
+            )
+            actions.append(
+                ExitOrderAction(
+                    action="replace",
+                    order=replacement,
+                    cancel_order_id=exit_sl.order_id,
+                )
+            )
+            entry.exit_orders["stop_loss"] = replacement
+            entry.trailing_stop_price = new_stop
+
+        return actions
+
+    # ------------------------------------------------------------------
+    # Fill monitoring
+    # ------------------------------------------------------------------
+    def record_fill(self, order_id: str, cumulative_quantity: float) -> List[ExitOrderAction]:
+        """Update the cumulative filled quantity for *order_id*.
+
+        Exit orders are resized (via cancel/replace) to mirror the filled
+        quantity so that reduce-only semantics are respected even on partial
+        fills.
+        """
+
+        entry = self._entries.get(order_id)
+        if entry is None:
+            raise KeyError(f"Order {order_id} not registered")
+        cumulative_quantity = min(cumulative_quantity, entry.order.quantity)
+        if cumulative_quantity < -self._qty_tol:
+            raise ValueError("cumulative_quantity cannot be negative")
+
+        if abs(cumulative_quantity - entry.filled) <= self._qty_tol:
+            return []
+
+        entry.filled = cumulative_quantity
+        actions: List[ExitOrderAction] = []
+
+        if cumulative_quantity <= self._qty_tol:
+            for label, exit_order in list(entry.exit_orders.items()):
+                actions.append(
+                    ExitOrderAction(
+                        action="cancel",
+                        order=exit_order,
+                        cancel_order_id=exit_order.order_id,
+                    )
+                )
+                entry.exit_orders.pop(label, None)
+            entry.trailing_stop_price = None
+            return actions
+
+        for label, exit_order in list(entry.exit_orders.items()):
+            if abs(exit_order.quantity - cumulative_quantity) <= self._qty_tol:
+                continue
+            replacement = self._create_exit_order(
+                entry,
+                label,
+                exit_order.trigger_price,
+                exit_order.exit_type,
+                quantity=cumulative_quantity,
+            )
+            actions.append(
+                ExitOrderAction(
+                    action="replace",
+                    order=replacement,
+                    cancel_order_id=exit_order.order_id,
+                )
+            )
+            entry.exit_orders[label] = replacement
+
+        return actions
+
+    # ------------------------------------------------------------------
+    # Cancellation lifecycle
+    # ------------------------------------------------------------------
+    def cancel_entry(self, order_id: str) -> List[ExitOrderAction]:
+        """Cancel the parent order and any associated exits."""
+
+        entry = self._entries.pop(order_id, None)
+        if entry is None:
+            return []
+
+        actions: List[ExitOrderAction] = []
+        for exit_order in entry.exit_orders.values():
+            actions.append(
+                ExitOrderAction(
+                    action="cancel",
+                    order=exit_order,
+                    cancel_order_id=exit_order.order_id,
+                )
+            )
+        entry.exit_orders.clear()
+        return actions
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _create_exit_order(
+        self,
+        entry: _TrackedEntry,
+        label: str,
+        trigger_price: float,
+        exit_type: ExitType,
+        *,
+        quantity: Optional[float] = None,
+    ) -> ExitOrder:
+        versions = entry.versions
+        version = versions.get(label, 0) + 1
+        versions[label] = version
+
+        parent = entry.order
+        child_side: Side = "sell" if parent.side == "buy" else "buy"
+        child_quantity = quantity if quantity is not None else parent.quantity
+
+        child_id = f"{parent.order_id}-{label}-{version}"
+        return ExitOrder(
+            order_id=child_id,
+            parent_order_id=parent.order_id,
+            side=child_side,
+            quantity=child_quantity,
+            trigger_price=trigger_price,
+            exit_type=exit_type,
+            reduce_only=True,
+        )
+
+    @staticmethod
+    def _compute_initial_trailing_stop(order: OrderSnapshot, trailing: float) -> float:
+        if order.side == "buy":
+            return max(order.price - trailing, 0.0) or trailing
+        return order.price + trailing
+
+    @staticmethod
+    def _initial_anchor(order: OrderSnapshot, stop_price: float, trailing: float) -> float:
+        if order.side == "buy":
+            return stop_price + trailing
+        return stop_price - trailing
+
+    def active_entries(self) -> Iterable[str]:
+        """Expose active entry identifiers for diagnostic purposes."""
+
+        return list(self._entries)

--- a/tests/services/risk/test_exit_rules.py
+++ b/tests/services/risk/test_exit_rules.py
@@ -1,0 +1,136 @@
+"""Unit tests for :mod:`services.risk.exit_rules`."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "services" / "risk" / "exit_rules.py"
+
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [str(ROOT / "services")]
+sys.modules.setdefault("services", services_pkg)
+
+risk_pkg = types.ModuleType("services.risk")
+risk_pkg.__path__ = [str(ROOT / "services" / "risk")]
+sys.modules.setdefault("services.risk", risk_pkg)
+
+spec = importlib.util.spec_from_file_location("services.risk.exit_rules", MODULE_PATH)
+assert spec and spec.loader, "Failed to load exit_rules module specification"
+exit_rules = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = exit_rules
+spec.loader.exec_module(exit_rules)
+
+ExitRuleEngine = exit_rules.ExitRuleEngine
+OrderSnapshot = exit_rules.OrderSnapshot
+
+
+def _build_order(**overrides: float | str | bool) -> OrderSnapshot:
+    payload = {
+        "order_id": "O-1",
+        "side": "buy",
+        "quantity": 5.0,
+        "price": 100.0,
+        "take_profit": 110.0,
+        "stop_loss": 95.0,
+        "trailing_offset": None,
+        "reduce_only": False,
+    }
+    payload.update(overrides)
+    return OrderSnapshot(**payload)
+
+
+def test_attach_exits_on_register() -> None:
+    engine = ExitRuleEngine()
+    order = _build_order()
+
+    actions = engine.register(order)
+
+    assert len(actions) == 2
+    tp_action = next(action for action in actions if action.order.exit_type == "take_profit")
+    sl_action = next(action for action in actions if action.order.exit_type != "take_profit")
+
+    assert tp_action.action == "create"
+    assert tp_action.order.quantity == pytest.approx(order.quantity)
+    assert tp_action.order.trigger_price == pytest.approx(order.take_profit)
+    assert tp_action.order.reduce_only is True
+
+    assert sl_action.action == "create"
+    assert sl_action.order.trigger_price == pytest.approx(order.stop_loss)
+    assert sl_action.order.reduce_only is True
+
+
+def test_trailing_stop_updates_on_improving_price() -> None:
+    engine = ExitRuleEngine(price_tolerance=1e-6)
+    order = _build_order(stop_loss=None, trailing_offset=2.5)
+
+    actions = engine.register(order)
+    assert len(actions) == 2
+    trailing = next(action for action in actions if action.order.exit_type == "trailing_stop")
+    assert trailing.order.trigger_price == pytest.approx(97.5)
+
+    # Price moves in favour of a long position -> trailing stop ratchets higher
+    updates = engine.update_market(best_bid=102.0, best_ask=103.0)
+    assert updates, "Trailing stop should be replaced when price improves"
+    replace_action = updates[0]
+    assert replace_action.action == "replace"
+    assert replace_action.cancel_order_id == trailing.order.order_id
+    assert replace_action.order.trigger_price > trailing.order.trigger_price
+
+    # Non-improving price should not trigger further replacements
+    assert not engine.update_market(best_bid=101.0, best_ask=102.0)
+
+    # Another improvement moves the stop higher again
+    updates = engine.update_market(best_bid=105.0, best_ask=106.0)
+    assert updates[-1].order.trigger_price > replace_action.order.trigger_price
+
+
+def test_cancel_entry_cancels_children() -> None:
+    engine = ExitRuleEngine()
+    engine.register(_build_order())
+
+    cancels = engine.cancel_entry("O-1")
+    assert {action.action for action in cancels} == {"cancel"}
+    assert {action.cancel_order_id for action in cancels}
+    assert not list(engine.active_entries())
+
+
+def test_reduce_only_orders_do_not_register() -> None:
+    engine = ExitRuleEngine()
+    actions = engine.register(_build_order(reduce_only=True))
+
+    assert actions == []
+    assert not list(engine.active_entries())
+
+
+@pytest.mark.parametrize("fill_sequence", [[2.0, 4.0], [3.5, 5.0]])
+def test_partial_fills_resize_exit_orders(fill_sequence: list[float]) -> None:
+    engine = ExitRuleEngine()
+    order = _build_order()
+    engine.register(order)
+
+    previous_quantity = 0.0
+    for filled in fill_sequence:
+        actions = engine.record_fill(order.order_id, filled)
+        assert actions, "Each partial fill should trigger a resize"
+        for action in actions:
+            assert action.action == "replace"
+            assert action.order is not None
+            assert math.isclose(action.order.quantity, filled)
+            assert action.order.reduce_only is True
+        previous_quantity = filled
+
+    # Replaying the last fill should be a no-op
+    assert not engine.record_fill(order.order_id, previous_quantity)
+
+    # When the position fully unwinds we cancel remaining exits
+    cancels = engine.record_fill(order.order_id, 0.0)
+    if previous_quantity > 0.0:
+        assert {action.action for action in cancels} == {"cancel"}
+        assert all(action.cancel_order_id for action in cancels)


### PR DESCRIPTION
## Summary
- add a dedicated exit rule engine that generates stop-loss, take-profit, and trailing exit orders while enforcing reduce-only behaviour
- support market monitoring, trailing adjustments, and partial fill resizing for attached exit orders
- cover the new behaviour with focused unit tests for exit order creation, trailing updates, cancellation, and partial fills

## Testing
- pytest tests/services/risk/test_exit_rules.py


------
https://chatgpt.com/codex/tasks/task_e_68e04a3c85308321936384df58f8dec4