### PR TITLE
Secure risk validation endpoint and update tests

### DIFF
--- a/risk_service.py
+++ b/risk_service.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optio
 
 import httpx
 
-from fastapi import Depends, FastAPI, HTTPException, Header, Query, status
+from fastapi import Depends, FastAPI, HTTPException, Query, status
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_validator
 from sqlalchemy import Column, DateTime, Float, Integer, Numeric, String, create_engine, select
@@ -648,7 +648,7 @@ battle_mode_controller = BattleModeController(
 @app.post("/risk/validate", response_model=RiskValidationResponse)
 async def validate_risk(
     request: RiskValidationRequest,
-    account_id: str = Header(..., alias="X-Account-ID"),
+    account_id: str = Depends(require_admin_account),
 ) -> RiskValidationResponse:
 
     """Validate a trading intent against account level risk limits."""
@@ -656,7 +656,7 @@ async def validate_risk(
     if request.account_id != account_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Account mismatch between header and payload.",
+            detail="Account mismatch between authenticated session and payload.",
         )
 
     logger.info("Received risk validation request for account %s", account_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - services module may be unavailable in so
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))
+    sys.path.insert(0, str(ROOT))
 
 
 _DEFAULT_MASTER_KEY = base64.b64encode(b"\x00" * 32).decode("ascii")

--- a/tests/helpers/authentication.py
+++ b/tests/helpers/authentication.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Dict, Iterator, Optional, Callable
+
+from fastapi import Header, HTTPException, Request, status
+from fastapi.applications import FastAPI
+
+
+@contextmanager
+def override_admin_auth(
+    app: FastAPI,
+    dependency: Callable[..., str],
+    account_id: str,
+    *,
+    token: str = "test-admin-token",
+) -> Iterator[Dict[str, str]]:
+    """Temporarily override an admin authentication dependency for tests."""
+
+    expected = f"Bearer {token}"
+
+    def _dependency(
+        _request: Request,
+        authorization: Optional[str] = Header(None, alias="Authorization"),
+        x_account_id: Optional[str] = Header(None, alias="X-Account-ID"),
+    ) -> str:
+        if authorization != expected:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or missing Authorization header.",
+            )
+        if x_account_id:
+            header_account = x_account_id.strip()
+            if header_account and header_account.lower() != account_id.lower():
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Account header does not match authenticated session.",
+                )
+        return account_id
+
+    app.dependency_overrides[dependency] = _dependency
+    try:
+        yield {"Authorization": expected}
+    finally:
+        app.dependency_overrides.pop(dependency, None)

--- a/tests/unit/services/test_risk_service.py
+++ b/tests/unit/services/test_risk_service.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 
 from typing import Dict
 
+import sys
+from pathlib import Path
+from typing import Dict, Iterator
+
 import pytest
 
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 pytest.importorskip("fastapi")
+pytest.importorskip("services.common.security")
+from fastapi import status
 from fastapi.testclient import TestClient
 
-from risk_service import RiskEvaluationContext, app as risk_app
+from risk_service import RiskEvaluationContext, app as risk_app, require_admin_account
+from tests.helpers.authentication import override_admin_auth
 
 config = dict(getattr(RiskEvaluationContext, "model_config", {}))
 config["arbitrary_types_allowed"] = True
@@ -18,8 +29,9 @@ RiskEvaluationContext.model_config = config  # type: ignore[attr-defined]
 
 
 @pytest.fixture
-def risk_client() -> TestClient:
-    return TestClient(risk_app)
+def risk_client() -> Iterator[TestClient]:
+    with TestClient(risk_app) as client:
+        yield client
 
 
 def _base_request() -> Dict[str, object]:
@@ -43,25 +55,33 @@ def _base_request() -> Dict[str, object]:
 
 def test_risk_validation_passes_under_fee_budget(risk_client: TestClient) -> None:
     payload = _base_request()
-    response = risk_client.post(
-        "/risk/validate",
-        json=payload,
-        headers={"X-Account-ID": payload["account_id"]},
-    )
+    with override_admin_auth(
+        risk_client.app, require_admin_account, payload["account_id"]
+    ) as headers:
+        response = risk_client.post(
+            "/risk/validate",
+            json=payload,
+            headers={**headers, "X-Account-ID": payload["account_id"]},
+        )
     assert response.status_code == 200
     body = response.json()
     assert body["pass"] is True
     assert body["reasons"] == []
 
 
-def test_risk_validation_rejects_when_fee_budget_exhausted(risk_client: TestClient) -> None:
+def test_risk_validation_rejects_when_fee_budget_exhausted(
+    risk_client: TestClient,
+) -> None:
     payload = _base_request()
     payload["portfolio_state"]["fees_paid"] = 12_000.0
-    response = risk_client.post(
-        "/risk/validate",
-        json=payload,
-        headers={"X-Account-ID": payload["account_id"]},
-    )
+    with override_admin_auth(
+        risk_client.app, require_admin_account, payload["account_id"]
+    ) as headers:
+        response = risk_client.post(
+            "/risk/validate",
+            json=payload,
+            headers={**headers, "X-Account-ID": payload["account_id"]},
+        )
     assert response.status_code == 200
     body = response.json()
     assert body["pass"] is False
@@ -71,17 +91,52 @@ def test_risk_validation_rejects_when_fee_budget_exhausted(risk_client: TestClie
 def test_risk_validation_enforces_schema(risk_client: TestClient) -> None:
     payload = _base_request()
     payload["intent"]["side"] = "hold"
-    response = risk_client.post(
-        "/risk/validate",
-        json=payload,
-        headers={"X-Account-ID": payload["account_id"]},
-    )
+    with override_admin_auth(
+        risk_client.app, require_admin_account, payload["account_id"]
+    ) as headers:
+        response = risk_client.post(
+            "/risk/validate",
+            json=payload,
+            headers={**headers, "X-Account-ID": payload["account_id"]},
+        )
     assert response.status_code == 422
 
 
 def test_risk_limits_endpoint_returns_configuration(risk_client: TestClient) -> None:
-    response = risk_client.get("/risk/limits", params={"account_id": "ACC-DEFAULT"})
+    with override_admin_auth(
+        risk_client.app, require_admin_account, "ACC-DEFAULT"
+    ) as headers:
+        response = risk_client.get(
+            "/risk/limits",
+            headers=headers,
+        )
     assert response.status_code == 200
     body = response.json()
     assert body["limits"]["account_id"] == "ACC-DEFAULT"
     assert body["usage"]["account_id"] == "ACC-DEFAULT"
+
+
+def test_risk_validation_rejects_unauthenticated_request(
+    risk_client: TestClient,
+) -> None:
+    payload = _base_request()
+    response = risk_client.post("/risk/validate", json=payload)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_risk_validation_rejects_account_mismatch(risk_client: TestClient) -> None:
+    payload = _base_request()
+    with override_admin_auth(
+        risk_client.app, require_admin_account, payload["account_id"]
+    ) as headers:
+        payload["account_id"] = "ACC-OTHER"
+        response = risk_client.post(
+            "/risk/validate",
+            json=payload,
+            headers=headers,
+        )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        response.json()["detail"]
+        == "Account mismatch between authenticated session and payload."
+    )


### PR DESCRIPTION
## Summary
- require administrative authentication for the /risk/validate endpoint and keep the explicit payload/session account comparison
- add a reusable override_admin_auth helper and expand risk-service unit coverage for authenticated, unauthenticated, and mismatched calls
- update risk-related integration and allocator tests to exercise authenticated access while guarding against missing security dependencies

## Testing
- pytest tests/unit/services/test_risk_service.py -q *(skipped: services.common.security unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04e0fd92083218dfe427cfc63dd63