### PR TITLE
Support non-USD Kraken precision metadata

### DIFF
--- a/policy_service.py
+++ b/policy_service.py
@@ -312,10 +312,20 @@ def _reset_regime_state() -> None:
 
 
 def _resolve_precision(symbol: str) -> Dict[str, float]:
-    try:
-        return precision_provider.require(symbol)
-    except PrecisionMetadataUnavailable as exc:
+    native = precision_provider.resolve_native(symbol)
+    if not native:
         logger.error("Precision metadata unavailable for instrument %s", symbol)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Precision metadata unavailable",
+        )
+    try:
+        return precision_provider.require_native(native)
+    except PrecisionMetadataUnavailable as exc:
+        logger.error(
+            "Precision metadata unavailable for native instrument %s", native,
+            extra={"requested_symbol": symbol},
+        )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Precision metadata unavailable",

--- a/services/common/precision.py
+++ b/services/common/precision.py
@@ -34,7 +34,10 @@ class PrecisionMetadataProvider:
         self._timeout = max(float(timeout), 0.0)
         self._time_source = time_source
         self._lock = threading.Lock()
+        # Cache keyed by Kraken native pair identifier (e.g. "ETH/USDT").
         self._cache: Dict[str, Dict[str, float]] = {}
+        # Mapping of normalized client symbols to cached native identifiers.
+        self._aliases: Dict[str, str] = {}
         self._last_refresh: float = 0.0
 
     # ------------------------------------------------------------------
@@ -43,12 +46,12 @@ class PrecisionMetadataProvider:
     def get(self, symbol: str) -> Optional[Dict[str, float]]:
         """Return precision metadata for ``symbol`` if available."""
 
-        normalized = _normalize_symbol(symbol)
-        if not normalized:
-            return None
         self._maybe_refresh()
         with self._lock:
-            entry = self._cache.get(normalized)
+            native = self._resolve_native_locked(symbol)
+            if not native:
+                return None
+            entry = self._cache.get(native)
             return dict(entry) if entry else None
 
     def require(self, symbol: str) -> Dict[str, float]:
@@ -57,6 +60,34 @@ class PrecisionMetadataProvider:
         metadata = self.get(symbol)
         if metadata is None:
             raise PrecisionMetadataUnavailable(f"Precision metadata unavailable for {symbol}")
+        return metadata
+
+    def resolve_native(self, symbol: str) -> Optional[str]:
+        """Resolve a client-facing symbol to the cached native pair identifier."""
+
+        self._maybe_refresh()
+        with self._lock:
+            return self._resolve_native_locked(symbol)
+
+    def get_native(self, native_symbol: str) -> Optional[Dict[str, float]]:
+        """Return precision metadata for a native Kraken pair identifier."""
+
+        key = (native_symbol or "").strip().upper()
+        if not key:
+            return None
+        self._maybe_refresh()
+        with self._lock:
+            entry = self._cache.get(key)
+        return dict(entry) if entry else None
+
+    def require_native(self, native_symbol: str) -> Dict[str, float]:
+        """Return precision metadata for a native Kraken pair identifier or raise."""
+
+        metadata = self.get_native(native_symbol)
+        if metadata is None:
+            raise PrecisionMetadataUnavailable(
+                f"Precision metadata unavailable for native pair {native_symbol}"
+            )
         return metadata
 
     def refresh(self, *, force: bool = False) -> None:
@@ -70,13 +101,14 @@ class PrecisionMetadataProvider:
             logger.warning("Failed to fetch Kraken precision metadata: %s", exc)
             return
 
-        parsed = _parse_asset_pairs(payload)
+        parsed, aliases = _parse_asset_pairs(payload)
         if not parsed:
             logger.warning("Received empty Kraken precision metadata payload")
             return
 
         with self._lock:
             self._cache = parsed
+            self._aliases = aliases
             self._last_refresh = self._time_source()
 
     # ------------------------------------------------------------------
@@ -91,6 +123,23 @@ class PrecisionMetadataProvider:
     def _maybe_refresh(self) -> None:
         if self._needs_refresh():
             self.refresh(force=True)
+
+    def _resolve_native_locked(self, symbol: str) -> Optional[str]:
+        normalized = _normalize_symbol(symbol)
+        if not normalized:
+            return None
+        native = self._aliases.get(normalized)
+        if native:
+            return native
+
+        direct = (symbol or "").strip().upper()
+        if direct and direct in self._cache:
+            return direct
+
+        fallback = normalized.replace("-", "/")
+        if fallback in self._cache:
+            return fallback
+        return None
 
     def _default_fetcher(self) -> Mapping[str, Any]:
         url = "https://api.kraken.com/0/public/AssetPairs"
@@ -140,28 +189,38 @@ def _normalize_asset(symbol: str, *, is_quote: bool) -> str:
     return aliases.get(trimmed, trimmed)
 
 
-def _normalize_instrument(entry: Mapping[str, Any]) -> str:
-    wsname = entry.get("wsname")
-    if isinstance(wsname, str) and "/" in wsname:
-        base_part, quote_part = wsname.split("/", 1)
-        base = _normalize_asset(base_part, is_quote=False)
-        quote = _normalize_asset(quote_part, is_quote=True)
-        if base and quote == "USD":
-            return f"{base}-USD"
-
-    altname = entry.get("altname")
-    if isinstance(altname, str):
-        cleaned = altname.replace("/", "").upper()
-        if cleaned.endswith("USD") and len(cleaned) > 3:
-            base = _normalize_asset(cleaned[:-3], is_quote=False)
-            if base:
-                return f"{base}-USD"
-
+def _normalize_instrument(entry: Mapping[str, Any]) -> Optional[tuple[str, str, str]]:
     base = _normalize_asset(str(entry.get("base") or ""), is_quote=False)
     quote = _normalize_asset(str(entry.get("quote") or ""), is_quote=True)
-    if base and quote == "USD":
-        return f"{base}-USD"
-    return ""
+
+    native: Optional[str] = None
+
+    wsname = entry.get("wsname")
+    if isinstance(wsname, str):
+        candidate = wsname.strip().upper()
+        if candidate:
+            native = candidate
+            if "/" in candidate:
+                base_part, quote_part = candidate.split("/", 1)
+                parsed_base = _normalize_asset(base_part, is_quote=False)
+                parsed_quote = _normalize_asset(quote_part, is_quote=True)
+                base = parsed_base or base
+                quote = parsed_quote or quote
+
+    if native is None:
+        altname = entry.get("altname")
+        if isinstance(altname, str):
+            candidate = altname.strip().upper()
+            if candidate:
+                native = candidate
+
+    if native is None and base and quote:
+        native = f"{base}/{quote}"
+
+    if not native or not base or not quote:
+        return None
+
+    return native, base, quote
 
 
 def _step_from_metadata(
@@ -194,17 +253,21 @@ def _step_from_metadata(
     return None
 
 
-def _parse_asset_pairs(payload: Mapping[str, Any]) -> Dict[str, Dict[str, float]]:
+def _parse_asset_pairs(
+    payload: Mapping[str, Any]
+) -> tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
     if isinstance(payload.get("result"), Mapping):
         payload = payload["result"]  # type: ignore[assignment]
 
     parsed: Dict[str, Dict[str, float]] = {}
+    aliases: Dict[str, str] = {}
     for entry in payload.values():
         if not isinstance(entry, Mapping):
             continue
-        instrument = _normalize_instrument(entry)
-        if not instrument:
+        normalized = _normalize_instrument(entry)
+        if not normalized:
             continue
+        native, base, quote = normalized
         tick = _step_from_metadata(
             entry,
             ("tick_size", "price_increment"),
@@ -217,8 +280,31 @@ def _parse_asset_pairs(payload: Mapping[str, Any]) -> Dict[str, Dict[str, float]
         )
         if tick is None or lot is None:
             continue
-        parsed[instrument] = {"tick": float(tick), "lot": float(lot)}
-    return parsed
+        native_key = native.strip().upper()
+        parsed[native_key] = {"tick": float(tick), "lot": float(lot)}
+
+        alias_candidates = {
+            native_key,
+            native_key.replace("/", "-"),
+            f"{base}-{quote}",
+            f"{base}/{quote}",
+            f"{base}{quote}",
+        }
+
+        wsname = entry.get("wsname")
+        if isinstance(wsname, str):
+            alias_candidates.add(wsname.strip().upper())
+
+        altname = entry.get("altname")
+        if isinstance(altname, str):
+            alias_candidates.add(altname.strip().upper())
+
+        for candidate in alias_candidates:
+            normalized_alias = _normalize_symbol(candidate)
+            if normalized_alias:
+                aliases.setdefault(normalized_alias, native_key)
+
+    return parsed, aliases
 
 
 precision_provider = PrecisionMetadataProvider()

--- a/services/risk/position_sizer.py
+++ b/services/risk/position_sizer.py
@@ -412,14 +412,17 @@ class PositionSizer:
         return None
 
     def _resolve_lot_size(self, symbol: str) -> float:
-        metadata = precision_provider.require(symbol)
+        native = precision_provider.resolve_native(symbol)
+        if not native:
+            raise PrecisionMetadataUnavailable(f"Precision metadata unavailable for {symbol}")
+        metadata = precision_provider.require_native(native)
         lot_size = metadata.get("lot")
         try:
             value = float(lot_size) if lot_size is not None else 0.0
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive casting
-            raise PrecisionMetadataUnavailable(f"Invalid lot size for {symbol}") from exc
+            raise PrecisionMetadataUnavailable(f"Invalid lot size for {native}") from exc
         if value <= 0:
-            raise PrecisionMetadataUnavailable(f"Invalid lot size for {symbol}")
+            raise PrecisionMetadataUnavailable(f"Invalid lot size for {native}")
         return value
 
     def _finalize_result(

--- a/shared/graceful_shutdown.py
+++ b/shared/graceful_shutdown.py
@@ -115,6 +115,13 @@ class GracefulShutdownManager:
                 callback()
         return started
 
+    def reset(self) -> None:
+        """Clear draining state to allow the service to accept requests again."""
+
+        with self._condition:
+            self._draining = False
+            self._drain_started_at = None
+
     def wait_for_inflight(self, timeout: Optional[float] = None) -> bool:
         deadline = None if timeout is None else time.monotonic() + max(timeout, 0.0)
         with self._condition:
@@ -241,6 +248,7 @@ def setup_graceful_shutdown(
 
     @app.on_event("startup")
     async def _on_startup() -> None:
+        manager.reset()
         install_sigterm_handler(manager)
 
     @app.on_event("shutdown")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,20 +421,49 @@ if _class_validators is not None:
 
 
 def _precision_fixture_payload() -> Dict[str, Dict[str, str]]:
-    def _entry(base: str, tick: float, lot: float) -> Dict[str, str]:
+    def _entry(
+        base: str,
+        quote: str,
+        tick: float,
+        lot: float,
+        *,
+        alt: str | None = None,
+        base_field: str | None = None,
+        quote_field: str | None = None,
+    ) -> Dict[str, str]:
         return {
-            "wsname": f"{base}/USD",
+            "wsname": f"{base}/{quote}",
+            "altname": alt or f"{base}{quote}",
+            "base": base_field or base,
+            "quote": quote_field or quote,
             "tick_size": str(tick),
             "lot_step": str(lot),
         }
 
     return {
-        "BTCUSD": _entry("BTC", 0.1, 0.0001),
-        "ETHUSD": _entry("ETH", 0.05, 0.001),
-        "SOLUSD": _entry("SOL", 0.01, 0.1),
-        "USDTUSD": _entry("USDT", 0.001, 1.0),
-        "ADAUSD": _entry("ADA", 0.0001, 0.1),
-        "TSTUSD": _entry("TST", 1e-08, 1e-08),
+        "BTCUSD": _entry("BTC", "USD", 0.1, 0.0001, base_field="XXBT", quote_field="ZUSD"),
+        "ETHUSD": _entry("ETH", "USD", 0.05, 0.001, base_field="XETH", quote_field="ZUSD"),
+        "SOLUSD": _entry("SOL", "USD", 0.01, 0.1),
+        "USDTUSD": _entry("USDT", "USD", 0.001, 1.0),
+        "ADAUSD": _entry("ADA", "USD", 0.0001, 0.1),
+        "TSTUSD": _entry("TST", "USD", 1e-08, 1e-08),
+        "ETHUSDT": _entry(
+            "ETH",
+            "USDT",
+            0.01,
+            0.001,
+            alt="ETHUSDT",
+            base_field="XETH",
+            quote_field="USDT",
+        ),
+        "ADAEUR": _entry(
+            "ADA",
+            "EUR",
+            0.0001,
+            0.1,
+            alt="ADAEUR",
+            quote_field="ZEUR",
+        ),
     }
 
 

--- a/tests/risk/test_position_sizer_precision.py
+++ b/tests/risk/test_position_sizer_precision.py
@@ -41,18 +41,18 @@ def test_position_sizer_quantizes_using_precision() -> None:
     )
 
     result = sizer.suggest_max_position(
-        "ADA-USD",
+        "ETH-USDT",
         nav=2000.0,
         available_balance=2000.0,
         volatility=0.25,
         expected_edge_bps=50.0,
         fee_bps_estimate=1.0,
-        price=0.25973,
+        price=1875.12,
         regime="trend",
     )
 
     assert result.reason == "sized"
-    multiple = result.size_units / 0.1
+    multiple = result.size_units / 0.001
     assert multiple == pytest.approx(round(multiple), abs=1e-9)
     assert result.size_units > 0
 

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -14,6 +14,9 @@ def _payload(tick: float, lot: float) -> dict[str, dict[str, str]]:
     return {
         "ADAUSD": {
             "wsname": "ADA/USD",
+            "altname": "ADAUSD",
+            "base": "ADA",
+            "quote": "ZUSD",
             "tick_size": str(tick),
             "lot_step": str(lot),
         }
@@ -39,6 +42,43 @@ def test_precision_provider_refreshes_metadata() -> None:
     updated = provider.require("ADA-USD")
     assert updated["tick"] == pytest.approx(0.001)
     assert updated["lot"] == pytest.approx(5.0)
+
+
+def test_precision_provider_handles_non_usd_pairs() -> None:
+    payload = {
+        "ETHUSDT": {
+            "wsname": "ETH/USDT",
+            "altname": "ETHUSDT",
+            "base": "XETH",
+            "quote": "USDT",
+            "tick_size": "0.01",
+            "lot_step": "0.001",
+        },
+        "ADAEUR": {
+            "wsname": "ADA/EUR",
+            "altname": "ADAEUR",
+            "base": "ADA",
+            "quote": "ZEUR",
+            "tick_size": "0.0001",
+            "lot_step": "0.1",
+        },
+    }
+
+    provider = PrecisionMetadataProvider(fetcher=lambda: payload, refresh_interval=0.0)
+    provider.refresh(force=True)
+
+    native = provider.resolve_native("ETH-USDT")
+    assert native == "ETH/USDT"
+
+    metadata = provider.require_native(native)
+    assert metadata["tick"] == pytest.approx(0.01)
+    assert metadata["lot"] == pytest.approx(0.001)
+
+    ada_native = provider.resolve_native("ADA-EUR")
+    assert ada_native == "ADA/EUR"
+    ada_metadata = provider.require("ADA-EUR")
+    assert ada_metadata["tick"] == pytest.approx(0.0001)
+    assert ada_metadata["lot"] == pytest.approx(0.1)
 
 
 def test_precision_provider_missing_symbol_raises() -> None:

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -341,6 +341,11 @@ def test_policy_resolves_precision_for_ada_pair() -> None:
     assert snapped_qty == pytest.approx(12.3)
 
 
+def test_policy_resolves_precision_for_usdt_pair() -> None:
+    precision = policy_service._resolve_precision("ETH-USDT")
+    assert precision["tick"] == pytest.approx(0.01)
+    assert precision["lot"] == pytest.approx(0.001)
+
 def test_policy_decide_rejects_when_slippage_erodes_edge(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:


### PR DESCRIPTION
## Summary
- keep the precision cache keyed by Kraken native pair identifiers and build aliases for client symbols
- have the policy service and position sizer resolve native pairs before requiring precision metadata
- reset the graceful shutdown manager on startup and extend fixtures/tests to cover USDT/EUR-quoted pairs

## Testing
- PYTHONPATH=. pytest tests/services/common/test_precision_provider.py tests/risk/test_position_sizer_precision.py tests/test_policy_service_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f3db3a9483219bb7e82e6b5de331