### PR TITLE
Switch config service to shared Postgres backend

### DIFF
--- a/config_service.py
+++ b/config_service.py
@@ -29,28 +29,72 @@ except Exception:  # pragma: no cover - degrade gracefully
 # ---------------------------------------------------------------------------
 
 
-DEFAULT_DATABASE_URL = "sqlite+pysqlite:////tmp/config.db"
+LOGGER = logging.getLogger("config_service")
+_SQLITE_FALLBACK_FLAG = "CONFIG_ALLOW_SQLITE_FOR_TESTS"
+
+
+def _require_database_url() -> str:
+    """Return the configured database URL ensuring it targets Postgres."""
+
+    raw_url = os.getenv("CONFIG_DATABASE_URL")
+    if not raw_url:
+        raise RuntimeError(
+            "CONFIG_DATABASE_URL environment variable is required for the config service."
+        )
+
+    normalized = raw_url.lower()
+    allowed_prefixes = ("postgresql://", "postgresql+psycopg://", "postgresql+psycopg2://")
+    if normalized.startswith("postgres://"):
+        raw_url = "postgresql://" + raw_url.split("://", 1)[1]
+        normalized = raw_url.lower()
+
+    if normalized.startswith(allowed_prefixes):
+        return raw_url
+
+    if os.getenv(_SQLITE_FALLBACK_FLAG) == "1":
+        LOGGER.warning(
+            "Non-Postgres CONFIG_DATABASE_URL '%s' permitted because %s=1.",
+            raw_url,
+            _SQLITE_FALLBACK_FLAG,
+        )
+        return raw_url
+
+    raise RuntimeError(
+        "CONFIG_DATABASE_URL must point to a PostgreSQL/TimescaleDB instance; "
+        f"received '{raw_url}'. Set {_SQLITE_FALLBACK_FLAG}=1 to allow alternative URLs in tests."
+    )
 
 
 def _create_engine(database_url: str):
     connect_args: Dict[str, Any] = {}
-    engine_kwargs: Dict[str, Any] = {"future": True}
-    if database_url.startswith("sqlite"):  # pragma: no cover - defensive branch
+    engine_kwargs: Dict[str, Any] = {
+        "future": True,
+        "pool_pre_ping": True,
+    }
+
+    if database_url.startswith("sqlite"):
         connect_args["check_same_thread"] = False
         engine_kwargs["connect_args"] = connect_args
         if ":memory:" in database_url:
             engine_kwargs["poolclass"] = StaticPool
+    else:
+        connect_args["sslmode"] = os.getenv("CONFIG_DB_SSLMODE", "require")
+        engine_kwargs["connect_args"] = connect_args
+        engine_kwargs.update(
+            pool_size=int(os.getenv("CONFIG_DB_POOL_SIZE", "10")),
+            max_overflow=int(os.getenv("CONFIG_DB_MAX_OVERFLOW", "5")),
+            pool_timeout=int(os.getenv("CONFIG_DB_POOL_TIMEOUT", "30")),
+            pool_recycle=int(os.getenv("CONFIG_DB_POOL_RECYCLE", "1800")),
+        )
+
     return create_engine(database_url, **engine_kwargs)
 
 
-DATABASE_URL = os.getenv("CONFIG_DATABASE_URL", DEFAULT_DATABASE_URL)
+DATABASE_URL = _require_database_url()
 engine = _create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
 
 Base = declarative_base()
-
-
-LOGGER = logging.getLogger("config_service")
 
 
 class ConfigVersion(Base):

--- a/data/alembic/versions/0004_config_service_postgres.py
+++ b/data/alembic/versions/0004_config_service_postgres.py
@@ -1,0 +1,165 @@
+"""Backfill config_versions into the shared Timescale cluster."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import SQLAlchemyError
+
+# revision identifiers, used by Alembic.
+revision = "0004_config_service_postgres"
+down_revision = "0003_update_risk_numeric"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn: Connection, table_name: str) -> bool:
+    inspector = sa.inspect(conn)
+    return table_name in inspector.get_table_names()
+
+
+def _create_config_versions(conn: Connection) -> None:
+    if _table_exists(conn, "config_versions"):
+        return
+
+    op.create_table(
+        "config_versions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("account_id", sa.String(), nullable=False, server_default="global"),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value_json", sa.JSON(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("approvers", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "ts",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW() AT TIME ZONE 'UTC'"),
+        ),
+        sa.UniqueConstraint("account_id", "key", "version", name="uq_config_version"),
+    )
+
+
+def _coerce_json(value: object) -> object:
+    if isinstance(value, (dict, list)):
+        return value
+    if value is None:
+        return value
+    try:
+        return json.loads(value)  # type: ignore[arg-type]
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def _coerce_timestamp(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iter_legacy_rows() -> Iterable[Mapping[str, object]]:
+    configured_url = os.getenv("LEGACY_CONFIG_DATABASE_URL")
+    sqlite_path = Path(os.getenv("LEGACY_CONFIG_SQLITE_PATH", "/tmp/config.db"))
+
+    if configured_url:
+        source_url = configured_url
+    elif sqlite_path.exists():
+        source_url = f"sqlite+pysqlite:///{sqlite_path}"
+    else:
+        return []
+
+    engine = sa.create_engine(source_url, future=True)
+    try:
+        with engine.connect() as legacy_conn:
+            if not legacy_conn.dialect.has_table(legacy_conn, "config_versions"):
+                return []
+            try:
+                result = legacy_conn.execute(
+                    text(
+                        """
+                        SELECT id, account_id, key, value_json, version, approvers, ts
+                        FROM config_versions
+                        ORDER BY id
+                        """
+                    )
+                )
+            except SQLAlchemyError:
+                return []
+            return [row._mapping for row in result]
+    finally:
+        engine.dispose()
+
+
+def _import_legacy_rows(conn: Connection) -> None:
+    try:
+        existing_count = conn.execute(text("SELECT COUNT(1) FROM config_versions")).scalar()
+    except SQLAlchemyError:
+        existing_count = None
+    if existing_count and existing_count > 0:
+        return
+
+    rows = list(_iter_legacy_rows())
+    if not rows:
+        return
+
+    config_versions = sa.table(
+        "config_versions",
+        sa.column("id", sa.Integer()),
+        sa.column("account_id", sa.String()),
+        sa.column("key", sa.String()),
+        sa.column("value_json", sa.JSON()),
+        sa.column("version", sa.Integer()),
+        sa.column("approvers", sa.JSON()),
+        sa.column("ts", sa.DateTime(timezone=True)),
+    )
+
+    payload = []
+    for row in rows:
+        payload.append(
+            {
+                "id": row.get("id"),
+                "account_id": row.get("account_id") or "global",
+                "key": row.get("key"),
+                "value_json": _coerce_json(row.get("value_json")),
+                "version": row.get("version") or 1,
+                "approvers": _coerce_json(row.get("approvers")) or [],
+                "ts": _coerce_timestamp(row.get("ts")) or datetime.now(timezone.utc),
+            }
+        )
+
+    op.bulk_insert(config_versions, payload)
+
+    if conn.dialect.name == "postgresql":
+        conn.execute(
+            text(
+                "SELECT setval(pg_get_serial_sequence('config_versions', 'id'), "
+                "COALESCE((SELECT MAX(id) FROM config_versions), 0))"
+            )
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _create_config_versions(conn)
+    _import_legacy_rows(conn)
+
+
+def downgrade() -> None:
+    if _table_exists(op.get_bind(), "config_versions"):
+        op.drop_table("config_versions")

--- a/deploy/k8s/base/aether-services/deployment-config.yaml
+++ b/deploy/k8s/base/aether-services/deployment-config.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-service
+  labels:
+    app: config-service
+    app.kubernetes.io/name: config-service
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: config-service
+  template:
+    metadata:
+      labels:
+        app: config-service
+        app.kubernetes.io/name: config-service
+        app.kubernetes.io/component: api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: config-service
+          image: ghcr.io/aether/config-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: CONFIG_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: config-service-database
+                  key: dsn
+            - name: CONFIG_DB_SSLMODE
+              value: require
+          readinessProbe:
+            httpGet:
+              path: /config/current
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /config/current
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/deploy/k8s/base/aether-services/kustomization.yaml
+++ b/deploy/k8s/base/aether-services/kustomization.yaml
@@ -2,12 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - deployment-config.yaml
   - deployment-policy.yaml
   - deployment-risk.yaml
   - deployment-oms.yaml
   - deployment-fees.yaml
   - deployment-secrets.yaml
   - deployment-universe.yaml
+  - service-config.yaml
   - service-policy.yaml
   - service-risk.yaml
   - service-oms.yaml

--- a/deploy/k8s/base/aether-services/service-config.yaml
+++ b/deploy/k8s/base/aether-services/service-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: config-service
+  labels:
+    app: config-service
+spec:
+  selector:
+    app: config-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000

--- a/deploy/k8s/base/secrets/external-secrets.yaml
+++ b/deploy/k8s/base/secrets/external-secrets.yaml
@@ -23,6 +23,24 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: config-service-database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aether-vault
+    kind: ClusterSecretStore
+  target:
+    name: config-service-database
+    creationPolicy: Owner
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: trading/databases/config-service
+        property: dsn
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: fastapi-credentials
 spec:
   refreshInterval: 30m

--- a/ops/releases/release_manifest.py
+++ b/ops/releases/release_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -25,7 +26,42 @@ except ImportError:  # pragma: no cover - optional dependency
 
 
 DEFAULT_RELEASE_DB_URL = os.getenv("RELEASE_DATABASE_URL", "sqlite+pysqlite:////tmp/releases.db")
-DEFAULT_CONFIG_DB_URL = os.getenv("CONFIG_DATABASE_URL", "sqlite+pysqlite:////tmp/config.db")
+
+LOGGER = logging.getLogger("ops.release_manifest")
+_SQLITE_FALLBACK_FLAG = "CONFIG_ALLOW_SQLITE_FOR_TESTS"
+
+
+def _require_config_db_url() -> str:
+    url = os.getenv("CONFIG_DATABASE_URL")
+    if not url:
+        raise RuntimeError(
+            "CONFIG_DATABASE_URL must be set to collect configs for release manifests."
+        )
+
+    normalized = url.lower()
+    allowed_prefixes = ("postgresql://", "postgresql+psycopg://", "postgresql+psycopg2://")
+    if normalized.startswith("postgres://"):
+        url = "postgresql://" + url.split("://", 1)[1]
+        normalized = url.lower()
+
+    if normalized.startswith(allowed_prefixes):
+        return url
+
+    if os.getenv(_SQLITE_FALLBACK_FLAG) == "1":
+        LOGGER.warning(
+            "Allowing non-Postgres CONFIG_DATABASE_URL '%s' because %s=1.",
+            url,
+            _SQLITE_FALLBACK_FLAG,
+        )
+        return url
+
+    raise RuntimeError(
+        "CONFIG_DATABASE_URL must point to a PostgreSQL/TimescaleDB instance; "
+        f"received '{url}'."
+    )
+
+
+DEFAULT_CONFIG_DB_URL = _require_config_db_url()
 DEFAULT_SERVICES_DIR = Path("deploy/k8s/base/aether-services")
 DEFAULT_MODELS_DIR = Path("ml/models")
 DEFAULT_JSON_OUTPUT = Path("release_manifest_current.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ if str(ROOT) not in sys.path:
 _DEFAULT_MASTER_KEY = base64.b64encode(b"\x00" * 32).decode("ascii")
 os.environ.setdefault("SECRET_ENCRYPTION_KEY", _DEFAULT_MASTER_KEY)
 os.environ.setdefault("LOCAL_KMS_MASTER_KEY", _DEFAULT_MASTER_KEY)
+os.environ.setdefault("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
+os.environ.setdefault("CONFIG_DATABASE_URL", "sqlite+pysqlite:///:memory:")
 
 
 pytest_plugins = [

--- a/tests/integration/test_audit_chain.py
+++ b/tests/integration/test_audit_chain.py
@@ -91,6 +91,7 @@ def test_audit_chain_across_services(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("AUDIT_CHAIN_LOG", str(chain_log))
     monkeypatch.setenv("AUDIT_CHAIN_STATE", str(chain_state))
 
+    monkeypatch.setenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
     monkeypatch.setenv("CONFIG_DATABASE_URL", f"sqlite:///{tmp_path / 'config.db'}")
     monkeypatch.setenv("OVERRIDE_DATABASE_URL", f"sqlite:///{tmp_path / 'override.db'}")
     encryption_key = base64.b64encode(b"0" * 32).decode()

--- a/tests/smoke/test_config_service_smoke.py
+++ b/tests/smoke/test_config_service_smoke.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_config_module(alias: str):
+    spec = importlib.util.spec_from_file_location(alias, ROOT / "config_service.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load config_service module for smoke tests")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def _sqlite_db(tmp_path, monkeypatch):
+    def _factory(alias: str, *, reset: bool = False, path: Path | None = None):
+        db_path = path or (tmp_path / f"{alias}.db")
+        monkeypatch.setenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
+        monkeypatch.setenv("CONFIG_DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+        module = _load_config_module(alias)
+        if reset:
+            module.reset_state()
+        return module, db_path
+
+    yield _factory
+
+    # Ensure any dynamically loaded module state is removed between tests.
+    for key in list(sys.modules):
+        if key.startswith("config_service_smoke_"):
+            sys.modules.pop(key, None)
+
+
+def test_config_update_visible_across_replicas(_sqlite_db, monkeypatch):
+    primary, db_path = _sqlite_db("config_service_smoke_primary", reset=True)
+
+    with TestClient(primary.app) as client:
+        response = client.post(
+            "/config/update",
+            json={"key": "features.latency", "value": {"enabled": True}, "author": "alice"},
+        )
+        assert response.status_code == 200
+
+    monkeypatch.setenv("CONFIG_DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+    replica, _ = _sqlite_db("config_service_smoke_replica", path=db_path)
+
+    with TestClient(replica.app) as replica_client:
+        current = replica_client.get("/config/current").json()
+
+    assert current["features.latency"]["value"] == {"enabled": True}
+    assert current["features.latency"]["approvers"] == ["alice"]
+
+    primary.engine.dispose()
+    replica.engine.dispose()
+
+
+def test_config_versions_survive_module_reload(_sqlite_db, monkeypatch):
+    initial, db_path = _sqlite_db("config_service_smoke_initial", reset=True)
+
+    with TestClient(initial.app) as client:
+        response = client.post(
+            "/config/update",
+            json={"key": "limits.max_notional", "value": 42, "author": "bob"},
+        )
+        assert response.status_code == 200
+
+    monkeypatch.setenv("CONFIG_DATABASE_URL", f"sqlite+pysqlite:///{db_path}")
+    restarted = _load_config_module("config_service_smoke_restarted")
+
+    with TestClient(restarted.app) as client:
+        current = client.get("/config/current").json()
+
+    assert current["limits.max_notional"]["version"] == 1
+    assert current["limits.max_notional"]["approvers"] == ["bob"]
+
+    initial.engine.dispose()
+    restarted.engine.dispose()

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import os
+
 from fastapi.testclient import TestClient
+
+os.environ.setdefault("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
+os.environ.setdefault("CONFIG_DATABASE_URL", "sqlite+pysqlite:///:memory:")
 
 from config_service import app, reset_state, set_guarded_keys
 


### PR DESCRIPTION
## Summary
- require CONFIG_DATABASE_URL for the config service and CLI utilities, enabling Postgres-specific pooling/SSL settings with a controlled sqlite fallback for tests
- add an Alembic migration to create config_versions on Timescale and backfill rows from the legacy sqlite database
- provision Kubernetes secrets/deployments for the config service DSN and add smoke tests that cover replica visibility and restart persistence

## Testing
- pytest tests/test_config_service.py tests/smoke/test_config_service_smoke.py
- pytest tests/integration/test_audit_chain.py *(fails: ModuleNotFoundError: No module named 'services.common.security')*


------
https://chatgpt.com/codex/tasks/task_e_68e05242728c832198d57ac0e946f46c