### PR TITLE
Secure policy regime endpoint and share session store

### DIFF
--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import os
 import sys
 import types
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Callable, Iterator
 from uuid import uuid4
 
 import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
+
+from auth.service import InMemorySessionStore
 
 if "metrics" not in sys.modules:
     metrics_stub = types.ModuleType("metrics")
@@ -25,6 +30,9 @@ if "metrics" not in sys.modules:
     metrics_stub.get_request_id = lambda: None
     sys.modules["metrics"] = metrics_stub
 
+os.environ.setdefault("SESSION_REDIS_URL", "memory://policy-tests")
+
+import services.common.security as security
 from services.common.schemas import ActionTemplate, ConfidenceMetrics, PolicyDecisionResponse
 
 import policy_service
@@ -49,12 +57,67 @@ class DataclassIntent:
     reason: str | None = None
 
 
+@pytest.fixture(name="session_store")
+def _session_store() -> Iterator[InMemorySessionStore]:
+    previous_store = getattr(policy_service.app.state, "session_store", None)
+    previous_global = getattr(policy_service, "SESSION_STORE", None)
+    previous_default = getattr(security, "_DEFAULT_SESSION_STORE", None)
+
+    store = InMemorySessionStore()
+    policy_service.app.state.session_store = store
+    policy_service.SESSION_STORE = store
+    security.set_default_session_store(store)
+
+    try:
+        yield store
+    finally:
+        if previous_store is None:
+            policy_service.app.state.session_store = None
+        else:
+            policy_service.app.state.session_store = previous_store
+        policy_service.SESSION_STORE = previous_global
+        security.set_default_session_store(previous_default)
+
+
 @pytest.fixture(name="client")
-def _client() -> TestClient:
-    return TestClient(policy_service.app)
+def _client(
+    session_store: InMemorySessionStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    del session_store  # Fixture ensures session store configured
+    monkeypatch.setattr(
+        "shared.graceful_shutdown.install_sigterm_handler",
+        lambda manager: None,
+    )
+    async def _noop_place_order(*args: object, **kwargs: object) -> dict[str, str]:
+        return {"order_id": "test"}
+
+    monkeypatch.setattr(
+        policy_service.EXCHANGE_ADAPTER,
+        "place_order",
+        _noop_place_order,
+    )
+    with TestClient(policy_service.app) as client:
+        yield client
 
 
-def test_decide_policy_accepts_dataclass_intent(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+@pytest.fixture
+def auth_headers(session_store: InMemorySessionStore) -> Callable[[str], dict[str, str]]:
+    def _build(account: str) -> dict[str, str]:
+        session = session_store.create(account)
+        return {
+            "Authorization": f"Bearer {session.token}",
+            "X-Account-ID": account,
+        }
+
+    return _build
+
+
+def test_decide_policy_accepts_dataclass_intent(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    auth_headers: Callable[[str], dict[str, str]],
+) -> None:
     intent = DataclassIntent(
         edge_bps=20.0,
         confidence=ConfidenceMetrics(
@@ -94,8 +157,9 @@ def test_decide_policy_accepts_dataclass_intent(monkeypatch: pytest.MonkeyPatch,
     monkeypatch.setattr(policy_service, "predict_intent", lambda **_: intent)
     policy_service._ATR_CACHE.clear()
 
+    account_id = "company"
     payload = {
-        "account_id": str(uuid4()),
+        "account_id": account_id,
         "order_id": "unit-test",
         "instrument": "BTC-USD",
         "side": "BUY",
@@ -117,7 +181,7 @@ def test_decide_policy_accepts_dataclass_intent(monkeypatch: pytest.MonkeyPatch,
         },
     }
 
-    response = client.post("/policy/decide", json=payload)
+    response = client.post("/policy/decide", json=payload, headers=auth_headers(account_id))
     assert response.status_code == 200
 
     body = PolicyDecisionResponse.model_validate(response.json())
@@ -137,9 +201,52 @@ def test_metrics_endpoint_exposed_after_import():
     assert response.status_code == 200
 
 
-def test_regime_endpoint_returns_latest_snapshot(client: TestClient) -> None:
+def test_regime_endpoint_returns_latest_snapshot(
+    client: TestClient,
+    auth_headers: Callable[[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    intent = DataclassIntent(
+        edge_bps=18.0,
+        confidence=ConfidenceMetrics(
+            model_confidence=0.7,
+            state_confidence=0.68,
+            execution_confidence=0.66,
+            overall_confidence=0.7,
+        ),
+        take_profit_bps=25.0,
+        stop_loss_bps=12.0,
+        selected_action="maker",
+        action_templates=[
+            ActionTemplate(
+                name="maker",
+                venue_type="maker",
+                edge_bps=18.0,
+                fee_bps=0.0,
+                confidence=0.7,
+            ),
+            ActionTemplate(
+                name="taker",
+                venue_type="taker",
+                edge_bps=16.0,
+                fee_bps=0.0,
+                confidence=0.65,
+            ),
+        ],
+        approved=True,
+    )
+
+    monkeypatch.setattr(policy_service, "predict_intent", lambda **_: intent)
+
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return Decimal("3.0")
+
+    monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
+    account_id = "company"
     base_payload = {
-        "account_id": str(uuid4()),
+        "account_id": account_id,
         "order_id": "regime-test",
         "instrument": "ETH-USD",
         "side": "BUY",
@@ -158,12 +265,106 @@ def test_regime_endpoint_returns_latest_snapshot(client: TestClient) -> None:
             "spread_bps": 1.5,
             "imbalance": 0.05,
         }
-        client.post("/policy/decide", json=payload)
+        client.post("/policy/decide", json=payload, headers=auth_headers(account_id))
+        policy_service.regime_classifier.observe(payload["instrument"], mid_price)
 
-    response = client.get("/policy/regime", params={"symbol": "ETH-USD"})
+    response = client.get(
+        "/policy/regime",
+        params={"symbol": "ETH-USD", "account_id": account_id},
+        headers=auth_headers(account_id),
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["symbol"] == "ETH-USD"
     assert payload["regime"] in {"trend", "range", "high_vol"}
     assert payload["sample_count"] >= 5
+
+
+def test_regime_endpoint_requires_authentication(client: TestClient) -> None:
+    response = client.get("/policy/regime", params={"symbol": "BTC-USD"})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_regime_endpoint_rejects_mismatched_account(
+    client: TestClient,
+    auth_headers: Callable[[str], dict[str, str]],
+) -> None:
+    headers = auth_headers("company")
+    headers["X-Account-ID"] = "intruder"
+
+    response = client.get(
+        "/policy/regime",
+        params={"symbol": "ETH-USD", "account_id": "intruder"},
+        headers=headers,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_regime_endpoint_allows_authenticated_access(
+    client: TestClient,
+    auth_headers: Callable[[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    intent = DataclassIntent(
+        edge_bps=22.0,
+        confidence=ConfidenceMetrics(
+            model_confidence=0.8,
+            state_confidence=0.78,
+            execution_confidence=0.76,
+            overall_confidence=0.8,
+        ),
+        take_profit_bps=28.0,
+        stop_loss_bps=14.0,
+        selected_action="maker",
+        action_templates=[
+            ActionTemplate(
+                name="maker",
+                venue_type="maker",
+                edge_bps=22.0,
+                fee_bps=0.0,
+                confidence=0.8,
+            ),
+            ActionTemplate(
+                name="taker",
+                venue_type="taker",
+                edge_bps=18.0,
+                fee_bps=0.0,
+                confidence=0.72,
+            ),
+        ],
+        approved=True,
+    )
+
+    monkeypatch.setattr(policy_service, "predict_intent", lambda **_: intent)
+
+    async def _fake_fee(
+        account_id: str, symbol: str, liquidity: str, notional: float | Decimal
+    ) -> Decimal:
+        return Decimal("2.5")
+
+    monkeypatch.setattr(policy_service, "_fetch_effective_fee", _fake_fee)
+    account_id = "company"
+    payload = {
+        "account_id": account_id,
+        "order_id": "regime-auth",
+        "instrument": "BTC-USD",
+        "side": "BUY",
+        "quantity": 0.25,
+        "price": 30250.0,
+        "fee": {"currency": "USD", "maker": 2.0, "taker": 4.0},
+        "features": [0.1, 0.2, -0.1],
+        "book_snapshot": {"mid_price": 30250.0, "spread_bps": 1.0, "imbalance": 0.02},
+    }
+
+    client.post("/policy/decide", json=payload, headers=auth_headers(account_id))
+    policy_service.regime_classifier.observe(payload["instrument"], payload["book_snapshot"]["mid_price"])
+
+    response = client.get(
+        "/policy/regime",
+        params={"symbol": "BTC-USD", "account_id": account_id},
+        headers=auth_headers(account_id),
+    )
+
+    assert response.status_code == status.HTTP_200_OK
 


### PR DESCRIPTION
## Summary
- configure the policy service with the shared session store and enforce authenticated account checks on `/policy/regime`
- repair precision metadata parsing to produce alias mappings and normalized assets for downstream lookups
- update policy service tests and related fixtures to exercise authenticated access patterns and cover regime authorization scenarios

## Testing
- `PYTHONPATH=$PWD pytest tests/policy/test_policy_service.py tests/policy/test_policy_service_v2.py tests/integration/test_fee_aware_sizing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68e0f9759dec8321b977a338a7b87fbc