### PR TITLE
Fix indentation of shared auth middleware import

### DIFF
--- a/portfolio_service.py
+++ b/portfolio_service.py
@@ -16,7 +16,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from services.portfolio.balance_reader import BalanceReader, BalanceRetrievalError
 
 try:  # pragma: no cover - shared middleware may be unavailable in minimal environments
-from shared.authz_middleware import (  # type: ignore
+    from shared.authz_middleware import (  # type: ignore
         BearerTokenError,
         _coerce_account_scopes as _shared_coerce_account_scopes,
         _decode_jwt as _shared_decode_jwt,


### PR DESCRIPTION
## Summary
- indent the optional shared auth middleware import so it is properly guarded by the try/except

## Testing
- python -m pyflakes portfolio_service.py *(fails: No module named pyflakes)*

------
https://chatgpt.com/codex/tasks/task_e_68e05e5b51d483219b04798e749e863d