### PR TITLE
Require managed compliance DSN and add persistence smoke test

### DIFF
--- a/data/migrations/versions/0005_create_compliance_assets.py
+++ b/data/migrations/versions/0005_create_compliance_assets.py
@@ -1,0 +1,29 @@
+"""Create compliance assets table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "compliance_assets",
+        sa.Column("symbol", sa.String(length=64), primary_key=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("compliance_assets")

--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -300,7 +300,18 @@ backendServices:
       tag: latest
     replicaCount: 2
     containerPort: 8000
-    env: []
+    env:
+      - name: COMPLIANCE_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: compliance-service-database
+            key: dsn
+      - name: COMPLIANCE_DB_SSLMODE
+        valueFrom:
+          secretKeyRef:
+            name: compliance-service-database
+            key: sslmode
+            optional: true
     usesKrakenSecrets: true
     extraVolumeMounts: []
     extraVolumes: []

--- a/deploy/k8s/base/aether-services/deployment-risk.yaml
+++ b/deploy/k8s/base/aether-services/deployment-risk.yaml
@@ -35,6 +35,17 @@ spec:
             - containerPort: 8000
               name: http
           env:
+            - name: COMPLIANCE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: compliance-service-database
+                  key: dsn
+            - name: COMPLIANCE_DB_SSLMODE
+              valueFrom:
+                secretKeyRef:
+                  name: compliance-service-database
+                  key: sslmode
+                  optional: true
             - name: KRAKEN_SECRETS_BASE
               value: /var/run/secrets/kraken
             - name: AETHER_COMPANY_KRAKEN_SECRET_PATH

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - kafka
   - nats
   - fastapi
+  - secrets/external-secrets.yaml
   - ingress
   - networkpolicies
   - aether-services

--- a/deploy/k8s/base/secrets/external-secrets.yaml
+++ b/deploy/k8s/base/secrets/external-secrets.yaml
@@ -117,3 +117,26 @@ spec:
       remoteRef:
         key: trading/databases/strategy-orchestrator
         property: sslmode
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: compliance-service-database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aether-vault
+    kind: ClusterSecretStore
+  target:
+    name: compliance-service-database
+    creationPolicy: Owner
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: trading/databases/compliance-service
+        property: dsn
+    - secretKey: sslmode
+      remoteRef:
+        key: trading/databases/compliance-service
+        property: sslmode

--- a/tests/compliance/test_compliance_filter_replication.py
+++ b/tests/compliance/test_compliance_filter_replication.py
@@ -1,0 +1,80 @@
+"""Smoke tests for the compliance filter's shared persistence."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def test_restricted_symbols_persist_and_replicate(
+    tmp_path: Path,
+) -> None:
+    """Restricted instruments must persist across restarts and replicas."""
+
+    project_root = Path(__file__).resolve().parents[2]
+    filtered_path = [str(project_root)]
+    filtered_path.extend(p for p in sys.path if "tests" not in p)
+    sys.path = filtered_path
+    importlib.invalidate_caches()
+    sys.modules.pop("services", None)
+    sys.modules.pop("services.common", None)
+    sys.modules.pop("services.common.security", None)
+
+    module = importlib.import_module("compliance_filter")
+    module = importlib.reload(module)
+
+    db_path = tmp_path / "compliance-smoke.db"
+    dsn = f"sqlite:///{db_path}"
+
+    engine = create_engine(dsn, future=True)
+    module.run_compliance_migrations(engine)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False, future=True
+    )
+
+    primary = module.ComplianceFilter(session_factory)
+    replica = module.ComplianceFilter(session_factory)
+
+    entry = primary.update_asset("btc-usd", "restricted", "manual review")
+
+    allowed, replica_entry = replica.evaluate("btc-usd")
+    assert not allowed
+    assert replica_entry is not None
+    assert replica_entry.status == "restricted"
+    assert replica_entry.reason == "manual review"
+
+    engine.dispose()
+
+    restarted_engine = create_engine(dsn, future=True)
+    module.run_compliance_migrations(restarted_engine)
+    restarted_factory = sessionmaker(
+        bind=restarted_engine, autoflush=False, expire_on_commit=False, future=True
+    )
+    restarted_filter = module.ComplianceFilter(restarted_factory)
+
+    allowed_after_restart, persisted_entry = restarted_filter.evaluate("btc-usd")
+    assert not allowed_after_restart
+    assert persisted_entry is not None
+    assert persisted_entry.status == "restricted"
+    assert persisted_entry.reason == "manual review"
+    assert persisted_entry.updated_at >= entry.updated_at
+
+
+@pytest.fixture(autouse=True)
+def _configure_sqlite_compliance_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Configure a throwaway SQLite URL so the module can import in tests."""
+
+    monkeypatch.setattr(sys, "path", list(sys.path), raising=False)
+    bootstrap_dsn = f"sqlite:///{(tmp_path / 'bootstrap.db')}"
+    monkeypatch.setenv("COMPLIANCE_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.setenv("COMPLIANCE_DATABASE_URL", bootstrap_dsn)
+    yield
+    monkeypatch.delenv("COMPLIANCE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("COMPLIANCE_ALLOW_SQLITE_FOR_TESTS", raising=False)


### PR DESCRIPTION
## Summary
- enforce managed PostgreSQL/Timescale DSNs for the compliance filter and configure connection pooling with migrations
- provision Kubernetes and Helm manifests with compliance database secrets for the risk service
- add an Alembic migration and smoke test verifying compliance restrictions persist across replicas and restarts

## Testing
- pytest tests/compliance/test_compliance_filter_replication.py


------
https://chatgpt.com/codex/tasks/task_e_68e05d73bc3c8321bbc8c91a68151858