### PR TITLE
Require Postgres DSN for volatility analytics and add smoke tests

### DIFF
--- a/data/migrations/versions/0005_create_vol_metrics_table.py
+++ b/data/migrations/versions/0005_create_vol_metrics_table.py
@@ -1,0 +1,33 @@
+"""Create volatility metrics hypertable."""
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS vol_metrics (
+    symbol TEXT NOT NULL,
+    realized_vol DOUBLE PRECISION NOT NULL,
+    garch_vol DOUBLE PRECISION NOT NULL,
+    jump_prob DOUBLE PRECISION NOT NULL,
+    atr DOUBLE PRECISION NOT NULL,
+    band_width DOUBLE PRECISION NOT NULL,
+    ts TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (symbol, ts)
+);
+"""
+
+
+def upgrade() -> None:
+    op.execute(CREATE_TABLE)
+    op.execute("SELECT create_hypertable('vol_metrics', 'ts', if_not_exists => TRUE);")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS vol_metrics;")

--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -188,6 +188,67 @@ backendServices:
     pdb:
       enabled: true
       maxUnavailable: 1
+  volatility:
+    enabled: true
+    nameOverride: volatility-service
+    image:
+      repository: ghcr.io/aether/volatility-service
+      tag: latest
+    replicaCount: 2
+    containerPort: 8000
+    env:
+      - name: ANALYTICS_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: volatility-service-database
+            key: dsn
+      - name: ANALYTICS_DB_SSLMODE
+        value: require
+      - name: ANALYTICS_DB_POOL_SIZE
+        value: "20"
+      - name: ANALYTICS_DB_MAX_OVERFLOW
+        value: "10"
+      - name: ANALYTICS_DB_POOL_TIMEOUT
+        value: "30"
+      - name: ANALYTICS_DB_POOL_RECYCLE
+        value: "1800"
+    usesKrakenSecrets: false
+    extraVolumeMounts: []
+    extraVolumes: []
+    service:
+      port: 80
+      targetPort: http
+    ingress:
+      enabled: true
+      host: volatility.aether.example.com
+      tlsSecret: volatility-service-tls
+      annotations: {}
+    resources:
+      requests:
+        cpu: 150m
+        memory: 384Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 5
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 65
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 120
+    pdb:
+      enabled: true
+      maxUnavailable: 1
   oms:
     enabled: true
     nameOverride: oms-service

--- a/deploy/k8s/base/secrets/external-secrets.yaml
+++ b/deploy/k8s/base/secrets/external-secrets.yaml
@@ -59,6 +59,24 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: volatility-service-database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aether-vault
+    kind: ClusterSecretStore
+  target:
+    name: volatility-service-database
+    creationPolicy: Owner
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: trading/databases/volatility-service
+        property: dsn
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: fastapi-credentials
 spec:
   refreshInterval: 30m

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,5 +67,6 @@ markers = [
     "unit: unit test suite",
     "integration: integration test suite",
     "slow: end-to-end trading pipeline checks",
+    "smoke: smoke tests covering service persistence and deployment wiring",
 ]
 

--- a/tests/smoke/test_volatility_service_persistence.py
+++ b/tests/smoke/test_volatility_service_persistence.py
@@ -1,0 +1,150 @@
+"""Smoke tests for the volatility analytics service."""
+from __future__ import annotations
+
+import importlib
+from importlib import util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine as _sa_create_engine, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.url import make_url
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+pytest.importorskip("sqlalchemy")
+
+_REAL_CREATE_ENGINE = _sa_create_engine
+_SERVICE_MODULE = "services.analytics.volatility_service"
+
+
+class _EngineProxy:
+    """Proxy that pretends to be a Postgres engine while using SQLite underneath."""
+
+    def __init__(self, inner: Engine) -> None:
+        self._inner = inner
+        self.url = make_url("postgresql+psycopg2://analytics:test@localhost/analytics")
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._inner, item)
+
+    def dispose(self) -> None:  # pragma: no cover - passthrough
+        self._inner.dispose()
+
+
+def _reload_service(monkeypatch: pytest.MonkeyPatch, sqlite_url: str) -> Any:
+    monkeypatch.setenv(
+        "ANALYTICS_DATABASE_URL",
+        "postgresql://analytics:test@localhost/analytics",
+    )
+
+    def _patched_create_engine(url: str, **kwargs: Any) -> _EngineProxy:  # type: ignore[override]
+        assert url.startswith("postgresql")
+        inner = _REAL_CREATE_ENGINE(sqlite_url, future=True)
+        return _EngineProxy(inner)
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _patched_create_engine, raising=False)
+
+    importlib.import_module("services")
+
+    analytics_pkg = "services.analytics"
+    if analytics_pkg not in sys.modules:
+        pkg_spec = util.spec_from_file_location(
+            analytics_pkg, ROOT / "services" / "analytics" / "__init__.py"
+        )
+        if pkg_spec and pkg_spec.loader:
+            package = util.module_from_spec(pkg_spec)
+            sys.modules[analytics_pkg] = package
+            pkg_spec.loader.exec_module(package)
+
+    if _SERVICE_MODULE in sys.modules:
+        del sys.modules[_SERVICE_MODULE]
+
+    spec = util.spec_from_file_location(
+        _SERVICE_MODULE, ROOT / "services" / "analytics" / "volatility_service.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load volatility service module for testing")
+
+    module = util.module_from_spec(spec)
+    sys.modules[_SERVICE_MODULE] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_migration_stub(module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _stub() -> None:
+        module.Base.metadata.create_all(bind=module.ENGINE)
+
+    monkeypatch.setattr(module, "run_migrations", _stub)
+
+
+def _seed_ohlcv(module: Any) -> None:
+    with module.SessionLocal() as session:
+        base_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        close = 30_000.0
+        for offset in range(6):
+            bucket_start = base_time + timedelta(minutes=offset)
+            candle = module.OhlcvBar(
+                market="BTC-USD",
+                bucket_start=bucket_start,
+                open=close - 25 + offset,
+                high=close + 35 + offset,
+                low=close - 45,
+                close=close + offset * 50,
+                volume=1_000 + offset * 10,
+            )
+            session.merge(candle)
+        session.commit()
+
+
+@pytest.mark.smoke
+def test_volatility_metrics_survive_service_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sqlite_path = tmp_path / "volatility-analytics.db"
+    module = _reload_service(monkeypatch, f"sqlite:///{sqlite_path}")
+    _install_migration_stub(module, monkeypatch)
+
+    with TestClient(module.app) as client:
+        _seed_ohlcv(module)
+        response = client.get(
+            "/volatility/realized",
+            params={"symbol": "BTC-USD", "window": 5},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["symbol"] == "BTC-USD"
+        assert payload["realized_vol"] >= 0.0
+
+    with module.SessionLocal() as session:
+        stored = session.execute(select(module.VolatilityMetric)).scalars().all()
+        assert len(stored) == 1
+        stored_symbol = stored[0].symbol
+        stored_timestamp = stored[0].ts
+
+    module.ENGINE.dispose()
+    if _SERVICE_MODULE in sys.modules:
+        del sys.modules[_SERVICE_MODULE]
+
+    module_reloaded = _reload_service(monkeypatch, f"sqlite:///{sqlite_path}")
+    _install_migration_stub(module_reloaded, monkeypatch)
+
+    with module_reloaded.SessionLocal() as session:
+        persisted = session.execute(select(module_reloaded.VolatilityMetric)).scalars().all()
+        assert [(row.symbol, row.ts) for row in persisted] == [(stored_symbol, stored_timestamp)]
+
+    other_engine = _REAL_CREATE_ENGINE(f"sqlite:///{sqlite_path}", future=True)
+    try:
+        with other_engine.connect() as connection:
+            rows = connection.execute(text("SELECT symbol FROM vol_metrics"))
+            symbols = [row[0] for row in rows]
+        assert symbols == ["BTC-USD"]
+    finally:
+        other_engine.dispose()


### PR DESCRIPTION
## Summary
- require a PostgreSQL/Timescale connection for the volatility analytics service, configure pooling/SSL, and run Alembic migrations on startup
- add a vol_metrics hypertable migration and wire deployment configs to provision the shared analytics DSN
- add a smoke test that simulates persistence across service restarts and checks data visibility from another client

## Testing
- pytest tests/smoke/test_volatility_service_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68e05b2392bc8321981a93cbd113dc64