### PR TITLE
Update Docker workflow path triggers

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -6,8 +6,9 @@ on:
     branches:
       - main
     paths:
-      - 'services/**'
-      - 'Dockerfile*'
+      - 'deploy/docker/risk-api/**'
+      - 'deploy/docker/risk-ingestor/**'
+      - 'deploy/docker/kraken-ws-ingest/**'
 
 jobs:
   kaniko-build:


### PR DESCRIPTION
## Summary
- update the build-images workflow to watch the actual Dockerfile directories so Docker builds rerun when they change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05a82cc60832195e7538a9f1ad93c