### PR TITLE
Add stablecoin monitor import to OMS service

### DIFF
--- a/oms_service.py
+++ b/oms_service.py
@@ -35,6 +35,7 @@ from services.oms.kraken_ws import (
 )
 
 from services.oms.rate_limit_guard import RateLimitGuard, rate_limit_guard as shared_rate_limit_guard
+from services.risk.stablecoin_monitor import format_depeg_alert, get_global_monitor
 
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
 from services.oms.oms_service import (  # type: ignore  # pragma: no cover - shared helpers


### PR DESCRIPTION
## Summary
- add the stablecoin monitor helpers to the OMS service imports so they can be used downstream

## Testing
- python -m compileall oms_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ee9568e48321a195247a660da740