### PR TITLE
Fix KafkaFillReplayer deserialize placement

### DIFF
--- a/services/oms/warm_start.py
+++ b/services/oms/warm_start.py
@@ -186,15 +186,6 @@ class KafkaFillReplayer:
 
         return offsets
 
-
-def _coerce_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):  # pragma: no cover - defensive
-        return None
-
     @staticmethod
     def _deserialize(payload: bytes | str | Dict[str, Any] | None) -> Dict[str, Any] | None:
         if payload is None:
@@ -211,6 +202,15 @@ def _coerce_int(value: Any) -> Optional[int]:
                 return json.loads(payload)
             except Exception:  # pragma: no cover - defensive
                 return None
+        return None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
         return None
 
 


### PR DESCRIPTION
## Summary
- move the `_deserialize` helper onto `KafkaFillReplayer` so the class can use it in the replay lambda
- keep `_coerce_int` as a standalone helper for offset parsing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f4fabf14832196cf3599c30f8456