### PR TITLE
Add missing adapters imports

### DIFF
--- a/services/common/adapters.py
+++ b/services/common/adapters.py
@@ -3,29 +3,24 @@ from __future__ import annotations
 
 import asyncio
 import base64
-
 import hashlib
-import tempfile
-
 import json
 import logging
-
 import os
-
-import uuid
 import sqlite3
+import tempfile
 import threading
+import time
+import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
-
-from pathlib import Path
-from weakref import WeakSet
-
-
-
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, Iterable, List, Mapping, Optional, Tuple
+from urllib.parse import urlparse
 from weakref import WeakSet
+
+import httpx
 
 
 from common.utils.tracing import attach_correlation, current_correlation_id


### PR DESCRIPTION
## Summary
- add missing standard library and third-party imports to the adapters module

## Testing
- python -m compileall services/common/adapters.py

------
https://chatgpt.com/codex/tasks/task_e_68e0631e3d8483218b8eb406b9dbacf0