### PR TITLE
Expand CI workflows to run on kill-switch branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - kill-switch
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - kill-switch
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- update CI workflows to run on pushes to both main and kill-switch branches

## Testing
- ./bin/act push --validate -e /tmp/push-kill-switch.json -W .github/workflows/ci.yaml
- ./bin/act push --validate -e /tmp/push-kill-switch.json -W .github/workflows/lint-test.yml

------
https://chatgpt.com/codex/tasks/task_e_68e0f05cefd08321a6ec82fb91313081