### PR TITLE
Refactor precision metadata provider to async

### DIFF
--- a/risk_service.py
+++ b/risk_service.py
@@ -830,7 +830,7 @@ async def get_position_size(
     )
 
     try:
-        result = sizer.suggest_max_position(
+        result = await sizer.suggest_max_position(
             symbol,
             nav=nav_value,
             available_balance=available_balance,
@@ -1063,7 +1063,7 @@ async def _evaluate(context: RiskEvaluationContext) -> RiskValidationResponse:
         nav_value = float(state.net_asset_value)
         exposure = float(state.notional_exposure or 0.0)
         available_balance = max(nav_value - exposure, 0.0)
-        sizing_result = sizer.suggest_max_position(
+        sizing_result = await sizer.suggest_max_position(
             normalized_instrument,
             nav=nav_value,
             available_balance=available_balance,

--- a/services/risk/position_sizer.py
+++ b/services/risk/position_sizer.py
@@ -96,7 +96,7 @@ class PositionSizer:
         self._log_callback = log_callback
         self._sizing_config: PositionSizingConfig | None = None
 
-    def suggest_max_position(
+    async def suggest_max_position(
         self,
         symbol: str,
         *,
@@ -173,7 +173,7 @@ class PositionSizer:
             base_size_usd = min(base_size_usd, notional_cap)
 
         try:
-            lot_size = self._resolve_lot_size(symbol)
+            lot_size = await self._resolve_lot_size(symbol)
         except PrecisionMetadataUnavailable:
             diagnostics["precision_metadata_missing"] = True
             reason = "precision_metadata_missing"
@@ -411,8 +411,8 @@ class PositionSizer:
             return max(maker, taker, 0.0)
         return None
 
-    def _resolve_lot_size(self, symbol: str) -> float:
-        metadata = precision_provider.require(symbol)
+    async def _resolve_lot_size(self, symbol: str) -> float:
+        metadata = await precision_provider.require(symbol)
         lot_size = metadata.get("lot")
         try:
             value = float(lot_size) if lot_size is not None else 0.0

--- a/tests/helpers/risk.py
+++ b/tests/helpers/risk.py
@@ -72,6 +72,11 @@ def risk_service_instance(
 
     db_path = tmp_path / db_filename
     _configure_test_engine(monkeypatch, db_path)
+    monkeypatch.setattr(
+        "shared.graceful_shutdown.install_sigterm_handler",
+        lambda manager: None,
+        raising=False,
+    )
     sys.modules.pop("risk_service", None)
     module = importlib.import_module("risk_service")
     try:

--- a/tests/integration/test_trading_pipeline.py
+++ b/tests/integration/test_trading_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import sys
 import types
@@ -124,6 +125,8 @@ def test_trading_pipeline_emits_fill_event(
         record_oms_submit_ack=lambda *args, **kwargs: None,
         record_scaling_state=lambda *args, **kwargs: None,
         observe_scaling_evaluation=lambda *args, **kwargs: None,
+        observe_risk_validation_latency=lambda *args, **kwargs: None,
+        traced_span=lambda *args, **kwargs: contextlib.nullcontext(),
         get_request_id=lambda: None,
     )
     sys.modules["metrics"] = metrics_stub
@@ -211,7 +214,7 @@ def test_trading_pipeline_emits_fill_event(
         ) -> None:
             if shadow:
                 return
-            precision = policy_module._resolve_precision(request.instrument)
+            precision = await policy_module._resolve_precision(request.instrument)
             snapped_price = policy_module._snap(request.price, precision["tick"])
             snapped_qty = policy_module._snap(request.quantity, precision["lot"])
             order_type = "limit" if response.selected_action.lower() == "maker" else "market"

--- a/tests/risk/test_position_sizer_precision.py
+++ b/tests/risk/test_position_sizer_precision.py
@@ -32,7 +32,8 @@ class _StaticFeatures:
         return None
 
 
-def test_position_sizer_quantizes_using_precision() -> None:
+@pytest.mark.asyncio
+async def test_position_sizer_quantizes_using_precision() -> None:
     sizer = PositionSizer(
         "acct-1",
         limits=_Limits(),
@@ -40,7 +41,7 @@ def test_position_sizer_quantizes_using_precision() -> None:
         feature_store=_StaticFeatures(),
     )
 
-    result = sizer.suggest_max_position(
+    result = await sizer.suggest_max_position(
         "ADA-USD",
         nav=2000.0,
         available_balance=2000.0,
@@ -57,11 +58,14 @@ def test_position_sizer_quantizes_using_precision() -> None:
     assert result.size_units > 0
 
 
-def test_position_sizer_halts_when_precision_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_position_sizer_halts_when_precision_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from services.common import precision as precision_module
 
     provider = precision_module.PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
-    provider.refresh(force=True)
+    await provider.refresh(force=True)
 
     monkeypatch.setattr(precision_module, "precision_provider", provider)
     monkeypatch.setattr("services.risk.position_sizer.precision_provider", provider)
@@ -73,7 +77,7 @@ def test_position_sizer_halts_when_precision_missing(monkeypatch: pytest.MonkeyP
         feature_store=_StaticFeatures(),
     )
 
-    result = sizer.suggest_max_position(
+    result = await sizer.suggest_max_position(
         "MISSING-USD",
         nav=1000.0,
         available_balance=1000.0,

--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
+from typing import Any, Dict, Mapping
 
 import pytest
 
@@ -20,33 +22,61 @@ def _payload(tick: float, lot: float) -> dict[str, dict[str, str]]:
     }
 
 
-def test_precision_provider_refreshes_metadata() -> None:
+@pytest.mark.asyncio
+async def test_precision_provider_refreshes_metadata() -> None:
     payload_ref: dict[str, dict[str, dict[str, str]]] = {"data": _payload(0.0001, 0.1)}
 
     def _fetch() -> dict[str, dict[str, str]]:
         return payload_ref["data"]
 
-    provider = PrecisionMetadataProvider(fetcher=_fetch, refresh_interval=0.0)
-    provider.refresh(force=True)
+    provider = PrecisionMetadataProvider(fetcher=_fetch, refresh_interval=60.0)
+    await provider.refresh(force=True)
 
-    first = provider.require("ADA-USD")
+    first = await provider.require("ADA-USD")
     assert first["tick"] == pytest.approx(0.0001)
     assert first["lot"] == pytest.approx(0.1)
 
     payload_ref["data"] = _payload(0.001, 5.0)
-    provider.refresh(force=True)
+    await provider.refresh(force=True)
 
-    updated = provider.require("ADA-USD")
+    updated = await provider.require("ADA-USD")
     assert updated["tick"] == pytest.approx(0.001)
     assert updated["lot"] == pytest.approx(5.0)
 
 
-def test_precision_provider_missing_symbol_raises() -> None:
+@pytest.mark.asyncio
+async def test_precision_provider_missing_symbol_raises() -> None:
     provider = PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
-    provider.refresh(force=True)
+    await provider.refresh(force=True)
 
     with pytest.raises(PrecisionMetadataUnavailable):
-        provider.require("UNKNOWN")
+        await provider.require("UNKNOWN")
+
+
+@pytest.mark.asyncio
+async def test_precision_provider_coalesces_concurrent_refreshes() -> None:
+    payload = _payload(0.01, 0.1)
+    gate = asyncio.Event()
+    call_order: list[str] = []
+
+    async def _fetch() -> Mapping[str, Any]:
+        call_order.append("fetch")
+        await gate.wait()
+        return payload
+
+    provider = PrecisionMetadataProvider(fetcher=_fetch, refresh_interval=60.0)
+
+    async def _require() -> Dict[str, float]:
+        return await provider.require("ADA-USD")
+
+    tasks = [asyncio.create_task(_require()) for _ in range(5)]
+    await asyncio.sleep(0)
+    gate.set()
+    results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=1.0)
+
+    assert len(call_order) == 1
+    assert all(result["tick"] == pytest.approx(0.01) for result in results)
+    assert all(result["lot"] == pytest.approx(0.1) for result in results)
 
 
 def test_precision_module_import_and_instantiation() -> None:


### PR DESCRIPTION
## Summary
- migrate `PrecisionMetadataProvider` to an async-first implementation with an async HTTP client and shared refresh coordination
- update policy and risk sizing paths to await precision metadata and adjust related fixtures and helpers
- convert precision-related tests to async and add a concurrency regression test to ensure cache refreshes are coalesced

## Testing
- `PYTHONPATH=. pytest tests/services/common/test_precision_provider.py tests/risk/test_position_sizer_precision.py tests/test_policy_service_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0f3db6b2083219214cfa1ab9873b3