### PR TITLE
Fix cosign command formatting

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -138,7 +138,7 @@ jobs:
           fi
           echo "$COSIGN_PRIVATE_KEY" > cosign.key
           trap 'rm -f cosign.key' EXIT
-          cosign sign --key cosign.key "${{ needs.build-image.outputs.image_ref }}@${{ needs.build-image.outputs.image_digest }}"
+          cosign sign --key cosign.key "${{ needs.build-image.outputs.image_ref }}@${{ needs.build-image.outputs.image_digest}}"
 
   deploy:
     name: Deploy to Linode via Argo CD


### PR DESCRIPTION
## Summary
- keep the cosign signing command on a single line so the image reference and digest remain within the quoted argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ee9532f48321bff35c99145cccef