### PR TITLE
Normalize precision provider cache lookups

### DIFF
--- a/tests/services/common/test_precision_provider.py
+++ b/tests/services/common/test_precision_provider.py
@@ -157,6 +157,21 @@ async def test_precision_provider_coalesces_concurrent_refreshes() -> None:
     assert all(result["lot"] == pytest.approx(0.1) for result in results)
 
 
+@pytest.mark.asyncio
+async def test_precision_provider_get_normalizes_symbols() -> None:
+    provider = PrecisionMetadataProvider(fetcher=lambda: {}, refresh_interval=0.0)
+
+    provider._cache = {  # type: ignore[attr-defined]
+        "ADA-USD": {"tick": 0.1, "lot": 1.0, "native_pair": "ADA/USD"}
+    }
+    provider._aliases = {"ADAUSD": "ADA-USD"}  # type: ignore[attr-defined]
+    provider._refresh_interval = float("inf")  # type: ignore[attr-defined]
+    provider._last_refresh = provider._time_source()  # type: ignore[attr-defined]
+
+    result = await provider.get("adausd")
+
+    assert result == {"tick": 0.1, "lot": 1.0, "native_pair": "ADA/USD"}
+
 
 def test_precision_module_import_and_instantiation() -> None:
     module = importlib.import_module("services.common.precision")


### PR DESCRIPTION
## Summary
- normalize symbols before cache lookups in `PrecisionMetadataProvider.get`
- persist parsed aliases when refreshing precision metadata
- add a regression test covering normalized precision lookups

## Testing
- PYTHONPATH=. pytest tests/services/common/test_precision_provider.py -k get_normalizes_symbols -vv

------
https://chatgpt.com/codex/tasks/task_e_68e0f8f597f0832182578bef0564d6c4