### PR TITLE
Persist cost throttler state in Timescale repository

### DIFF
--- a/cost_throttler.py
+++ b/cost_throttler.py
@@ -9,17 +9,29 @@ from __future__ import annotations
 
 import logging
 import os
-import threading
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from typing import Dict, Optional, Tuple
+from typing import Callable, ClassVar, Mapping, Optional, Tuple
 
 from cost_efficiency import CostEfficiencyMetrics, get_cost_metrics
 
 logger = logging.getLogger(__name__)
 
+try:  # pragma: no cover - SQLAlchemy is optional in some environments
+    from sqlalchemy import Boolean, Column, DateTime, Float, Integer, MetaData, String, Table, create_engine, select
+    from sqlalchemy.orm import Session, sessionmaker
+
+    SQLALCHEMY_AVAILABLE = True
+except Exception:  # pragma: no cover - fall back gracefully when SQLAlchemy missing
+    SQLALCHEMY_AVAILABLE = False
+    Boolean = Column = DateTime = Float = Integer = MetaData = String = Table = object  # type: ignore[assignment]
+    Session = sessionmaker = object  # type: ignore[assignment]
+    select = create_engine = None  # type: ignore[assignment]
+
 __all__ = [
     "CostThrottler",
+    "ThrottleHistoryEntry",
+    "ThrottleRepository",
     "ThrottleStatus",
     "throttle_log",
     "get_throttle_log",
@@ -36,8 +48,11 @@ def _env_ratio_threshold() -> float:
 
 
 DEFAULT_RATIO_THRESHOLD = _env_ratio_threshold()
-_THROTTLE_LOG: list[dict[str, object]] = []
-_LOG_LOCK = threading.Lock()
+
+
+def _ensure_sqlalchemy_available() -> None:
+    if not SQLALCHEMY_AVAILABLE:
+        raise RuntimeError("sqlalchemy is required for persistent cost throttling state")
 
 
 @dataclass(frozen=True)
@@ -53,34 +68,317 @@ class ThrottleStatus:
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+@dataclass(frozen=True)
+class ThrottleHistoryEntry:
+    """Immutable representation of a throttle history record."""
+
+    account_id: str
+    active: bool
+    reason: Optional[str]
+    action: Optional[str]
+    cost_ratio: Optional[float]
+    infra_cost: Optional[float]
+    recent_pnl: Optional[float]
+    recorded_at: datetime
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a serialisable view of the history record."""
+
+        return {
+            "account_id": self.account_id,
+            "active": self.active,
+            "reason": self.reason,
+            "action": self.action,
+            "cost_ratio": self.cost_ratio,
+            "infra_cost": self.infra_cost,
+            "recent_pnl": self.recent_pnl,
+            "recorded_at": self.recorded_at,
+            # ``ts`` maintained for backwards compatibility with legacy tests/tools.
+            "ts": self.recorded_at,
+        }
+
+
+class ThrottleRepository:
+    """Persistence layer for throttle status and audit history."""
+
+    _STATUS_TABLE_NAME: ClassVar[str] = "cost_throttle_status"
+    _HISTORY_TABLE_NAME: ClassVar[str] = "cost_throttle_history"
+    _metadata: ClassVar[MetaData | None] = None
+    _status_table: ClassVar[Table | None] = None
+    _history_table: ClassVar[Table | None] = None
+
+    def __init__(
+        self,
+        session_factory: Callable[[], Session] | sessionmaker | None = None,
+    ) -> None:
+        _ensure_sqlalchemy_available()
+
+        if session_factory is None:
+            session_factory = self._default_session_factory()
+
+        if isinstance(session_factory, sessionmaker):
+            factory_callable: Callable[[], Session] = session_factory  # type: ignore[assignment]
+        else:
+            factory_callable = session_factory  # type: ignore[assignment]
+
+        probe_session = factory_callable()
+        try:
+            bind = getattr(probe_session, "get_bind", lambda: None)()
+            if bind is None:
+                raise RuntimeError(
+                    "session_factory must provide sessions bound to an engine",
+                )
+            engine = getattr(bind, "engine", bind)
+        finally:
+            close = getattr(probe_session, "close", None)
+            if callable(close):
+                close()
+
+        self._session_factory = factory_callable
+        self._engine = engine
+        self._ensure_schema()
+
+    @staticmethod
+    def _default_session_factory() -> sessionmaker:
+        database_url = os.getenv("COST_THROTTLE_DATABASE_URL")
+        if not database_url:
+            raise RuntimeError(
+                "COST_THROTTLE_DATABASE_URL must be configured to persist throttle state",
+            )
+        engine = create_engine(database_url, future=True)
+        return sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    @classmethod
+    def _define_tables(cls) -> tuple[Table, Table]:
+        if cls._metadata is None:
+            cls._metadata = MetaData()
+            cls._status_table = Table(
+                cls._STATUS_TABLE_NAME,
+                cls._metadata,
+                Column("account_id", String, primary_key=True),
+                Column("active", Boolean, nullable=False),
+                Column("reason", String, nullable=True),
+                Column("action", String, nullable=True),
+                Column("cost_ratio", Float, nullable=True),
+                Column("infra_cost", Float, nullable=True),
+                Column("recent_pnl", Float, nullable=True),
+                Column("updated_at", DateTime(timezone=True), nullable=False),
+            )
+            cls._history_table = Table(
+                cls._HISTORY_TABLE_NAME,
+                cls._metadata,
+                Column("id", Integer, primary_key=True, autoincrement=True),
+                Column("account_id", String, nullable=False, index=True),
+                Column("active", Boolean, nullable=False),
+                Column("reason", String, nullable=True),
+                Column("action", String, nullable=True),
+                Column("cost_ratio", Float, nullable=True),
+                Column("infra_cost", Float, nullable=True),
+                Column("recent_pnl", Float, nullable=True),
+                Column("recorded_at", DateTime(timezone=True), nullable=False),
+            )
+        assert cls._status_table is not None
+        assert cls._history_table is not None
+        return cls._status_table, cls._history_table
+
+    def _ensure_schema(self) -> None:
+        status_table, history_table = self._define_tables()
+        assert self._engine is not None
+        with self._engine.begin() as connection:
+            metadata = status_table.metadata
+            assert metadata is not None
+            metadata.create_all(connection, tables=[status_table, history_table])
+
+    @property
+    def session_factory(self) -> Callable[[], Session]:
+        return self._session_factory
+
+    @staticmethod
+    def _normalize_datetime(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def _row_to_status(self, row: Mapping[str, object]) -> ThrottleStatus:
+        return ThrottleStatus(
+            active=bool(row["active"]),
+            reason=row.get("reason"),
+            action=row.get("action"),
+            cost_ratio=row.get("cost_ratio"),
+            infra_cost=row.get("infra_cost"),
+            recent_pnl=row.get("recent_pnl"),
+            updated_at=self._normalize_datetime(row["updated_at"]),
+        )
+
+    def get_status(self, account_id: str) -> Optional[ThrottleStatus]:
+        status_table, _ = self._define_tables()
+        with self._session_factory() as session:
+            row = session.execute(
+                select(status_table).where(status_table.c.account_id == account_id).limit(1)
+            ).mappings().first()
+        if row is None:
+            return None
+        return self._row_to_status(row)
+
+    def persist_evaluation(self, account_id: str, status: ThrottleStatus) -> Optional[ThrottleStatus]:
+        status_table, history_table = self._define_tables()
+        history_reason = status.reason or ("throttle_cleared" if not status.active else None)
+        recorded_at = self._normalize_datetime(status.updated_at)
+        status_payload = {
+            "account_id": account_id,
+            "active": status.active,
+            "reason": status.reason,
+            "action": status.action,
+            "cost_ratio": status.cost_ratio,
+            "infra_cost": status.infra_cost,
+            "recent_pnl": status.recent_pnl,
+            "updated_at": recorded_at,
+        }
+        history_payload = {
+            "account_id": account_id,
+            "active": status.active,
+            "reason": history_reason,
+            "action": status.action,
+            "cost_ratio": status.cost_ratio,
+            "infra_cost": status.infra_cost,
+            "recent_pnl": status.recent_pnl,
+            "recorded_at": recorded_at,
+        }
+
+        with self._session_factory() as session:
+            with session.begin():
+                previous_row = session.execute(
+                    select(status_table).where(status_table.c.account_id == account_id).limit(1)
+                ).mappings().first()
+                if previous_row is None:
+                    session.execute(status_table.insert().values(**status_payload))
+                else:
+                    session.execute(
+                        status_table.update()
+                        .where(status_table.c.account_id == account_id)
+                        .values(**status_payload)
+                    )
+                session.execute(history_table.insert().values(**history_payload))
+
+            if previous_row is None:
+                return None
+            return self._row_to_status(previous_row)
+
+    def history(self, account_id: Optional[str] = None) -> list[ThrottleHistoryEntry]:
+        _, history_table = self._define_tables()
+        stmt = select(history_table).order_by(history_table.c.recorded_at.asc(), history_table.c.id.asc())
+        if account_id is not None:
+            stmt = stmt.where(history_table.c.account_id == account_id)
+        with self._session_factory() as session:
+            rows = session.execute(stmt).mappings().all()
+        return [
+            ThrottleHistoryEntry(
+                account_id=row["account_id"],
+                active=bool(row["active"]),
+                reason=row.get("reason"),
+                action=row.get("action"),
+                cost_ratio=row.get("cost_ratio"),
+                infra_cost=row.get("infra_cost"),
+                recent_pnl=row.get("recent_pnl"),
+                recorded_at=self._normalize_datetime(row["recorded_at"]),
+            )
+            for row in rows
+        ]
+
+    def record_manual_entry(self, account_id: str, *, reason: str, recorded_at: datetime) -> None:
+        _, history_table = self._define_tables()
+        normalized = self._normalize_datetime(recorded_at)
+        with self._session_factory() as session:
+            with session.begin():
+                session.execute(
+                    history_table.insert().values(
+                        account_id=account_id,
+                        active=reason != "throttle_cleared",
+                        reason=reason,
+                        action=None,
+                        cost_ratio=None,
+                        infra_cost=None,
+                        recent_pnl=None,
+                        recorded_at=normalized,
+                    )
+                )
+
+    def clear(self) -> None:
+        """Remove all status and history records. Intended for tests only."""
+
+        status_table, history_table = self._define_tables()
+        with self._session_factory() as session:
+            with session.begin():
+                session.execute(history_table.delete())
+                session.execute(status_table.delete())
+
+    def clear_account(self, account_id: str) -> None:
+        status_table, history_table = self._define_tables()
+        with self._session_factory() as session:
+            with session.begin():
+                session.execute(history_table.delete().where(history_table.c.account_id == account_id))
+                session.execute(status_table.delete().where(status_table.c.account_id == account_id))
+
+    def clear_history(self) -> None:
+        _, history_table = self._define_tables()
+        with self._session_factory() as session:
+            with session.begin():
+                session.execute(history_table.delete())
+
+
+_DEFAULT_REPOSITORY: ThrottleRepository | None = None
+
+
+def _get_repository() -> ThrottleRepository:
+    global _DEFAULT_REPOSITORY
+    if _DEFAULT_REPOSITORY is None:
+        _DEFAULT_REPOSITORY = ThrottleRepository()
+    return _DEFAULT_REPOSITORY
+
+
+def _set_repository(repository: ThrottleRepository) -> None:
+    global _DEFAULT_REPOSITORY
+    _DEFAULT_REPOSITORY = repository
+
+
 def throttle_log(account_id: str, reason: str, ts: datetime) -> None:
     """Persist throttle actions for auditability."""
 
-    entry = {"account_id": account_id, "reason": reason, "ts": ts}
-    with _LOG_LOCK:
-        _THROTTLE_LOG.append(entry)
-    logger.info("Throttle action", extra={"event": "cost_throttle", **entry})
+    repository = _get_repository()
+    repository.record_manual_entry(account_id, reason=reason, recorded_at=ts)
+    logger.info(
+        "Manual throttle log entry",
+        extra={"event": "cost_throttle.manual_log", "account_id": account_id, "reason": reason, "ts": ts},
+    )
 
 
 def get_throttle_log() -> list[dict[str, object]]:
-    with _LOG_LOCK:
-        return list(_THROTTLE_LOG)
+    repository = _get_repository()
+    return [entry.as_dict() for entry in repository.history()]
 
 
 def clear_throttle_log() -> None:
-    with _LOG_LOCK:
-        _THROTTLE_LOG.clear()
+    repository = _get_repository()
+    repository.clear_history()
 
 
 class CostThrottler:
     """Simple controller that toggles throttled mode based on cost ratios."""
 
-    def __init__(self, ratio_threshold: Optional[float] = None) -> None:
+    def __init__(
+        self,
+        ratio_threshold: Optional[float] = None,
+        *,
+        repository: Optional[ThrottleRepository] = None,
+    ) -> None:
         if ratio_threshold is None:
             ratio_threshold = DEFAULT_RATIO_THRESHOLD
         self._ratio_threshold = max(float(ratio_threshold), 0.0)
-        self._state: Dict[str, ThrottleStatus] = {}
-        self._lock = threading.Lock()
+        if repository is None:
+            repository = _get_repository()
+        else:
+            _set_repository(repository)
+        self._repository = repository
 
     @staticmethod
     def _extract_metrics(metrics: Optional[CostEfficiencyMetrics]) -> Optional[Tuple[float, float]]:
@@ -111,15 +409,17 @@ class CostThrottler:
             return "reduce_inference_refresh"
         return "throttle_retraining"
 
-    def _update_state(self, account_id: str, status: ThrottleStatus) -> ThrottleStatus:
-        with self._lock:
-            previous = self._state.get(account_id)
-            self._state[account_id] = status
-
-        if previous is None or previous.active != status.active or previous.reason != status.reason:
-            reason = status.reason if status.active else "throttle_cleared"
-            throttle_log(account_id, reason or "throttle_cleared", status.updated_at)
-        return status
+    @staticmethod
+    def _status_as_dict(status: ThrottleStatus) -> dict[str, object]:
+        return {
+            "active": status.active,
+            "reason": status.reason,
+            "action": status.action,
+            "cost_ratio": status.cost_ratio,
+            "infra_cost": status.infra_cost,
+            "recent_pnl": status.recent_pnl,
+            "updated_at": status.updated_at,
+        }
 
     def evaluate(self, account_id: str) -> ThrottleStatus:
         metrics = self._extract_metrics(get_cost_metrics(account_id))
@@ -160,19 +460,27 @@ class CostThrottler:
                 updated_at=now,
             )
 
-        return self._update_state(account_id, status)
+        previous = self._repository.persist_evaluation(account_id, status)
+        log_payload = {
+            "event": "cost_throttle.evaluate",
+            "account_id": account_id,
+            "status": self._status_as_dict(status),
+        }
+        if previous is not None:
+            log_payload["previous_status"] = self._status_as_dict(previous)
+        logger.info("Cost throttle evaluation", extra=log_payload)
+        return status
 
     def get_status(self, account_id: str) -> ThrottleStatus:
-        with self._lock:
-            status = self._state.get(account_id)
+        status = self._repository.get_status(account_id)
         if status is None:
             return ThrottleStatus(active=False)
         return replace(status)
 
     def clear(self, account_id: Optional[str] = None) -> None:
-        with self._lock:
-            if account_id is None:
-                self._state.clear()
-            else:
-                self._state.pop(account_id, None)
+        repository = self._repository
+        if account_id is None:
+            repository.clear()
+        else:
+            repository.clear_account(account_id)
 

--- a/tests/risk/test_cost_throttler.py
+++ b/tests/risk/test_cost_throttler.py
@@ -1,21 +1,35 @@
 from datetime import datetime, timezone
 
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine  # type: ignore[import-untyped]
+from sqlalchemy.orm import sessionmaker  # type: ignore[import-untyped]
+
 from cost_efficiency import (
     CostEfficiencyMetrics,
     clear_cost_metrics,
     set_cost_metrics,
 )
-from cost_throttler import (
-    CostThrottler,
-    clear_throttle_log,
-    get_throttle_log,
-)
+from cost_throttler import CostThrottler, ThrottleRepository, get_throttle_log
 
 
-def test_cost_throttler_transitions_between_states() -> None:
-    throttler = CostThrottler(ratio_threshold=0.5)
+@pytest.fixture()
+def throttle_repository(tmp_path):
+    database_path = tmp_path / "cost-throttle.db"
+    engine = create_engine(f"sqlite:///{database_path}", future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+    repository = ThrottleRepository(session_factory)
+    repository.clear()
+    yield repository
+    repository.clear()
+    engine.dispose()
+
+
+def test_cost_throttler_transitions_between_states(throttle_repository: ThrottleRepository) -> None:
+    throttler = CostThrottler(ratio_threshold=0.5, repository=throttle_repository)
     clear_cost_metrics()
-    clear_throttle_log()
 
     set_cost_metrics(
         "acct-1",
@@ -28,11 +42,14 @@ def test_cost_throttler_transitions_between_states() -> None:
     status = throttler.evaluate("acct-1")
 
     assert status.active is True
-    assert status.action == "throttle_retraining" or status.action == "reduce_inference_refresh"
-    assert throttler.get_status("acct-1").active is True
+    assert status.action in {"throttle_retraining", "reduce_inference_refresh"}
+    persisted = throttler.get_status("acct-1")
+    assert persisted.active is True
 
-    logs = get_throttle_log()
-    assert any(entry["account_id"] == "acct-1" and entry["reason"] != "throttle_cleared" for entry in logs)
+    history = throttle_repository.history("acct-1")
+    assert len(history) == 1
+    assert history[0].active is True
+    assert history[0].reason and history[0].reason != "throttle_cleared"
 
     set_cost_metrics(
         "acct-1",
@@ -44,8 +61,58 @@ def test_cost_throttler_transitions_between_states() -> None:
     )
     status = throttler.evaluate("acct-1")
     assert status.active is False
-    assert throttler.get_status("acct-1").active is False
+    persisted = throttler.get_status("acct-1")
+    assert persisted.active is False
 
-    logs = get_throttle_log()
-    assert any(entry["account_id"] == "acct-1" and entry["reason"] == "throttle_cleared" for entry in logs)
+    history = throttle_repository.history("acct-1")
+    assert len(history) == 2
+    assert history[-1].active is False
+    assert history[-1].reason == "throttle_cleared"
+
+    logs = [entry for entry in get_throttle_log() if entry["account_id"] == "acct-1"]
+    assert [entry["active"] for entry in logs] == [True, False]
+
+
+def test_cost_throttler_persists_state_across_restart(throttle_repository: ThrottleRepository) -> None:
+    throttler = CostThrottler(ratio_threshold=0.5, repository=throttle_repository)
+    clear_cost_metrics()
+
+    set_cost_metrics(
+        "acct-1",
+        CostEfficiencyMetrics(
+            infra_cost=800.0,
+            recent_pnl=1000.0,
+            observed_at=datetime.now(timezone.utc),
+        ),
+    )
+    throttler.evaluate("acct-1")
+
+    set_cost_metrics(
+        "acct-1",
+        CostEfficiencyMetrics(
+            infra_cost=100.0,
+            recent_pnl=1000.0,
+            observed_at=datetime.now(timezone.utc),
+        ),
+    )
+    throttler.evaluate("acct-1")
+
+    history_before_restart = throttle_repository.history("acct-1")
+    assert [entry.active for entry in history_before_restart] == [True, False]
+
+    restarted_repo = ThrottleRepository(throttle_repository.session_factory)
+    restarted_throttler = CostThrottler(ratio_threshold=0.5, repository=restarted_repo)
+
+    persisted_status = restarted_throttler.get_status("acct-1")
+    assert persisted_status.active is False
+    assert persisted_status.cost_ratio is not None
+
+    # evaluate without metrics should fall back to stored status
+    clear_cost_metrics()
+    resumed_status = restarted_throttler.evaluate("acct-1")
+    assert resumed_status.active is False
+
+    history_after_restart = restarted_repo.history("acct-1")
+    assert [entry.active for entry in history_after_restart] == [True, False]
+    assert history_after_restart[-1].reason == "throttle_cleared"
 


### PR DESCRIPTION
## Summary
- replace the in-memory cost throttler cache and log with a SQL-backed repository that persists state and history
- record structured audit events when evaluating throttles and ensure manual logging flows through the repository
- add regression tests that exercise throttle transitions across a restart using an ephemeral sqlite-backed repository

## Testing
- pytest tests/risk/test_cost_throttler.py

------
https://chatgpt.com/codex/tasks/task_e_68e0fb301e7c832188f87032bb5d049b