### PR TITLE
Refactor precision metadata provider for async refresh

### DIFF
--- a/services/common/precision.py
+++ b/services/common/precision.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
 import threading
 import time
 from decimal import Decimal, InvalidOperation
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
 
 import httpx
 
@@ -24,12 +26,36 @@ class PrecisionMetadataProvider:
     def __init__(
         self,
         *,
-        fetcher: Callable[[], Mapping[str, Any]] | None = None,
+        fetcher: Callable[[], Mapping[str, Any]]
+        | Callable[[], Awaitable[Mapping[str, Any]]]
+        | None = None,
         refresh_interval: float = 300.0,
         timeout: float = 2.5,
         time_source: Callable[[], float] = time.monotonic,
     ) -> None:
-        self._fetcher = fetcher or self._default_fetcher
+        raw_fetcher = fetcher or self._default_fetcher
+        self._fetcher: Callable[[], Awaitable[Mapping[str, Any]]]
+        if inspect.iscoroutinefunction(raw_fetcher):
+
+            async def _async_fetcher() -> Mapping[str, Any]:
+                result = raw_fetcher()
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+
+            self._fetcher = _async_fetcher
+        else:
+
+            def _call_fetcher() -> Mapping[str, Any] | Awaitable[Mapping[str, Any]]:
+                return raw_fetcher()
+
+            async def _threaded_fetcher() -> Mapping[str, Any]:
+                result = await asyncio.to_thread(_call_fetcher)
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+
+            self._fetcher = _threaded_fetcher
         self._refresh_interval = max(float(refresh_interval), 0.0)
         self._timeout = max(float(timeout), 0.0)
         self._time_source = time_source
@@ -59,13 +85,13 @@ class PrecisionMetadataProvider:
             raise PrecisionMetadataUnavailable(f"Precision metadata unavailable for {symbol}")
         return metadata
 
-    def refresh(self, *, force: bool = False) -> None:
+    async def refresh(self, *, force: bool = False) -> None:
         """Force a metadata refresh regardless of cache age if requested."""
 
         if not force and not self._needs_refresh():
             return
         try:
-            payload = self._fetcher()
+            payload = await self._fetcher()
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning("Failed to fetch Kraken precision metadata: %s", exc)
             return
@@ -90,12 +116,28 @@ class PrecisionMetadataProvider:
 
     def _maybe_refresh(self) -> None:
         if self._needs_refresh():
-            self.refresh(force=True)
+            self._refresh_sync(force=True)
 
-    def _default_fetcher(self) -> Mapping[str, Any]:
+    def _refresh_sync(self, *, force: bool) -> None:
+        try:
+            asyncio.run(self.refresh(force=force))
+        except RuntimeError as exc:  # pragma: no cover - defensive guard
+            if "asyncio.run()" in str(exc):
+                raise RuntimeError(
+                    "PrecisionMetadataProvider.refresh() cannot be called from an "
+                    "active event loop; await refresh() or call within asyncio.to_thread()."
+                ) from exc
+            raise
+
+    def refresh_sync(self, *, force: bool = False) -> None:
+        """Synchronously refresh metadata for callers without an event loop."""
+
+        self._refresh_sync(force=force)
+
+    async def _default_fetcher(self) -> Mapping[str, Any]:
         url = "https://api.kraken.com/0/public/AssetPairs"
-        with httpx.Client(timeout=self._timeout) as client:
-            response = client.get(url)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(url)
             response.raise_for_status()
             payload = response.json()
         if isinstance(payload, Mapping):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import os
 import sys
@@ -451,7 +452,7 @@ def _seed_precision_cache(monkeypatch: pytest.MonkeyPatch):
         fetcher=lambda: payload,
         refresh_interval=0.0,
     )
-    provider.refresh(force=True)
+    asyncio.run(provider.refresh(force=True))
     monkeypatch.setattr(precision_module, "precision_provider", provider)
 
     policy_module = sys.modules.get("policy_service")

--- a/tests/integration/test_trading_pipeline.py
+++ b/tests/integration/test_trading_pipeline.py
@@ -211,7 +211,7 @@ def test_trading_pipeline_emits_fill_event(
         ) -> None:
             if shadow:
                 return
-            precision = policy_module._resolve_precision(request.instrument)
+            precision = await policy_module._resolve_precision(request.instrument)
             snapped_price = policy_module._snap(request.price, precision["tick"])
             snapped_qty = policy_module._snap(request.quantity, precision["lot"])
             order_type = "limit" if response.selected_action.lower() == "maker" else "market"

--- a/tests/risk/test_position_sizer_precision.py
+++ b/tests/risk/test_position_sizer_precision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 import pytest
@@ -61,7 +62,7 @@ def test_position_sizer_halts_when_precision_missing(monkeypatch: pytest.MonkeyP
     from services.common import precision as precision_module
 
     provider = precision_module.PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
-    provider.refresh(force=True)
+    asyncio.run(provider.refresh(force=True))
 
     monkeypatch.setattr(precision_module, "precision_provider", provider)
     monkeypatch.setattr("services.risk.position_sizer.precision_provider", provider)

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 
 import pytest
@@ -20,33 +21,38 @@ def _payload(tick: float, lot: float) -> dict[str, dict[str, str]]:
     }
 
 
-def test_precision_provider_refreshes_metadata() -> None:
+@pytest.mark.asyncio
+async def test_precision_provider_refreshes_metadata() -> None:
     payload_ref: dict[str, dict[str, dict[str, str]]] = {"data": _payload(0.0001, 0.1)}
 
-    def _fetch() -> dict[str, dict[str, str]]:
+    async def _fetch() -> dict[str, dict[str, str]]:
         return payload_ref["data"]
 
     provider = PrecisionMetadataProvider(fetcher=_fetch, refresh_interval=0.0)
-    provider.refresh(force=True)
+    await provider.refresh(force=True)
 
-    first = provider.require("ADA-USD")
+    first = await asyncio.to_thread(provider.require, "ADA-USD")
     assert first["tick"] == pytest.approx(0.0001)
     assert first["lot"] == pytest.approx(0.1)
 
     payload_ref["data"] = _payload(0.001, 5.0)
-    provider.refresh(force=True)
+    await provider.refresh(force=True)
 
-    updated = provider.require("ADA-USD")
+    updated = await asyncio.to_thread(provider.require, "ADA-USD")
     assert updated["tick"] == pytest.approx(0.001)
     assert updated["lot"] == pytest.approx(5.0)
 
 
-def test_precision_provider_missing_symbol_raises() -> None:
-    provider = PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
-    provider.refresh(force=True)
+@pytest.mark.asyncio
+async def test_precision_provider_missing_symbol_raises() -> None:
+    async def _fetch_empty() -> dict[str, dict[str, str]]:
+        return {}
+
+    provider = PrecisionMetadataProvider(fetcher=_fetch_empty, refresh_interval=0.0)
+    await provider.refresh(force=True)
 
     with pytest.raises(PrecisionMetadataUnavailable):
-        provider.require("UNKNOWN")
+        await asyncio.to_thread(provider.require, "UNKNOWN")
 
 
 def test_precision_module_import_and_instantiation() -> None:

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
+import time
 import types
+from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
 
 from typing import List
@@ -329,8 +332,9 @@ def test_policy_decide_preserves_tick_precision(
     assert body.effective_fee.taker == pytest.approx(2.3456)
 
 
-def test_policy_resolves_precision_for_ada_pair() -> None:
-    precision = policy_service._resolve_precision("ADA-USD")
+@pytest.mark.asyncio
+async def test_policy_resolves_precision_for_ada_pair() -> None:
+    precision = await policy_service._resolve_precision("ADA-USD")
     assert precision["tick"] == pytest.approx(0.0001)
     assert precision["lot"] == pytest.approx(0.1)
 
@@ -339,6 +343,68 @@ def test_policy_resolves_precision_for_ada_pair() -> None:
 
     assert snapped_price == pytest.approx(0.2568)
     assert snapped_qty == pytest.approx(12.3)
+
+
+def test_policy_decide_handles_concurrent_precision_refresh(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    from services.common import precision as precision_module
+
+    sleep_duration = 0.2
+    fetch_calls = 0
+
+    async def _slow_fetch() -> dict[str, dict[str, str]]:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        await asyncio.sleep(sleep_duration)
+        return {
+            "XBTUSD": {
+                "wsname": "XBT/USD",
+                "tick_size": "0.5",
+                "lot_step": "0.0001",
+            }
+        }
+
+    provider = precision_module.PrecisionMetadataProvider(
+        fetcher=_slow_fetch,
+        refresh_interval=0.0,
+    )
+    monkeypatch.setattr(precision_module, "precision_provider", provider, raising=False)
+    monkeypatch.setattr(policy_service, "precision_provider", provider, raising=False)
+
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return Decimal("5.0")
+
+    monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
+    monkeypatch.setattr(
+        policy_service,
+        "predict_intent",
+        lambda **_: _intent(edge_bps=22.0, approved=True, selected="maker"),
+    )
+    monkeypatch.setattr(policy_service, "_enforce_stablecoin_guard", lambda: None)
+
+    async def _noop_dispatch(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(policy_service, "_dispatch_shadow_orders", _noop_dispatch)
+
+    def _post_decision():
+        payload = _decision_request_payload("company")
+        return client.post("/policy/decide", json=payload)
+
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(_post_decision) for _ in range(2)]
+        responses = [future.result(timeout=2.0) for future in futures]
+    duration = time.perf_counter() - start
+
+    assert duration < sleep_duration * 1.8
+    for response in responses:
+        assert response.status_code == status.HTTP_200_OK, response.text
+
+    assert 1 <= fetch_calls <= 2
 
 
 def test_policy_decide_rejects_when_slippage_erodes_edge(


### PR DESCRIPTION
## Summary
- refactor the shared precision metadata provider to fetch using httpx.AsyncClient and expose an async refresh API while keeping synchronous callers supported via to_thread helpers
- update policy service precision lookups to avoid blocking the event loop and add regression coverage for concurrent cache refresh scenarios
- adjust fixtures and unit tests to await async refreshes and exercise the new threading boundaries

## Testing
- PYTHONPATH=. pytest tests/services/common/test_precision_provider.py
- PYTHONPATH=. pytest tests/test_policy_service_api.py::test_policy_decide_handles_concurrent_precision_refresh
- PYTHONPATH=. pytest tests/test_policy_service_api.py::test_policy_resolves_precision_for_ada_pair

------
https://chatgpt.com/codex/tasks/task_e_68e0f25e3ecc8321bd0305cd671883e0