### PR TITLE
Secure sentiment API with shared storage backend

### DIFF
--- a/data/alembic/versions/0005_create_sentiment_scores.py
+++ b/data/alembic/versions/0005_create_sentiment_scores.py
@@ -1,0 +1,41 @@
+"""Create sentiment_scores table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0005_create_sentiment_scores"
+down_revision = "0004_config_service_postgres"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sentiment_scores",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("symbol", sa.String(length=64), nullable=False),
+        sa.Column("score", sa.String(length=16), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ingested_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_sentiment_scores_symbol_ts",
+        "sentiment_scores",
+        ["symbol", "ts"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sentiment_scores_ts",
+        "sentiment_scores",
+        ["ts"],
+        unique=False,
+    )
+    op.execute("SELECT create_hypertable('sentiment_scores', 'ts', if_not_exists => TRUE)")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sentiment_scores_ts", table_name="sentiment_scores")
+    op.drop_index("ix_sentiment_scores_symbol_ts", table_name="sentiment_scores")
+    op.drop_table("sentiment_scores")

--- a/tests/test_sentiment_service.py
+++ b/tests/test_sentiment_service.py
@@ -1,0 +1,60 @@
+import datetime as dt
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sentiment_ingest import (
+    SentimentIngestService,
+    SentimentRepository,
+    SocialPost,
+    create_app,
+)
+
+
+class _StaticSentimentModel:
+    def classify(self, text: str):  # pragma: no cover - deterministic for tests
+        return "positive", 1.0
+
+
+@pytest.fixture
+def sentiment_app(tmp_path: Path) -> TestClient:
+    database_url = f"sqlite:///{tmp_path/'sentiment.db'}"
+    repository = SentimentRepository(database_url)
+    service = SentimentIngestService(repository=repository, model=_StaticSentimentModel(), sources=[])
+    app = create_app(service=service, repository=repository)
+    return TestClient(app)
+
+
+def test_latest_requires_admin_token(sentiment_app: TestClient) -> None:
+    response = sentiment_app.get("/sentiment/latest", params={"symbol": "BTC-USD"})
+    assert response.status_code == 401
+    assert response.json()["detail"].lower().startswith("missing authorization")
+
+
+def test_refresh_requires_admin_token(sentiment_app: TestClient) -> None:
+    response = sentiment_app.post("/sentiment/refresh", json=["BTC-USD"])
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_repository_persists_across_instances(tmp_path: Path) -> None:
+    database_url = f"sqlite:///{tmp_path/'sentiment_history.db'}"
+    repository = SentimentRepository(database_url)
+    observation = SocialPost(
+        symbol="btc-usd",
+        text="BTC rally continues",
+        source="twitter",
+        created_at=dt.datetime.now(dt.timezone.utc),
+    )
+    await repository.insert(observation, "positive")
+
+    second_repo = SentimentRepository(database_url)
+    latest = await second_repo.latest("BTC-USD")
+
+    assert latest is not None
+    stored_symbol, stored_label, stored_source, stored_ts = latest
+    assert stored_symbol == "BTC-USD"
+    assert stored_label == "positive"
+    assert stored_source == "twitter"
+    assert stored_ts.tzinfo is not None


### PR DESCRIPTION
## Summary
- secure the sentiment API endpoints with the existing admin-token dependency
- move the sentiment repository to a shared SQL/Timescale backend and add an Alembic migration
- add regression tests covering authorization failures and repository durability across restarts

## Testing
- `pytest tests/test_sentiment_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68e05a332114832191ca2faafa767ef6