### PR TITLE
Enforce admin authentication for config service updates

### DIFF
--- a/config_service.py
+++ b/config_service.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, List, Optional, Set, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
@@ -14,6 +17,27 @@ from pydantic import BaseModel, Field
 from sqlalchemy import JSON, Column, DateTime, Integer, String, UniqueConstraint, create_engine, func, select
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import StaticPool
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:  # pragma: no cover - support alternative namespace packages
+    from services.common.security import require_admin_account
+except ModuleNotFoundError:  # pragma: no cover - fallback when installed under package namespace
+    try:
+        from aether.services.common.security import require_admin_account
+    except ModuleNotFoundError:  # pragma: no cover - direct file import when running from source tree
+        spec = importlib.util.spec_from_file_location(
+            "config_service._security",
+            ROOT / "services" / "common" / "security.py",
+        )
+        if spec is None or spec.loader is None:  # pragma: no cover - defensive
+            raise
+        security_module = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("config_service._security", security_module)
+        spec.loader.exec_module(security_module)
+        require_admin_account = getattr(security_module, "require_admin_account")
 
 try:  # pragma: no cover - optional audit dependency
     from common.utils.audit_logger import hash_ip, log_audit
@@ -249,6 +273,7 @@ def _commit_version(
 @app.get("/config/current", response_model=Dict[str, ConfigEntry])
 def get_current_config(
     account_id: str = Query("global", description="Account identifier"),
+    _admin_account: str = Depends(require_admin_account),
     session: Session = Depends(get_session),
 ) -> Dict[str, ConfigEntry]:
     stmt = (
@@ -269,6 +294,7 @@ def update_config(
     payload: ConfigUpdateRequest,
     request: Request,
     account_id: str = Query("global", description="Account identifier"),
+    admin_account: str = Depends(require_admin_account),
     session: Session = Depends(get_session),
 ):
     key = payload.key
@@ -286,7 +312,7 @@ def update_config(
             created_at = datetime.now(timezone.utc)
             _pending_guarded[pending_identifier] = PendingGuardedChange(
                 value=payload.value,
-                author=payload.author,
+                author=admin_account,
                 created_at=created_at,
             )
             response = ConfigUpdateResponse(
@@ -294,7 +320,7 @@ def update_config(
                 account_id=account_id,
                 key=key,
                 value=payload.value,
-                approvers=[payload.author],
+                approvers=[admin_account],
                 version=None,
                 ts=None,
                 required_approvals=required_approvals,
@@ -307,12 +333,12 @@ def update_config(
                         "key": key,
                         "value": payload.value,
                         "status": "pending",
-                        "requested_by": payload.author,
+                        "requested_by": admin_account,
                         "requested_at": created_at.isoformat(),
                         "required_approvals": required_approvals,
                     }
                     log_audit(
-                        actor=payload.author,
+                        actor=admin_account,
                         action="config.change.requested",
                         entity=entity,
                         before=before_snapshot,
@@ -325,7 +351,7 @@ def update_config(
                     )
             return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=response.model_dump())
 
-        if pending.author == payload.author:
+        if pending.author == admin_account:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="second_author_required")
         if pending.value != payload.value:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="value_mismatch")
@@ -335,7 +361,7 @@ def update_config(
             account_id=account_id,
             key=key,
             value=payload.value,
-            approvers=[pending.author, payload.author],
+            approvers=[pending.author, admin_account],
         )
         _pending_guarded.pop(pending_identifier, None)
         response = ConfigUpdateResponse(
@@ -352,7 +378,7 @@ def update_config(
         if log_audit is not None:
             try:
                 log_audit(
-                    actor=payload.author,
+                    actor=admin_account,
                     action="config.change.approved",
                     entity=entity,
                     before=before_snapshot,
@@ -369,7 +395,7 @@ def update_config(
         account_id=account_id,
         key=key,
         value=payload.value,
-        approvers=[payload.author],
+        approvers=[admin_account],
     )
     response = ConfigUpdateResponse(
         status="applied",
@@ -385,7 +411,7 @@ def update_config(
     if log_audit is not None:
         try:
             log_audit(
-                actor=payload.author,
+                actor=admin_account,
                 action="config.change.applied",
                 entity=entity,
                 before=before_snapshot,

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -1,8 +1,43 @@
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+from typing import Iterator
+
+import sys
+
+import pytest
 from fastapi.testclient import TestClient
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+def _import_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ModuleNotFoundError(f"Unable to load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+try:
+    from auth.service import InMemorySessionStore
+except ModuleNotFoundError:
+    auth_module = _import_module("tests.config_service_auth", ROOT / "auth" / "service.py")
+    InMemorySessionStore = auth_module.InMemorySessionStore  # type: ignore[attr-defined]
+
 from config_service import app, reset_state, set_guarded_keys
+
+try:
+    from services.common.security import set_default_session_store
+except ModuleNotFoundError:
+    security_module = _import_module(
+        "tests.config_service_security", ROOT / "services" / "common" / "security.py"
+    )
+    set_default_session_store = security_module.set_default_session_store  # type: ignore[attr-defined]
 
 
 def setup_function() -> None:
@@ -10,22 +45,81 @@ def setup_function() -> None:
     set_guarded_keys(set())
 
 
-def test_update_and_history_for_account() -> None:
-    client = TestClient(app)
+@pytest.fixture
+def config_client() -> Iterator[tuple[TestClient, InMemorySessionStore]]:
+    store = InMemorySessionStore()
+    set_default_session_store(store)
+    app.state.session_store = store
+
+    try:
+        with TestClient(app) as client:
+            yield client, store
+    finally:
+        set_default_session_store(None)
+        if hasattr(app.state, "session_store"):
+            delattr(app.state, "session_store")
+
+
+def _auth_headers(store: InMemorySessionStore, account: str) -> dict[str, str]:
+    session = store.create(account)
+    return {"Authorization": f"Bearer {session.token}"}
+
+
+def test_requires_authenticated_session(
+    config_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, _store = config_client
+
+    current = client.get("/config/current")
+    assert current.status_code == 401
+
+    response = client.post(
+        "/config/update",
+        params={"account_id": "acct-unauth"},
+        json={"key": "features.toggle_x", "value": True, "author": "ignored"},
+    )
+    assert response.status_code == 401
+
+
+def test_rejects_non_admin_session(
+    config_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, store = config_client
+    headers = _auth_headers(store, "guest")
+
+    response = client.post(
+        "/config/update",
+        params={"account_id": "acct-unauth"},
+        json={"key": "features.toggle_x", "value": True, "author": "ignored"},
+        headers=headers,
+    )
+    assert response.status_code == 403
+
+
+def test_update_and_history_for_account(
+    config_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
+    client, store = config_client
+    headers = _auth_headers(store, "company")
 
     response = client.post(
         "/config/update",
         params={"account_id": "acct-1"},
         json={"key": "features.toggle_x", "value": True, "author": "alice"},
+        headers=headers,
     )
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "applied"
     assert body["version"] == 1
-    assert body["approvers"] == ["alice"]
+    assert body["approvers"] == ["company"]
     assert body["required_approvals"] == 1
 
-    current = client.get("/config/current", params={"account_id": "acct-1"})
+    current = client.get(
+        "/config/current",
+        params={"account_id": "acct-1"},
+        headers=headers,
+    )
     assert current.status_code == 200
     current_body = current.json()
     assert set(current_body.keys()) == {"features.toggle_x"}
@@ -34,7 +128,7 @@ def test_update_and_history_for_account() -> None:
     assert current_entry["key"] == "features.toggle_x"
     assert current_entry["value"] is True
     assert current_entry["version"] == 1
-    assert current_entry["approvers"] == ["alice"]
+    assert current_entry["approvers"] == ["company"]
     assert "id" in current_entry
     assert "ts" in current_entry
 
@@ -46,17 +140,18 @@ def test_update_and_history_for_account() -> None:
     history_body = history.json()
     assert len(history_body) == 1
     assert history_body[0]["version"] == 1
-    assert history_body[0]["approvers"] == ["alice"]
+    assert history_body[0]["approvers"] == ["company"]
 
     second_response = client.post(
         "/config/update",
         params={"account_id": "acct-1"},
         json={"key": "features.toggle_x", "value": False, "author": "bob"},
+        headers=headers,
     )
     assert second_response.status_code == 200
     second_body = second_response.json()
     assert second_body["version"] == 2
-    assert second_body["approvers"] == ["bob"]
+    assert second_body["approvers"] == ["company"]
 
     history_body = client.get(
         "/config/history",
@@ -65,23 +160,32 @@ def test_update_and_history_for_account() -> None:
     assert [entry["version"] for entry in history_body] == [1, 2]
 
 
-def test_guarded_key_requires_two_authors() -> None:
+def test_guarded_key_requires_two_authors(
+    config_client: tuple[TestClient, InMemorySessionStore]
+) -> None:
     set_guarded_keys({"risk.max_notional"})
-    client = TestClient(app)
+    client, store = config_client
+    requester_headers = _auth_headers(store, "company")
+    second_headers = _auth_headers(store, "director-1")
 
     first = client.post(
         "/config/update",
         params={"account_id": "acct-77"},
         json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "alice"},
+        headers=requester_headers,
     )
     assert first.status_code == 202
     first_body = first.json()
     assert first_body["status"] == "pending"
-    assert first_body["approvers"] == ["alice"]
+    assert first_body["approvers"] == ["company"]
     assert first_body["version"] is None
     assert first_body["required_approvals"] == 2
 
-    current = client.get("/config/current", params={"account_id": "acct-77"})
+    current = client.get(
+        "/config/current",
+        params={"account_id": "acct-77"},
+        headers=requester_headers,
+    )
     assert current.status_code == 200
     assert current.json() == {}
 
@@ -89,6 +193,7 @@ def test_guarded_key_requires_two_authors() -> None:
         "/config/update",
         params={"account_id": "acct-77"},
         json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "alice"},
+        headers=requester_headers,
     )
     assert duplicate_author.status_code == 400
     assert duplicate_author.json()["detail"] == "second_author_required"
@@ -97,6 +202,7 @@ def test_guarded_key_requires_two_authors() -> None:
         "/config/update",
         params={"account_id": "acct-77"},
         json={"key": "risk.max_notional", "value": {"notional": 2000}, "author": "bob"},
+        headers=second_headers,
     )
     assert mismatched_value.status_code == 400
     assert mismatched_value.json()["detail"] == "value_mismatch"
@@ -105,16 +211,21 @@ def test_guarded_key_requires_two_authors() -> None:
         "/config/update",
         params={"account_id": "acct-77"},
         json={"key": "risk.max_notional", "value": {"notional": 1000}, "author": "bob"},
+        headers=second_headers,
     )
     assert second.status_code == 200
     second_body = second.json()
     assert second_body["status"] == "applied"
     assert second_body["version"] == 1
-    assert second_body["approvers"] == ["alice", "bob"]
+    assert second_body["approvers"] == ["company", "director-1"]
 
-    final_current = client.get("/config/current", params={"account_id": "acct-77"}).json()
+    final_current = client.get(
+        "/config/current",
+        params={"account_id": "acct-77"},
+        headers=second_headers,
+    ).json()
     assert final_current["risk.max_notional"]["value"] == {"notional": 1000}
-    assert final_current["risk.max_notional"]["approvers"] == ["alice", "bob"]
+    assert final_current["risk.max_notional"]["approvers"] == ["company", "director-1"]
 
     history = client.get(
         "/config/history",
@@ -123,5 +234,4 @@ def test_guarded_key_requires_two_authors() -> None:
     assert history.status_code == 200
     history_body = history.json()
     assert len(history_body) == 1
-    assert history_body[0]["approvers"] == ["alice", "bob"]
-
+    assert history_body[0]["approvers"] == ["company", "director-1"]


### PR DESCRIPTION
## Summary
- load the shared security dependency even when the code runs outside an installed package layout
- require `require_admin_account` for config fetch/update endpoints and derive approvers from the authenticated admin session
- harden guarded key approvals to reject self-approval and update audit metadata accordingly
- update config service tests to exercise authentication failures, dual-approval success, and session-backed identity checks

## Testing
- pytest tests/test_config_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e05243ac848321aa1f1f667d28fd17