### PR TITLE
Add InMemorySessionStore import to OMS service

### DIFF
--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from auth.service import (
+    InMemorySessionStore,
     RedisSessionStore,
     SessionStoreProtocol,
 )


### PR DESCRIPTION
## Summary
- include the in-memory session store in the OMS service auth imports to support fallback session configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0622b9bb4832184a32e64a90da0b1