### PR TITLE
Require managed Postgres for benchmark service

### DIFF
--- a/data/alembic/versions/0006_create_benchmark_curves.py
+++ b/data/alembic/versions/0006_create_benchmark_curves.py
@@ -1,0 +1,42 @@
+"""Create benchmark_curves hypertable."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0006_create_benchmark_curves"
+down_revision = "0005_create_sentiment_scores"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "benchmark_curves",
+        sa.Column("account_id", sa.String(length=128), nullable=False),
+        sa.Column("benchmark", sa.String(length=64), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("pnl", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.PrimaryKeyConstraint("account_id", "benchmark", "ts", name="pk_benchmark_curves"),
+    )
+    op.create_index(
+        "ix_benchmark_curves_account_benchmark_ts",
+        "benchmark_curves",
+        ["account_id", "benchmark", "ts"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_benchmark_curves_ts",
+        "benchmark_curves",
+        ["ts"],
+        unique=False,
+    )
+    op.execute("SELECT create_hypertable('benchmark_curves', 'ts', if_not_exists => TRUE)")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_benchmark_curves_ts", table_name="benchmark_curves")
+    op.drop_index("ix_benchmark_curves_account_benchmark_ts", table_name="benchmark_curves")
+    op.drop_table("benchmark_curves")
+

--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -149,6 +149,65 @@ backendServices:
     pdb:
       enabled: true
       maxUnavailable: 1
+  benchmark:
+    enabled: true
+    nameOverride: benchmark-service
+    image:
+      repository: ghcr.io/aether/benchmark-service
+      tag: latest
+    replicaCount: 2
+    containerPort: 8000
+    env:
+      - name: BENCHMARK_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: benchmark-service-database
+            key: dsn
+      - name: BENCHMARK_DB_SSLMODE
+        valueFrom:
+          secretKeyRef:
+            name: benchmark-service-database
+            key: sslmode
+      - name: BENCHMARK_DB_POOL_SIZE
+        value: "15"
+      - name: BENCHMARK_DB_MAX_OVERFLOW
+        value: "5"
+      - name: BENCHMARK_DB_POOL_TIMEOUT
+        value: "30"
+      - name: BENCHMARK_DB_POOL_RECYCLE
+        value: "1800"
+    usesKrakenSecrets: false
+    extraVolumeMounts: []
+    extraVolumes: []
+    service:
+      port: 80
+      targetPort: http
+    ingress:
+      enabled: true
+      host: benchmark.aether.example.com
+      tlsSecret: benchmark-service-tls
+      annotations: {}
+    resources:
+      requests:
+        cpu: 150m
+        memory: 384Mi
+      limits:
+        cpu: 400m
+        memory: 768Mi
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 60
+    pdb:
+      enabled: true
+      maxUnavailable: 1
   fees:
     enabled: true
     nameOverride: fees-service

--- a/deploy/k8s/base/secrets/external-secrets.yaml
+++ b/deploy/k8s/base/secrets/external-secrets.yaml
@@ -174,3 +174,26 @@ spec:
         key: trading/databases/override-service
 
         property: sslmode
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: benchmark-service-database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aether-vault
+    kind: ClusterSecretStore
+  target:
+    name: benchmark-service-database
+    creationPolicy: Owner
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: trading/databases/benchmark-service
+        property: dsn
+    - secretKey: sslmode
+      remoteRef:
+        key: trading/databases/benchmark-service
+        property: sslmode

--- a/tests/helpers/benchmark_service.py
+++ b/tests/helpers/benchmark_service.py
@@ -1,0 +1,80 @@
+"""Test helpers for the benchmark service."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+_DEFAULT_TEST_DSN: Final[str] = "postgresql://benchmark.test/benchmark"
+
+
+def bootstrap_benchmark_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    reset: bool = False,
+    db_filename: str = "benchmark.db",
+    dsn: str | None = None,
+) -> ModuleType:
+    """Import ``benchmark_service`` with a persistent SQLite database for tests."""
+
+    database_url = dsn or _DEFAULT_TEST_DSN
+    monkeypatch.setenv("BENCHMARK_DATABASE_URL", database_url)
+    # Ensure optional fallbacks do not interfere with the configured DSN.
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    repo_path = str(repo_root)
+    if repo_path not in sys.path:
+        sys.path.insert(0, repo_path)
+    sys.modules.pop("services", None)
+    sys.modules.pop("services.common", None)
+
+    sys.modules.pop("benchmark_service", None)
+    module = importlib.import_module("benchmark_service")
+
+    db_path = tmp_path / db_filename
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Session = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    module.ENGINE = engine  # type: ignore[attr-defined]
+    module.SessionLocal = Session  # type: ignore[attr-defined]
+    module.app.state.db_sessionmaker = Session  # type: ignore[attr-defined]
+
+    try:
+        from fastapi import HTTPException, Request, status
+    except Exception:  # pragma: no cover - FastAPI is optional in some environments
+        pass
+    else:
+        allowed_admin = "company"
+
+        def _test_require_admin_account(request: Request) -> str:
+            account = request.headers.get("X-Account-ID", "").strip()
+            if not account or account.lower() != allowed_admin:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Account is not authorized for administrative access.",
+                )
+            return allowed_admin
+
+        _test_require_admin_account.__annotations__["request"] = Request
+        module.app.dependency_overrides[module.require_admin_account] = _test_require_admin_account  # type: ignore[attr-defined]
+
+    if reset:
+        module.Base.metadata.drop_all(bind=engine)  # type: ignore[attr-defined]
+    module.Base.metadata.create_all(bind=engine)  # type: ignore[attr-defined]
+
+    return module
+

--- a/tests/smoke/test_benchmark_service_persistence.py
+++ b/tests/smoke/test_benchmark_service_persistence.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from tests.helpers.benchmark_service import bootstrap_benchmark_service
+
+
+def _record_snapshot(
+    client: TestClient,
+    account_id: str,
+    ts: datetime,
+    *,
+    aether: float,
+    btc: float,
+    eth: float,
+    basket: float | None = None,
+) -> None:
+    payload = {
+        "account_id": account_id,
+        "ts": ts.isoformat(),
+        "aether_return": aether,
+        "btc_return": btc,
+        "eth_return": eth,
+    }
+    if basket is not None:
+        payload["basket_return"] = basket
+    response = client.post(
+        "/benchmark/curves",
+        json=payload,
+        headers={"X-Account-ID": "company"},
+    )
+    assert response.status_code == 204
+
+
+def _compare_snapshot(client: TestClient, account_id: str, when: datetime) -> dict[str, float]:
+    response = client.get(
+        "/benchmark/compare",
+        params={"account_id": account_id, "date": when.isoformat()},
+        headers={"X-Account-ID": "company"},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.smoke
+def test_benchmark_snapshots_persist_across_restarts_and_replicas(tmp_path, monkeypatch) -> None:
+    """Snapshots persist across restarts and are visible to new replicas."""
+
+    db_filename = "benchmark-smoke.db"
+    account = "acct-123"
+    first_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    second_ts = first_ts + timedelta(days=1)
+
+    module_a = bootstrap_benchmark_service(tmp_path, monkeypatch, reset=True, db_filename=db_filename)
+    with TestClient(module_a.app) as client_a:
+        _record_snapshot(
+            client_a,
+            account,
+            first_ts,
+            aether=0.12,
+            btc=0.05,
+            eth=0.03,
+            basket=0.04,
+        )
+        initial = _compare_snapshot(client_a, account, first_ts)
+        assert initial["aether_return"] == pytest.approx(0.12)
+        assert initial["basket_return"] == pytest.approx(0.04)
+        assert initial["excess_return"] == pytest.approx(initial["aether_return"] - initial["basket_return"])
+    module_a.ENGINE.dispose()
+
+    module_b = bootstrap_benchmark_service(tmp_path, monkeypatch, db_filename=db_filename)
+    with TestClient(module_b.app) as client_b:
+        persisted = _compare_snapshot(client_b, account, first_ts)
+        assert persisted["btc_return"] == pytest.approx(0.05)
+        _record_snapshot(
+            client_b,
+            account,
+            second_ts,
+            aether=0.2,
+            btc=0.06,
+            eth=0.04,
+        )
+    module_b.ENGINE.dispose()
+
+    module_c = bootstrap_benchmark_service(tmp_path, monkeypatch, db_filename=db_filename)
+    with TestClient(module_c.app) as client_c:
+        latest = _compare_snapshot(client_c, account, second_ts)
+        assert latest["aether_return"] == pytest.approx(0.2)
+        assert latest["basket_return"] == pytest.approx(0.05)
+        assert latest["excess_return"] == pytest.approx(latest["aether_return"] - latest["basket_return"])
+
+        historic = _compare_snapshot(client_c, account, first_ts)
+        assert historic["aether_return"] == pytest.approx(0.12)
+    module_c.ENGINE.dispose()
+
+    sys.modules.pop("benchmark_service", None)
+


### PR DESCRIPTION
## Summary
- require a managed PostgreSQL/Timescale DSN for the benchmark service and configure pooling/SSL options
- add an Alembic migration that creates the shared benchmark_curves hypertable
- wire deployment manifests to provide managed database credentials and add a smoke test covering multi-replica persistence

## Testing
- pytest tests/smoke/test_benchmark_service_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f06e93e083218de99e3afd0646c9