### PR TITLE
Pin requests dependency in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "argon2-cffi==23.1.0",
     "passlib[argon2]==1.7.4",
     "httpx==0.28.1",
+    "requests==2.32.5",
     "websockets==15.0.1",
     "pyyaml==6.0.3",
     "pandas==2.2.3",


### PR DESCRIPTION
## Summary
- add the pinned requests 2.32.5 dependency to the project metadata to stay consistent with requirements.txt

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f412655883218ee37412f659f2da