### PR TITLE
Fix sequencer exchange adapter import

### DIFF
--- a/sequencer.py
+++ b/sequencer.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 import httpx
 from auth.session_client import AdminSessionManager, get_default_session_manager
 from common.utils import tracing
+from exchange_adapter import get_exchange_adapter
 from services.common.adapters import KafkaNATSAdapter
 
 from services.common.security import require_admin_account

--- a/tests/test_sequencer_api.py
+++ b/tests/test_sequencer_api.py
@@ -26,6 +26,7 @@ if "metrics" not in sys.modules:
     metrics_stub.observe_risk_validation_latency = _noop
     metrics_stub.set_pipeline_latency = _noop
     metrics_stub.setup_metrics = _noop
+    metrics_stub.get_request_id = lambda: "test-request"
 
     class _Span(types.SimpleNamespace):
         async def __aenter__(self) -> "_Span":
@@ -126,6 +127,10 @@ def stubbed_pipeline(
 
     monkeypatch.setattr(sequencer_module.pipeline, "submit", _submit)
     return calls
+
+
+def test_module_initializes_exchange_adapter(sequencer_module: ModuleType) -> None:
+    assert getattr(sequencer_module, "EXCHANGE_ADAPTER") is not None
 
 
 def test_submit_intent_requires_authentication(


### PR DESCRIPTION
## Summary
- import the exchange adapter factory in the sequencer module so module import succeeds
- extend the sequencer API test stubs and add a regression test covering exchange adapter initialization

## Testing
- pytest tests/test_sequencer_api.py -k module_initializes_exchange_adapter

------
https://chatgpt.com/codex/tasks/task_e_68e05f7694d883219b282abc8747b82a