### PR TITLE
Support Kraken native precision metadata for non-USD pairs

### DIFF
--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, InvalidOperation
 
 import time
-from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Mapping, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.exception_handlers import request_validation_exception_handler
@@ -363,6 +363,20 @@ _BASE_ALIASES: Dict[str, str] = {
 _QUOTE_ALIASES: Dict[str, str] = {
     "USD": "USD",
     "ZUSD": "USD",
+    "USDT": "USDT",
+    "ZUSDT": "USDT",
+    "EUR": "EUR",
+    "ZEUR": "EUR",
+    "GBP": "GBP",
+    "ZGBP": "GBP",
+    "CAD": "CAD",
+    "ZCAD": "CAD",
+    "CHF": "CHF",
+    "ZCHF": "CHF",
+    "JPY": "JPY",
+    "ZJPY": "JPY",
+    "USDC": "USDC",
+    "ZUSDC": "USDC",
 }
 
 
@@ -420,30 +434,57 @@ def _step_from_metadata(
     return None
 
 
+def _sanitize_pair(value: str, entry: Mapping[str, Any]) -> str:
+    token = (value or "").strip().upper()
+    if not token:
+        return ""
+    if "/" in token:
+        base_part, quote_part = token.split("/", 1)
+        base = base_part.strip()
+        quote = quote_part.strip()
+        if base and quote:
+            return f"{base}/{quote}"
+        return ""
+
+    base = str(entry.get("base") or "").strip().upper()
+    quote = str(entry.get("quote") or "").strip().upper()
+    if base and quote and token == f"{base}{quote}":
+        return f"{base}/{quote}"
+
+    quote_candidates = [quote]
+    normalized_quote = _normalize_asset(quote, is_quote=True)
+    if normalized_quote and normalized_quote != quote:
+        quote_candidates.append(normalized_quote)
+
+    for candidate in quote_candidates:
+        if candidate and token.endswith(candidate) and len(token) > len(candidate):
+            base_part = token[: -len(candidate)]
+            if base_part:
+                return f"{base_part}/{candidate}"
+    return ""
+
+
 def _instrument_from_pair(metadata: Dict[str, Any]) -> Optional[str]:
-    base = _normalize_asset(str(metadata.get("base") or ""), is_quote=False)
-    quote = _normalize_asset(str(metadata.get("quote") or ""), is_quote=True)
+    wsname = metadata.get("wsname")
+    if isinstance(wsname, str):
+        pair = _sanitize_pair(wsname, metadata)
+        if pair:
+            return pair
 
-    if not base or not quote:
-        wsname = metadata.get("wsname")
-        if isinstance(wsname, str) and "/" in wsname:
-            base_part, quote_part = wsname.split("/", 1)
-            base = base or _normalize_asset(base_part, is_quote=False)
-            quote = quote or _normalize_asset(quote_part, is_quote=True)
+    altname = metadata.get("altname")
+    if isinstance(altname, str):
+        pair = _sanitize_pair(altname, metadata)
+        if pair:
+            return pair
 
-    if (not base or not quote) and isinstance(metadata.get("altname"), str):
-        altname = metadata["altname"].replace("/", "").upper()
-        if len(altname) >= 6:
-            base = base or _normalize_asset(altname[:-3], is_quote=False)
-            quote = quote or _normalize_asset(altname[-3:], is_quote=True)
-
-    if not base or quote != "USD":
-        return None
-
-    return f"{base}-USD"
+    base = str(metadata.get("base") or "").strip().upper()
+    quote = str(metadata.get("quote") or "").strip().upper()
+    if base and quote:
+        return f"{base}/{quote}"
+    return None
 
 
-MetadataEntry = Dict[str, float | str]
+MetadataEntry = Dict[str, Any]
 MarketMetadataDict = Dict[str, MetadataEntry]
 
 
@@ -465,24 +506,90 @@ def _native_pair_identifier(entry: Dict[str, Any], instrument: str) -> str:
     return fallback
 
 
-def _parse_asset_pairs(payload: Dict[str, Any]) -> MarketMetadataDict:
+def _collect_aliases(entry: Dict[str, Any], native_pair: str) -> Tuple[str, ...]:
+    base_native, quote_native = native_pair.split("/", 1)
+
+    bases = {base_native}
+    quotes = {quote_native}
+
+    base_raw = str(entry.get("base") or "").strip().upper()
+    if base_raw:
+        bases.add(base_raw)
+        normalized_base = _normalize_asset(base_raw, is_quote=False)
+        if normalized_base:
+            bases.add(normalized_base)
+
+    quote_raw = str(entry.get("quote") or "").strip().upper()
+    if quote_raw:
+        quotes.add(quote_raw)
+        normalized_quote = _normalize_asset(quote_raw, is_quote=True)
+        if normalized_quote:
+            quotes.add(normalized_quote)
+
+    altname = entry.get("altname")
+    if isinstance(altname, str):
+        cleaned = altname.strip().upper()
+        if "/" in cleaned:
+            alt_base, alt_quote = cleaned.split("/", 1)
+            if alt_base:
+                bases.add(alt_base)
+                normalized = _normalize_asset(alt_base, is_quote=False)
+                if normalized:
+                    bases.add(normalized)
+            if alt_quote:
+                quotes.add(alt_quote)
+                normalized = _normalize_asset(alt_quote, is_quote=True)
+                if normalized:
+                    quotes.add(normalized)
+        else:
+            for candidate in list(quotes):
+                if candidate and cleaned.endswith(candidate) and len(cleaned) > len(candidate):
+                    alt_base = cleaned[: -len(candidate)]
+                    if alt_base:
+                        bases.add(alt_base)
+                        normalized = _normalize_asset(alt_base, is_quote=False)
+                        if normalized:
+                            bases.add(normalized)
+
+    aliases = set()
+    for base in bases:
+        for quote in quotes:
+            if not base or not quote:
+                continue
+            aliases.add(f"{base}-{quote}")
+            aliases.add(f"{base}/{quote}")
+            aliases.add(f"{base}{quote}")
+
+    return tuple(sorted({alias for alias in aliases if alias}))
+
+
+def _parse_asset_pairs(payload: Dict[str, Any]) -> Tuple[MarketMetadataDict, Dict[str, str]]:
     parsed: MarketMetadataDict = {}
+    aliases: Dict[str, str] = {}
     for entry in payload.values():
         if not isinstance(entry, dict):
             continue
-        instrument = _instrument_from_pair(entry)
-        if not instrument:
+        native_pair = _instrument_from_pair(entry)
+        if not native_pair:
             continue
         tick = _step_from_metadata(entry, ["tick_size", "price_increment"], ["pair_decimals"])
         lot = _step_from_metadata(entry, ["lot_step", "step_size"], ["lot_decimals"])
         if tick is None or lot is None:
             continue
-        parsed[_normalize_instrument(instrument)] = {
+        key = _normalize_instrument(native_pair)
+        alias_values = _collect_aliases(entry, native_pair)
+        parsed[key] = {
             "tick": float(tick),
             "lot": float(lot),
-            "native_pair": _native_pair_identifier(entry, instrument),
+            "native_pair": _native_pair_identifier(entry, native_pair),
+            "aliases": [alias for alias in alias_values if _normalize_instrument(alias) != key],
         }
-    return parsed
+        aliases.setdefault(key, key)
+        for alias in alias_values:
+            alias_key = _normalize_instrument(alias)
+            if alias_key and alias_key not in aliases:
+                aliases[alias_key] = key
+    return parsed, aliases
 
 
 async def _fetch_asset_pairs() -> Dict[str, Any]:
@@ -502,6 +609,7 @@ async def _fetch_asset_pairs() -> Dict[str, Any]:
 class MarketMetadataCache:
     def __init__(self, refresh_interval: float) -> None:
         self._data: MarketMetadataDict = {}
+        self._aliases: Dict[str, str] = {}
         self._lock = asyncio.Lock()
         self._refresh_interval = max(refresh_interval, 0.0)
         self._task: Optional[asyncio.Task[None]] = None
@@ -525,18 +633,22 @@ class MarketMetadataCache:
         payload = await _fetch_asset_pairs()
         if not payload:
             return
-        parsed = _parse_asset_pairs(payload)
+        parsed, aliases = _parse_asset_pairs(payload)
         if not parsed:
             return
         async with self._lock:
             self._data = parsed
+            self._aliases = aliases
         global MARKET_METADATA
         MARKET_METADATA = {symbol: dict(values) for symbol, values in parsed.items()}
 
     async def get(self, instrument: str) -> Optional[MetadataEntry]:
         key = _normalize_instrument(instrument)
         async with self._lock:
-            entry = self._data.get(key)
+            lookup_key = self._aliases.get(key, key)
+            entry = self._data.get(lookup_key)
+            if entry is None and key in self._data:
+                entry = self._data.get(key)
             return dict(entry) if entry else None
 
     async def snapshot(self) -> MarketMetadataDict:

--- a/services/risk/position_sizer.py
+++ b/services/risk/position_sizer.py
@@ -413,13 +413,16 @@ class PositionSizer:
 
     def _resolve_lot_size(self, symbol: str) -> float:
         metadata = precision_provider.require(symbol)
+        native_pair = metadata.get("native_pair")
         lot_size = metadata.get("lot")
         try:
             value = float(lot_size) if lot_size is not None else 0.0
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive casting
-            raise PrecisionMetadataUnavailable(f"Invalid lot size for {symbol}") from exc
+            pair = native_pair or symbol
+            raise PrecisionMetadataUnavailable(f"Invalid lot size for {pair}") from exc
         if value <= 0:
-            raise PrecisionMetadataUnavailable(f"Invalid lot size for {symbol}")
+            pair = native_pair or symbol
+            raise PrecisionMetadataUnavailable(f"Invalid lot size for {pair}")
         return value
 
     def _finalize_result(

--- a/shared/graceful_shutdown.py
+++ b/shared/graceful_shutdown.py
@@ -115,6 +115,14 @@ class GracefulShutdownManager:
                 callback()
         return started
 
+    def reset(self) -> None:
+        """Reset draining state. Primarily used for tests where the app restarts."""
+
+        with self._condition:
+            self._draining = False
+            self._inflight = 0
+            self._drain_started_at = None
+
     def wait_for_inflight(self, timeout: Optional[float] = None) -> bool:
         deadline = None if timeout is None else time.monotonic() + max(timeout, 0.0)
         with self._condition:
@@ -241,6 +249,7 @@ def setup_graceful_shutdown(
 
     @app.on_event("startup")
     async def _on_startup() -> None:
+        manager.reset()
         install_sigterm_handler(manager)
 
     @app.on_event("shutdown")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,20 +421,56 @@ if _class_validators is not None:
 
 
 def _precision_fixture_payload() -> Dict[str, Dict[str, str]]:
-    def _entry(base: str, tick: float, lot: float) -> Dict[str, str]:
-        return {
-            "wsname": f"{base}/USD",
-            "tick_size": str(tick),
-            "lot_step": str(lot),
-        }
-
     return {
-        "BTCUSD": _entry("BTC", 0.1, 0.0001),
-        "ETHUSD": _entry("ETH", 0.05, 0.001),
-        "SOLUSD": _entry("SOL", 0.01, 0.1),
-        "USDTUSD": _entry("USDT", 0.001, 1.0),
-        "ADAUSD": _entry("ADA", 0.0001, 0.1),
-        "TSTUSD": _entry("TST", 1e-08, 1e-08),
+        "XXBTZUSD": {
+            "wsname": "XBT/USD",
+            "base": "XXBT",
+            "quote": "ZUSD",
+            "tick_size": "0.1",
+            "lot_step": "0.0001",
+        },
+        "XXBTZEUR": {
+            "wsname": "XBT/EUR",
+            "base": "XXBT",
+            "quote": "ZEUR",
+            "tick_size": "0.5",
+            "lot_step": "0.0005",
+        },
+        "XETHZUSD": {
+            "wsname": "ETH/USD",
+            "base": "XETH",
+            "quote": "ZUSD",
+            "tick_size": "0.05",
+            "lot_step": "0.001",
+        },
+        "SOLUSD": {
+            "wsname": "SOL/USD",
+            "base": "SOL",
+            "quote": "ZUSD",
+            "tick_size": "0.01",
+            "lot_step": "0.1",
+        },
+        "USDTZUSD": {
+            "wsname": "USDT/USD",
+            "base": "USDT",
+            "quote": "ZUSD",
+            "tick_size": "0.001",
+            "lot_step": "1.0",
+        },
+        "ADAUSD": {
+            "wsname": "ADA/USD",
+            "base": "ADA",
+            "quote": "ZUSD",
+            "tick_size": "0.0001",
+            "lot_step": "0.1",
+        },
+        "TSTUSD": {
+            "wsname": "TST/USD",
+            "base": "TST",
+            "quote": "USD",
+            "tick_size": str(1e-08),
+            "lot_step": str(1e-08),
+        },
     }
 
 

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -14,9 +14,25 @@ def _payload(tick: float, lot: float) -> dict[str, dict[str, str]]:
     return {
         "ADAUSD": {
             "wsname": "ADA/USD",
+            "base": "ADA",
+            "quote": "ZUSD",
             "tick_size": str(tick),
             "lot_step": str(lot),
-        }
+        },
+        "XXBTZEUR": {
+            "wsname": "XBT/EUR",
+            "base": "XXBT",
+            "quote": "ZEUR",
+            "tick_size": "0.1",
+            "lot_step": "0.0001",
+        },
+        "USDTUSD": {
+            "wsname": "USDT/USD",
+            "base": "USDT",
+            "quote": "ZUSD",
+            "tick_size": "0.0001",
+            "lot_step": "1",
+        },
     }
 
 
@@ -32,6 +48,7 @@ def test_precision_provider_refreshes_metadata() -> None:
     first = provider.require("ADA-USD")
     assert first["tick"] == pytest.approx(0.0001)
     assert first["lot"] == pytest.approx(0.1)
+    assert first["native_pair"] == "ADA/USD"
 
     payload_ref["data"] = _payload(0.001, 5.0)
     provider.refresh(force=True)
@@ -39,6 +56,22 @@ def test_precision_provider_refreshes_metadata() -> None:
     updated = provider.require("ADA-USD")
     assert updated["tick"] == pytest.approx(0.001)
     assert updated["lot"] == pytest.approx(5.0)
+    assert updated["native_pair"] == "ADA/USD"
+
+
+def test_precision_provider_resolves_non_usd_pairs() -> None:
+    provider = PrecisionMetadataProvider(fetcher=lambda: _payload(0.001, 1.0), refresh_interval=0.0)
+    provider.refresh(force=True)
+
+    eur_precision = provider.require("BTC-EUR")
+    assert eur_precision["tick"] == pytest.approx(0.1)
+    assert eur_precision["lot"] == pytest.approx(0.0001)
+    assert eur_precision["native_pair"] == "XBT/EUR"
+
+    usdt_precision = provider.require("USDT-USD")
+    assert usdt_precision["tick"] == pytest.approx(0.0001)
+    assert usdt_precision["lot"] == pytest.approx(1.0)
+    assert usdt_precision["native_pair"] == "USDT/USD"
 
 
 def test_precision_provider_missing_symbol_raises() -> None:

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -333,12 +333,20 @@ def test_policy_resolves_precision_for_ada_pair() -> None:
     precision = policy_service._resolve_precision("ADA-USD")
     assert precision["tick"] == pytest.approx(0.0001)
     assert precision["lot"] == pytest.approx(0.1)
+    assert precision["native_pair"] == "ADA/USD"
 
     snapped_price = policy_service._snap(0.256789, precision["tick"])
     snapped_qty = policy_service._snap(12.3456, precision["lot"])
 
     assert snapped_price == pytest.approx(0.2568)
     assert snapped_qty == pytest.approx(12.3)
+
+
+def test_policy_resolves_precision_for_eur_pair() -> None:
+    precision = policy_service._resolve_precision("BTC-EUR")
+    assert precision["tick"] == pytest.approx(0.5)
+    assert precision["lot"] == pytest.approx(0.0005)
+    assert precision["native_pair"] == "XBT/EUR"
 
 
 def test_policy_decide_rejects_when_slippage_erodes_edge(


### PR DESCRIPTION
## Summary
- extend the shared precision metadata cache to retain Kraken native pair identifiers, build alias maps for non-USD quotes, and expose the native pair to callers
- teach the OMS market metadata cache and hedging precision adapter to resolve client instruments through the new alias mapping while preserving native tick/lot data
- reset the shutdown manager between FastAPI startups, update downstream services to surface native pairs, and seed/cover EUR and USDT fixtures in tests

## Testing
- PYTHONPATH=. pytest tests/services/common/test_precision_provider.py
- PYTHONPATH=. pytest tests/test_policy_service_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f2600aa88321a2e042c2a8a3586b