### PR TITLE
Implement Kraken statement signing for downloader

### DIFF
--- a/secrets_service.py
+++ b/secrets_service.py
@@ -22,6 +22,7 @@ from kubernetes.client import ApiException
 from kubernetes.config.config_exception import ConfigException
 from pydantic import BaseModel, Field, validator
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from services.secrets.signing import sign_kraken_request
 
 try:  # pragma: no cover - optional audit dependency
     from common.utils.audit_logger import hash_ip, log_audit
@@ -398,21 +399,6 @@ def log_rotation(account_id: str, actor: str, timestamp: str) -> None:
         "kraken secret rotated",
         extra={"account_id": account_id, "actor": actor, "ts": timestamp},
     )
-
-
-def sign_kraken_request(path: str, data: Dict[str, Any], api_secret: str) -> Tuple[str, str]:
-    import hashlib
-    import hmac
-    from urllib.parse import urlencode
-
-    post_data = urlencode(data)
-    encoded = (data["nonce"] + post_data).encode()
-    message = hashlib.sha256(encoded).digest()
-    mac = hmac.new(base64.b64decode(api_secret), path.encode() + message, hashlib.sha512)
-    signature = base64.b64encode(mac.digest()).decode()
-    return post_data, signature
-
-
 _UNAVAILABLE_MESSAGE = "Kraken secrets service configuration is unavailable"
 
 

--- a/services/secrets/signing.py
+++ b/services/secrets/signing.py
@@ -1,0 +1,25 @@
+"""Kraken request signing utilities shared by services."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from typing import Any, Dict, Tuple
+from urllib.parse import urlencode
+
+
+def sign_kraken_request(path: str, data: Dict[str, Any], api_secret: str) -> Tuple[str, str]:
+    """Return the encoded payload and HMAC signature for a Kraken request."""
+
+    post_data = urlencode(data)
+    nonce = str(data.get("nonce", ""))
+    encoded = (nonce + post_data).encode()
+    message = hashlib.sha256(encoded).digest()
+    secret_key = base64.b64decode(api_secret)
+    mac = hmac.new(secret_key, path.encode() + message, hashlib.sha512)
+    signature = base64.b64encode(mac.digest()).decode()
+    return post_data, signature
+
+
+__all__ = ["sign_kraken_request"]

--- a/tests/services/reports/test_kraken_statement_downloader.py
+++ b/tests/services/reports/test_kraken_statement_downloader.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import pathlib
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[3]
+project_root_str = str(PROJECT_ROOT)
+if project_root_str in sys.path:
+    sys.path.remove(project_root_str)
+sys.path.insert(0, project_root_str)
+unique_path = []
+seen_paths = set()
+for entry in sys.path:
+    if entry in seen_paths:
+        continue
+    unique_path.append(entry)
+    seen_paths.add(entry)
+sys.path[:] = unique_path
+for module_name in (
+    "services",
+    "services.reports",
+    "services.common",
+    "services.common.config",
+):
+    sys.modules.pop(module_name, None)
+
+import base64
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+try:
+    from services.reports.kraken_reconciliation import KrakenStatementDownloader
+except ModuleNotFoundError:  # pragma: no cover - fallback for non-package execution
+    module_path = PROJECT_ROOT / "services" / "reports" / "kraken_reconciliation.py"
+    spec = importlib.util.spec_from_file_location(
+        "services.reports.kraken_reconciliation", module_path
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    KrakenStatementDownloader = module.KrakenStatementDownloader
+
+
+class _ResponseStub:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def raise_for_status(self) -> None:  # pragma: no cover - interface parity
+        return None
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.requests: List[Dict[str, Any]] = []
+
+    def get(self, url: str, params: Dict[str, Any], headers: Dict[str, str]):
+        self.requests.append({
+            "url": url,
+            "params": dict(params),
+            "headers": dict(headers),
+        })
+        if params.get("format") == "csv":
+            csv_payload = (
+                "order_id,executed_at,quantity,price,fee\n"
+                "abc,2023-01-01T00:00:00+00:00,1,100,0.1\n"
+            )
+            return _ResponseStub(csv_payload)
+        json_payload = "{\"nav_snapshots\": [], \"fee_adjustments\": []}"
+        return _ResponseStub(json_payload)
+
+
+def _statement_downloader(**kwargs: Any) -> tuple[KrakenStatementDownloader, _RecordingSession]:
+    session = _RecordingSession()
+    downloader = KrakenStatementDownloader(
+        base_url="https://api.test.kraken.com",
+        session=session,
+        **kwargs,
+    )
+    return downloader, session
+
+
+def test_fetch_uses_signed_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = base64.b64encode(b"supersecret").decode()
+    downloader, session = _statement_downloader(api_key="api_key_123", api_secret=secret)
+
+    monkeypatch.setattr(
+        "services.reports.kraken_reconciliation.time.time",
+        lambda: 1700000000.0,
+    )
+
+    start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2023, 1, 2, tzinfo=timezone.utc)
+    downloader.fetch("account-1", start, end)
+
+    assert len(session.requests) == 2
+    for request in session.requests:
+        headers = request["headers"]
+        params = request["params"]
+        assert "API-Secret" not in headers
+        assert headers.get("API-Key") == "api_key_123"
+        assert "API-Sign" in headers
+        assert params.get("nonce") == "1700000000000"
+
+    from services.secrets.signing import sign_kraken_request
+
+    csv_request = session.requests[0]
+    expected_csv_signature = sign_kraken_request(
+        "/statements/trades",
+        csv_request["params"],
+        secret,
+    )[1]
+    json_request = session.requests[1]
+    expected_json_signature = sign_kraken_request(
+        "/statements/accounting",
+        json_request["params"],
+        secret,
+    )[1]
+
+    assert session.requests[0]["headers"]["API-Sign"] == expected_csv_signature
+    assert session.requests[1]["headers"]["API-Sign"] == expected_json_signature
+
+
+def test_fetch_without_credentials_does_not_include_secrets() -> None:
+    downloader, session = _statement_downloader()
+
+    start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2023, 1, 2, tzinfo=timezone.utc)
+    downloader.fetch("account-1", start, end)
+
+    assert len(session.requests) == 2
+    for request in session.requests:
+        headers = request["headers"]
+        params = request["params"]
+        assert "API-Secret" not in headers
+        assert "API-Sign" not in headers
+        assert "Authorization" not in headers
+        assert "nonce" not in params
+


### PR DESCRIPTION
## Summary
- sign Kraken statement requests using the shared secrets signing helper instead of sending API-Secret headers
- update the statement downloader to attach per-request nonces, sanitized logging, and shared signing logic
- add a reusable signing helper module and unit tests that cover both signed and public download flows

## Testing
- pytest tests/services/reports/test_kraken_statement_downloader.py

------
https://chatgpt.com/codex/tasks/task_e_68e04d19c3788321b60c4d252e26e832