### PR TITLE
Add v prefix to Trivy action references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
           path: sbom-${{ matrix.build.name }}.spdx.json
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.21.0
+        uses: aquasecurity/trivy-action@0.21.0
         with:
           image-ref: ${{ steps.image_meta.outputs.sha_tag }}
           severity: CRITICAL,HIGH

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
           path: sbom-${{ matrix.build.name }}.spdx.json
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.21.0
+        uses: aquasecurity/trivy-action@v0.21.0
         with:
           image-ref: ${{ steps.image_meta.outputs.sha_tag }}
           severity: CRITICAL,HIGH

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy SAST scan
-        uses: aquasecurity/trivy-action@0.21.0
+        uses: aquasecurity/trivy-action@v0.21.0
         with:
           scan-type: fs
           severity: CRITICAL

--- a/.github/workflows/pr-security-tests.yml
+++ b/.github/workflows/pr-security-tests.yml
@@ -85,7 +85,7 @@ PY
 
       - name: Run Trivy filesystem scan
         id: trivy_scan
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           scan-type: fs
           format: json

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy config scan
-        uses: aquasecurity/trivy-action@0.17.0
+        uses: aquasecurity/trivy-action@v0.17.0
         with:
           scan-type: config
           format: table
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy FS scan
-        uses: aquasecurity/trivy-action@0.17.0
+        uses: aquasecurity/trivy-action@v0.17.0
         with:
           scan-type: fs
           format: table


### PR DESCRIPTION
## Summary
- update Trivy workflow steps to use tags with the v prefix so GitHub resolves the intended versions

## Testing
- not run (GitHub Actions workflows cannot be executed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e05e5c5f2c83219d0c6ffab396b448