### PR TITLE
Update OPA workflow to target policy bundle

### DIFF
--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -98,10 +98,10 @@ jobs:
             echo "No Kubernetes manifests found to test."
             exit 0
           fi
-          if [ -d policy ]; then
-            conftest test deploy
+          if [ -d deploy/k8s/policies ]; then
+            conftest test deploy --policy deploy/k8s/policies
           else
-            echo "No OPA policies found. Skipping check."
+            echo "No OPA policies found at deploy/k8s/policies. Skipping check."
             exit 0
           fi
 

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -99,7 +99,13 @@ jobs:
             exit 0
           fi
           if [ -d deploy/k8s/policies ]; then
-            conftest test deploy --policy deploy/k8s/policies
+            rego_policies="$(find deploy/k8s/policies -type f -name '*.rego' -print -quit)"
+            if [ -n "$rego_policies" ]; then
+              conftest test deploy --policy deploy/k8s/policies
+            else
+              echo "No Rego policies found in deploy/k8s/policies. Skipping check."
+              exit 0
+            fi
           else
             echo "No OPA policies found at deploy/k8s/policies. Skipping check."
             exit 0


### PR DESCRIPTION
## Summary
- ensure the security workflow looks for the Kubernetes policy bundle in deploy/k8s/policies
- run conftest with the repository's policy bundle when present

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e05f7ee3648321ad55b1f36a6adcd1