### PR TITLE
Ensure precision module imports logging and threading

### DIFF
--- a/services/common/precision.py
+++ b/services/common/precision.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Mapping, Optional
 
 import httpx
 
+# Module-level logger for metadata refresh diagnostics.
 logger = logging.getLogger(__name__)
 
 

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from services.common.precision import (
@@ -45,4 +47,12 @@ def test_precision_provider_missing_symbol_raises() -> None:
 
     with pytest.raises(PrecisionMetadataUnavailable):
         provider.require("UNKNOWN")
+
+
+def test_precision_module_import_and_instantiation() -> None:
+    module = importlib.import_module("services.common.precision")
+
+    provider = module.PrecisionMetadataProvider()
+
+    assert isinstance(provider, PrecisionMetadataProvider)
 


### PR DESCRIPTION
## Summary
- document the precision metadata module's logger initialization
- add a regression test to ensure the precision module imports and provider instantiation succeed

## Testing
- PYTHONPATH=. pytest tests/services/common/test_precision_provider.py
- PYTHONPATH=. pytest tests/risk/test_position_sizer_precision.py
- PYTHONPATH=. pytest tests/unit/test_hedging_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f0f075508321959e7a661bb5eac6