### PR TITLE
Fix Argo CD CLI install permissions

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Install Argo CD CLI
         run: |
           curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-          install -m 755 argocd /usr/local/bin/argocd
+          sudo install -m 755 argocd /usr/local/bin/argocd
 
       - name: Argo CD login and sync
         env:


### PR DESCRIPTION
## Summary
- add sudo to the Argo CD CLI install command in the release workflow to ensure permissions when writing to /usr/local/bin

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e0582241388321931cfad6f195fe78