### PR TITLE
Require ESG database configuration for ESG filter

### DIFF
--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -485,6 +485,16 @@ backendServices:
           secretKeyRef:
             name: risk-service-database
             key: sslmode
+      - name: ESG_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: risk-service-database
+            key: dsn
+      - name: ESG_DB_SSLMODE
+        valueFrom:
+          secretKeyRef:
+            name: risk-service-database
+            key: sslmode
 
     usesKrakenSecrets: true
     extraVolumeMounts: []

--- a/deploy/k8s/base/aether-services/deployment-risk.yaml
+++ b/deploy/k8s/base/aether-services/deployment-risk.yaml
@@ -65,6 +65,17 @@ spec:
                   name: risk-service-database
                   key: sslmode
                   optional: true
+            - name: ESG_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: risk-service-database
+                  key: dsn
+            - name: ESG_DB_SSLMODE
+              valueFrom:
+                secretKeyRef:
+                  name: risk-service-database
+                  key: sslmode
+                  optional: true
           readinessProbe:
             httpGet:
               path: /metrics

--- a/tests/helpers/risk.py
+++ b/tests/helpers/risk.py
@@ -7,19 +7,16 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
-from typing import Iterator
+from typing import Callable, Iterator
 
+import os
 import sqlalchemy
 
 
 MANAGED_RISK_DSN = "postgresql://risk:integration@timescaledb:5432/risk"
 
 
-def _configure_test_engine(monkeypatch, db_path: Path) -> None:
-    """Patch SQLAlchemy's ``create_engine`` to back the risk service with SQLite."""
-
-    real_create_engine = sqlalchemy.create_engine
-
+def _sqlite_engine_proxy(db_path: Path, real_create_engine):
     def _create_engine(url: str, **kwargs):  # type: ignore[override]
         if url.startswith("postgresql"):
             sqlite_kwargs = dict(kwargs)
@@ -31,12 +28,37 @@ def _configure_test_engine(monkeypatch, db_path: Path) -> None:
             sqlite_kwargs.pop("max_overflow", None)
             sqlite_kwargs.pop("pool_timeout", None)
             sqlite_kwargs.pop("pool_recycle", None)
+            sqlite_kwargs.pop("pool_pre_ping", None)
             return real_create_engine(f"sqlite:///{db_path}", **sqlite_kwargs)
         return real_create_engine(url, **kwargs)
 
+    return _create_engine
+
+
+def patch_sqlalchemy_for_risk(db_path: Path) -> Callable[[], None]:
+    """Patch SQLAlchemy globally so risk services use a SQLite backing store."""
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(sqlalchemy, "create_engine", _create_engine)
+    real_create_engine = sqlalchemy.create_engine
+    proxy = _sqlite_engine_proxy(db_path, real_create_engine)
+    sqlalchemy.create_engine = proxy
+    os.environ.setdefault("RISK_DATABASE_URL", MANAGED_RISK_DSN)
+    os.environ.setdefault("ESG_DATABASE_URL", MANAGED_RISK_DSN)
+
+    def restore() -> None:
+        sqlalchemy.create_engine = real_create_engine
+
+    return restore
+
+
+def _configure_test_engine(monkeypatch, db_path: Path) -> None:
+    """Patch SQLAlchemy's ``create_engine`` to back the risk service with SQLite."""
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    proxy = _sqlite_engine_proxy(db_path, sqlalchemy.create_engine)
+    monkeypatch.setattr(sqlalchemy, "create_engine", proxy)
     monkeypatch.setenv("RISK_DATABASE_URL", MANAGED_RISK_DSN)
+    monkeypatch.setenv("ESG_DATABASE_URL", MANAGED_RISK_DSN)
 
 
 @contextmanager
@@ -69,3 +91,35 @@ def reload_risk_service(tmp_path: Path, monkeypatch, *, db_filename: str = "risk
     _configure_test_engine(monkeypatch, db_path)
     sys.modules.pop("risk_service", None)
     return importlib.import_module("risk_service")
+
+
+@contextmanager
+def esg_filter_instance(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    db_filename: str = "risk.db",
+) -> Iterator[ModuleType]:
+    """Yield an ESG filter module backed by an isolated SQLite database."""
+
+    db_path = tmp_path / db_filename
+    _configure_test_engine(monkeypatch, db_path)
+    sys.modules.pop("esg_filter", None)
+    module = importlib.import_module("esg_filter")
+    try:
+        yield module
+    finally:
+        try:
+            module.ENGINE.dispose()
+        except Exception:  # pragma: no cover - defensive cleanup
+            pass
+        sys.modules.pop("esg_filter", None)
+
+
+def reload_esg_filter(tmp_path: Path, monkeypatch, *, db_filename: str = "risk.db") -> ModuleType:
+    """Return a freshly imported ESG filter module using the shared SQLite store."""
+
+    db_path = tmp_path / db_filename
+    _configure_test_engine(monkeypatch, db_path)
+    sys.modules.pop("esg_filter", None)
+    return importlib.import_module("esg_filter")

--- a/tests/risk/test_esg_filter_persistence.py
+++ b/tests/risk/test_esg_filter_persistence.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import sys
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+from sqlalchemy import select
+
+pytest.importorskip("fastapi")
+pytest.importorskip("services.common.security")
+
+from tests.helpers.risk import esg_filter_instance, reload_esg_filter
+
+
+def test_esg_assets_persist_across_restarts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_name = "esg_persist.db"
+    symbol = "eth-usd"
+
+    with esg_filter_instance(tmp_path, monkeypatch, db_filename=db_name) as module_a:
+        entry = module_a.esg_filter.update_asset(symbol, 72.5, "watch", "initial load")
+        assets = module_a.esg_filter.list_assets()
+        assert len(assets) == 1
+        assert assets[0].symbol == entry.symbol
+        assert assets[0].flag == entry.flag
+        assert assets[0].reason == entry.reason
+
+    with esg_filter_instance(tmp_path, monkeypatch, db_filename=db_name) as module_b:
+        assets_after_restart = module_b.esg_filter.list_assets()
+        assert len(assets_after_restart) == 1
+        stored = assets_after_restart[0]
+        assert stored.symbol == "ETH-USD"
+        assert stored.flag == "watch"
+        assert stored.reason == "initial load"
+
+
+def test_esg_rejections_visible_to_new_instances(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_name = "esg_consistency.db"
+    account_a = "acct-a"
+    account_b = "acct-b"
+    symbol = "btc-usd"
+
+    with esg_filter_instance(tmp_path, monkeypatch, db_filename=db_name) as module_a:
+        entry = module_a.esg_filter.update_asset(symbol, 5.0, "high_regulatory", "blocked")
+        module_a.esg_filter.log_rejection(account_a, symbol, entry)
+        with module_a.SessionLocal() as session:
+            records = session.execute(select(module_a.ESGRejection)).scalars().all()
+            assert len(records) == 1
+            assert records[0].account_id == account_a
+            assert records[0].symbol == "BTC-USD"
+
+    module_b = reload_esg_filter(tmp_path, monkeypatch, db_filename=db_name)
+    try:
+        allowed, entry_b = module_b.esg_filter.evaluate(symbol)
+        assert allowed is False
+        assert entry_b is not None
+        module_b.esg_filter.log_rejection(account_b, symbol, entry_b)
+        with module_b.SessionLocal() as session:
+            records = session.execute(select(module_b.ESGRejection)).scalars().all()
+            assert len(records) == 2
+            assert {record.account_id for record in records} == {account_a, account_b}
+            assert {record.symbol for record in records} == {"BTC-USD"}
+    finally:
+        module_b.ENGINE.dispose()
+        sys.modules.pop("esg_filter", None)

--- a/tests/risk/test_risk_service_endpoints.py
+++ b/tests/risk/test_risk_service_endpoints.py
@@ -8,6 +8,10 @@ from pathlib import Path
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from tests.helpers.risk import patch_sqlalchemy_for_risk
+
+_RESTORE_SQLALCHEMY = patch_sqlalchemy_for_risk(Path(__file__).with_name("risk_endpoints.db"))
+
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -49,6 +53,8 @@ pytest.importorskip("services.common.security")
 from risk_service import app, require_admin_account
 from services.common import security
 from tests.helpers.authentication import override_admin_auth
+
+_RESTORE_SQLALCHEMY()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/risk/test_validate.py
+++ b/tests/risk/test_validate.py
@@ -4,8 +4,21 @@ from __future__ import annotations
 from collections.abc import Generator
 from typing import Any
 
+from pathlib import Path
+
 import pytest
 
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.helpers.risk import patch_sqlalchemy_for_risk
+
+_RESTORE_SQLALCHEMY = patch_sqlalchemy_for_risk(Path(__file__).with_name("risk_validate.db"))
+
+pytest.importorskip("services.common.adapters")
 from services.common.adapters import RedisFeastAdapter, TimescaleAdapter
 from services.common.schemas import (
     FeeBreakdown,
@@ -18,6 +31,8 @@ from services.common.schemas import (
     RiskValidationResponse,
 )
 from services.risk.engine import RiskEngine
+
+_RESTORE_SQLALCHEMY()
 
 class StubUniverseRepository:
     def __init__(self) -> None:

--- a/tests/unit/services/test_risk_service.py
+++ b/tests/unit/services/test_risk_service.py
@@ -10,9 +10,13 @@ from typing import Dict, Iterator
 
 import pytest
 
+from tests.helpers.risk import patch_sqlalchemy_for_risk
+
 ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+_RESTORE_SQLALCHEMY = patch_sqlalchemy_for_risk(Path(__file__).with_name("risk_service_unit.db"))
 
 pytest.importorskip("fastapi")
 pytest.importorskip("services.common.security")
@@ -21,6 +25,8 @@ from fastapi.testclient import TestClient
 
 from risk_service import RiskEvaluationContext, app as risk_app, require_admin_account
 from tests.helpers.authentication import override_admin_auth
+
+_RESTORE_SQLALCHEMY()
 
 config = dict(getattr(RiskEvaluationContext, "model_config", {}))
 config["arbitrary_types_allowed"] = True


### PR DESCRIPTION
## Summary
- require ESG_DATABASE_URL and configure the ESG filter engine to use pooled Postgres connections with migrations
- update risk service deployment manifests to provide the shared ESG database settings
- extend risk test helpers and add regression tests covering ESG persistence across reloads

## Testing
- pytest tests/risk/test_esg_filter_persistence.py tests/risk/test_validate.py tests/unit/services/test_risk_service.py tests/risk/test_risk_service_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ed8f2e8c8321ba11c54fb50decdc