### PR TITLE
Enforce anomaly service auth and migrate to shared database

### DIFF
--- a/data/migrations/versions/0005_create_anomaly_log_table.py
+++ b/data/migrations/versions/0005_create_anomaly_log_table.py
@@ -1,0 +1,37 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "anomaly_log",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("account_id", sa.String(length=128), nullable=False),
+        sa.Column("anomaly_type", sa.String(length=128), nullable=False),
+        sa.Column(
+            "details_json",
+            sa.JSON().with_variant(postgresql.JSONB(none_as_null=True), "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "ts",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_anomaly_log_account_id", "anomaly_log", ["account_id"])
+    op.create_index("ix_anomaly_log_ts", "anomaly_log", ["ts"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_anomaly_log_ts", table_name="anomaly_log")
+    op.drop_index("ix_anomaly_log_account_id", table_name="anomaly_log")
+    op.drop_table("anomaly_log")

--- a/tests/integration/test_anomaly_service_persistence.py
+++ b/tests/integration/test_anomaly_service_persistence.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator, List, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit, quote_plus
+
+import pytest
+from fastapi.testclient import TestClient
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg is required for anomaly persistence tests")
+
+pytestmark = pytest.mark.integration
+
+_TEST_DSN = os.getenv("AETHER_ANOMALY_TEST_DSN") or os.getenv("AETHER_TIMESCALE_TEST_DSN")
+if not _TEST_DSN:
+    pytest.skip(
+        "AETHER_ANOMALY_TEST_DSN or AETHER_TIMESCALE_TEST_DSN must be configured for anomaly persistence tests",
+        allow_module_level=True,
+    )
+
+
+def _with_schema(dsn: str, schema: str) -> str:
+    parts = urlsplit(dsn)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["options"] = f"-csearch_path={schema}"
+    new_query = urlencode(query, doseq=True, quote_via=quote_plus)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+
+
+def _load_module(module_name: str, database_url: str) -> ModuleType:
+    module_path = Path(__file__).resolve().parents[2] / "anomaly_service.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load anomaly_service module")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    os.environ["ANOMALY_DATABASE_URL"] = database_url
+    os.environ.pop("TIMESCALE_DSN", None)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+class ModuleFactory:
+    def __init__(self, database_url: str) -> None:
+        self.database_url = database_url
+        self.loaded: List[Tuple[str, ModuleType]] = []
+
+    def load(self, alias: str | None = None) -> ModuleType:
+        name = alias or f"anomaly_instance_{uuid.uuid4().hex[:8]}"
+        if name in sys.modules:
+            sys.modules.pop(name, None)
+        module = _load_module(name, self.database_url)
+        module.Base.metadata.create_all(bind=module.ENGINE)
+
+        class _Detector:
+            def scan_account(self, account_id: str, lookback_minutes: int):
+                return [
+                    module.Incident(
+                        account_id=account_id,
+                        anomaly_type="integration_test",
+                        details={"source": "integration"},
+                        ts=datetime.now(timezone.utc),
+                    )
+                ]
+
+        class _Factory(module.ResponseFactory):
+            def __init__(self) -> None:
+                super().__init__(
+                    detector=_Detector(),
+                    repository=module.IncidentRepository(session_factory=module.SessionLocal),
+                )
+
+            def _raise_alert(self, incident):
+                return None
+
+            def _block_account(self, incident):
+                return None
+
+            def _is_blocked(self, account_id: str) -> bool:
+                return False
+
+        module._coordinator = _Factory()
+        self.loaded.append((name, module))
+        return module
+
+    def unload(self, alias: str) -> None:
+        for index, (name, module) in enumerate(list(self.loaded)):
+            if name != alias:
+                continue
+            engine = getattr(module, "ENGINE", None)
+            if engine is not None:
+                engine.dispose()
+            sys.modules.pop(name, None)
+            self.loaded.pop(index)
+            break
+
+
+@pytest.fixture
+def anomaly_environment() -> Iterator[ModuleFactory]:
+    schema = f"anomaly_int_{uuid.uuid4().hex[:8]}"
+    database_url = _with_schema(_TEST_DSN, schema)
+
+    with psycopg.connect(_TEST_DSN) as conn:  # type: ignore[arg-type]
+        with conn.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+            cursor.execute(f'CREATE SCHEMA "{schema}"')
+        conn.commit()
+
+    factory = ModuleFactory(database_url=database_url)
+    original_url = os.environ.get("ANOMALY_DATABASE_URL")
+    original_timescale = os.environ.get("TIMESCALE_DSN")
+
+    try:
+        yield factory
+    finally:
+        for name, module in list(factory.loaded):
+            engine = getattr(module, "ENGINE", None)
+            if engine is not None:
+                engine.dispose()
+            sys.modules.pop(name, None)
+        factory.loaded.clear()
+
+        if original_url is None:
+            os.environ.pop("ANOMALY_DATABASE_URL", None)
+        else:
+            os.environ["ANOMALY_DATABASE_URL"] = original_url
+
+        if original_timescale is None:
+            os.environ.pop("TIMESCALE_DSN", None)
+        else:
+            os.environ["TIMESCALE_DSN"] = original_timescale
+
+        with psycopg.connect(_TEST_DSN) as conn:  # type: ignore[arg-type]
+            with conn.cursor() as cursor:
+                cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+            conn.commit()
+
+
+def test_incidents_persist_across_restarts(anomaly_environment: ModuleFactory) -> None:
+    first = anomaly_environment.load("anomaly_primary")
+    first_client = TestClient(first.app)
+    first_client.app.dependency_overrides[first.require_admin_account] = lambda: "company"
+
+    response = first_client.post(
+        "/anomaly/scan",
+        json={"account_id": "company", "lookback_minutes": 15},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["incidents"], "Expected detector to log an incident"
+
+    anomaly_environment.unload("anomaly_primary")
+
+    second = anomaly_environment.load("anomaly_restart")
+    second_client = TestClient(second.app)
+    second_client.app.dependency_overrides[second.require_admin_account] = lambda: "company"
+
+    status_response = second_client.get("/anomaly/status", params={"account_id": "company"})
+
+    assert status_response.status_code == 200
+    payload = status_response.json()
+    assert payload["incidents"], "Expected persisted incidents to be available after restart"
+    assert payload["incidents"][0]["anomaly_type"] == "integration_test"

--- a/tests/test_anomaly_service_api.py
+++ b/tests/test_anomaly_service_api.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+import sqlalchemy
+from sqlalchemy.pool import StaticPool
+
+
+@pytest.fixture
+def anomaly_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[Tuple[object, TestClient]]:
+    monkeypatch.setenv(
+        "ANOMALY_DATABASE_URL",
+        "postgresql+psycopg://tester:password@localhost:5432/testdb",
+    )
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    root_path = Path(__file__).resolve().parents[1]
+    for key in list(sys.modules):
+        if key == "services" or key.startswith("services."):
+            sys.modules.pop(key, None)
+    monkeypatch.syspath_prepend(str(root_path))
+    import services.alert_manager  # noqa: F401
+
+    def _sqlite_engine(url: str, **kwargs):
+        return create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+            future=True,
+        )
+
+    monkeypatch.setattr(sqlalchemy, "create_engine", _sqlite_engine)
+
+    sys.modules.pop("anomaly_service", None)
+    module = importlib.import_module("anomaly_service")
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    module.ENGINE = engine
+    module.SessionLocal = module.sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False, future=True
+    )
+    module.Base.metadata.create_all(bind=engine)
+
+    class _NullDetector:
+        def scan_account(self, account_id: str, lookback_minutes: int):
+            return []
+
+    class _TestResponseFactory(module.ResponseFactory):
+        def __init__(self) -> None:
+            super().__init__(
+                detector=_NullDetector(),
+                repository=module.IncidentRepository(session_factory=module.SessionLocal),
+            )
+
+        def _raise_alert(self, incident):
+            return None
+
+        def _block_account(self, incident):
+            return None
+
+        def _is_blocked(self, account_id: str) -> bool:
+            return False
+
+    module._coordinator = _TestResponseFactory()
+
+    client = TestClient(module.app)
+    try:
+        yield module, client
+    finally:
+        client.app.dependency_overrides.clear()
+        engine.dispose()
+        sys.modules.pop("anomaly_service", None)
+
+
+def test_status_requires_authentication(anomaly_client: Tuple[object, TestClient]) -> None:
+    module, client = anomaly_client
+
+    response = client.get("/anomaly/status", params={"account_id": "company"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Authorization header."
+
+
+def test_status_rejects_account_mismatch(anomaly_client: Tuple[object, TestClient]) -> None:
+    module, client = anomaly_client
+    client.app.dependency_overrides[module.require_admin_account] = lambda: "company"
+
+    response = client.get("/anomaly/status", params={"account_id": "ops"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Authenticated account does not match requested account."
+
+
+def test_scan_rejects_payload_mismatch(anomaly_client: Tuple[object, TestClient]) -> None:
+    module, client = anomaly_client
+    client.app.dependency_overrides[module.require_admin_account] = lambda: "company"
+
+    response = client.post(
+        "/anomaly/scan",
+        json={"account_id": "ops", "lookback_minutes": 15},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Authenticated account does not match requested account."
+
+
+def test_scan_allows_matching_account(anomaly_client: Tuple[object, TestClient]) -> None:
+    module, client = anomaly_client
+    client.app.dependency_overrides[module.require_admin_account] = lambda: "company"
+
+    response = client.post(
+        "/anomaly/scan",
+        json={"account_id": "company", "lookback_minutes": 15},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["incidents"] == []
+    assert body["blocked"] is False


### PR DESCRIPTION
## Summary
- require administrative authentication on the anomaly status and scan endpoints and ensure the requested account matches the authenticated session
- switch the anomaly service to the shared PostgreSQL/Timescale database and add an Alembic migration for the anomaly_log table
- extend the FastAPI test suite with security coverage and an integration scenario verifying persistence across restarts

## Testing
- pytest tests/test_anomaly_service_api.py
- pytest tests/integration/test_anomaly_service_persistence.py


------
https://chatgpt.com/codex/tasks/task_e_68e05d0298108321a1beb5601ba8bb5a