### PR TITLE
Fix risk image build workflow with new Dockerfiles

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -35,13 +35,13 @@ jobs:
         run: |
           /kaniko/executor \
             --context $GITHUB_WORKSPACE \
-            --dockerfile services/risk-api/Dockerfile \
+            --dockerfile deploy/docker/risk-api/Dockerfile \
             --destination ghcr.io/aether/risk-api:${{ github.sha }}
       - name: Build Ingestor Image
         run: |
           /kaniko/executor \
             --context $GITHUB_WORKSPACE \
-            --dockerfile services/risk-ingestor/Dockerfile \
+            --dockerfile deploy/docker/risk-ingestor/Dockerfile \
             --destination ghcr.io/aether/risk-ingestor:${{ github.sha }}
 
   buildah-sbom:
@@ -57,10 +57,10 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
       - name: Build Risk API with Buildah
         run: |
-          buildah bud -f services/risk-api/Dockerfile -t ghcr.io/aether/risk-api:${{ github.sha }} .
+          buildah bud -f deploy/docker/risk-api/Dockerfile -t ghcr.io/aether/risk-api:${{ github.sha }} .
       - name: Build Ingestor with Buildah
         run: |
-          buildah bud -f services/risk-ingestor/Dockerfile -t ghcr.io/aether/risk-ingestor:${{ github.sha }} .
+          buildah bud -f deploy/docker/risk-ingestor/Dockerfile -t ghcr.io/aether/risk-ingestor:${{ github.sha }} .
       - name: Generate SBOMs
         run: |
           syft ghcr.io/aether/risk-api:${{ github.sha }} -o json > sbom-risk-api.json

--- a/deploy/docker/risk-api/Dockerfile
+++ b/deploy/docker/risk-api/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "services.risk.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/docker/risk-ingestor/Dockerfile
+++ b/deploy/docker/risk-ingestor/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+COPY deploy/docker/risk-ingestor/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []

--- a/deploy/docker/risk-ingestor/entrypoint.sh
+++ b/deploy/docker/risk-ingestor/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -euo pipefail
+
+PAIRS="${KRAKEN_PAIRS:-BTC/USD,ETH/USD}"
+BOOTSTRAP="${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}"
+TRADE_TOPIC="${KRAKEN_TRADE_TOPIC:-md.trades}"
+BOOK_TOPIC="${KRAKEN_BOOK_TOPIC:-md.book}"
+BOOK_DEPTH="${KRAKEN_BOOK_DEPTH:-}"
+EXTRA_ARGS="${RISK_INGESTOR_EXTRA_ARGS:-}"
+
+set -- \
+  --pairs "${PAIRS}" \
+  --kafka-bootstrap "${BOOTSTRAP}" \
+  --trade-topic "${TRADE_TOPIC}" \
+  --book-topic "${BOOK_TOPIC}"
+
+if [ -n "${BOOK_DEPTH}" ]; then
+  set -- "$@" --book-depth "${BOOK_DEPTH}"
+fi
+
+if [ -n "${EXTRA_ARGS}" ]; then
+  # shellcheck disable=SC2086
+  set -- "$@" ${EXTRA_ARGS}
+fi
+
+exec python -m services.kraken_ws_ingest "$@"


### PR DESCRIPTION
## Summary
- add dedicated Dockerfiles for the risk API and risk ingestor services under deploy/docker
- introduce an entrypoint script so the risk ingestor container wires CLI flags from environment variables
- update the build-images workflow so both Kaniko and Buildah builds use the new Dockerfile locations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e057565f5083219e077f5dbc76d9d8