### PR TITLE
Secure orderflow analytics endpoints

### DIFF
--- a/services/analytics/orderflow_service.py
+++ b/services/analytics/orderflow_service.py
@@ -15,15 +15,20 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 import statistics
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from threading import Lock
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query
+
+from auth.service import InMemorySessionStore, RedisSessionStore, SessionStoreProtocol
 
 from services.common.config import get_timescale_session
+from services.common import security
+from services.common.security import require_admin_account
 
 try:  # pragma: no cover - optional dependency during CI
     import psycopg
@@ -439,6 +444,7 @@ async def buy_sell_imbalance(
     *,
     symbol: str = Query(..., description="Market symbol to analyse"),
     window: int = Query(300, ge=1, le=3_600, description="Lookback window in seconds"),
+    _: str = Depends(require_admin_account),
 ) -> Dict[str, Any]:
     snapshot = await _service.snapshot(symbol, window)
     return {
@@ -454,6 +460,7 @@ async def queue_depth(
     *,
     symbol: str = Query(..., description="Market symbol to analyse"),
     window: int = Query(300, ge=1, le=3_600, description="Lookback window in seconds"),
+    _: str = Depends(require_admin_account),
 ) -> Dict[str, Any]:
     snapshot = await _service.snapshot(symbol, window)
     return {
@@ -470,6 +477,7 @@ async def liquidity_holes(
     *,
     symbol: str = Query(..., description="Market symbol to analyse"),
     window: int = Query(300, ge=1, le=3_600, description="Lookback window in seconds"),
+    _: str = Depends(require_admin_account),
 ) -> Dict[str, Any]:
     snapshot = await _service.snapshot(symbol, window)
     return {
@@ -480,7 +488,44 @@ async def liquidity_holes(
     }
 
 
+app = FastAPI(title="Orderflow Analytics Service", version="1.0.0")
+
+
+def _configure_session_store(application: FastAPI) -> SessionStoreProtocol:
+    existing = getattr(application.state, "session_store", None)
+    if isinstance(existing, SessionStoreProtocol):
+        store = existing
+    else:
+        redis_url = os.getenv("SESSION_REDIS_URL")
+        if not redis_url:
+            raise RuntimeError(
+                "SESSION_REDIS_URL is not configured. Provide a shared session store DSN to enable orderflow authentication.",
+            )
+
+        ttl_minutes = int(os.getenv("SESSION_TTL_MINUTES", "60"))
+        if redis_url.startswith("memory://"):
+            store = InMemorySessionStore(ttl_minutes=ttl_minutes)
+        else:
+            try:  # pragma: no cover - optional dependency import for production deployments
+                import redis  # type: ignore[import-not-found]
+            except ImportError as exc:  # pragma: no cover - surfaced when redis package missing at runtime
+                raise RuntimeError("redis package is required when SESSION_REDIS_URL is set") from exc
+
+            client = redis.Redis.from_url(redis_url)
+            store = RedisSessionStore(client, ttl_minutes=ttl_minutes)
+
+        application.state.session_store = store
+
+    security.set_default_session_store(store)
+    return store
+
+
+SESSION_STORE = _configure_session_store(app)
+app.include_router(router)
+
+
 __all__ = [
+    "app",
     "router",
     "OrderflowService",
     "OrderflowMetricsStore",

--- a/tests/services/analytics/test_orderflow_service.py
+++ b/tests/services/analytics/test_orderflow_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise ImportError(f"Unable to load module spec for {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+for module_name, module_path in (
+    ("auth", ROOT / "auth" / "__init__.py"),
+    ("auth.service", ROOT / "auth" / "service.py"),
+    ("services", ROOT / "services" / "__init__.py"),
+    ("services.common", ROOT / "services" / "common" / "__init__.py"),
+    ("services.common.security", ROOT / "services" / "common" / "security.py"),
+    ("services.common.config", ROOT / "services" / "common" / "config.py"),
+    ("services.analytics", ROOT / "services" / "analytics" / "__init__.py"),
+):
+    if module_name not in sys.modules:
+        _load_module(module_name, module_path)
+
+
+@pytest.fixture
+def orderflow_module(monkeypatch: pytest.MonkeyPatch):
+    module_name = "services.analytics.orderflow_service"
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://")
+    monkeypatch.setenv("SESSION_TTL_MINUTES", "5")
+    sys.modules.pop(module_name, None)
+    module = _load_module(module_name, ROOT / "services" / "analytics" / "orderflow_service.py")
+    yield module
+    module.app.dependency_overrides.clear()
+    module.security.set_default_session_store(None)
+    sys.modules.pop(module_name, None)
+
+
+@pytest.fixture
+def orderflow_client(orderflow_module) -> Iterator[Tuple[TestClient, object]]:
+    with TestClient(orderflow_module.app) as client:
+        yield client, orderflow_module
+
+
+def test_orderflow_endpoints_require_auth(orderflow_client) -> None:
+    client, _ = orderflow_client
+
+    response = client.get("/orderflow/imbalance", params={"symbol": "BTC-USD"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Authorization header."
+
+
+def test_orderflow_rejects_non_admin_sessions(orderflow_client) -> None:
+    client, module = orderflow_client
+    session = module.SESSION_STORE.create("viewer")
+
+    response = client.get(
+        "/orderflow/queue",
+        params={"symbol": "BTC-USD"},
+        headers={"Authorization": f"Bearer {session.token}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Account is not authorized for administrative access."
+
+
+def test_orderflow_metrics_available_to_admins(orderflow_client) -> None:
+    client, module = orderflow_client
+    session = module.SESSION_STORE.create("company")
+
+    response = client.get(
+        "/orderflow/liquidity_holes",
+        params={"symbol": "ETH-USD", "window": 600},
+        headers={"Authorization": f"Bearer {session.token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["symbol"] == "ETH-USD"
+    assert "liquidity_holes" in payload
+    assert "impact_estimates" in payload
+


### PR DESCRIPTION
## Summary
- protect the orderflow analytics endpoints with the shared admin authentication dependency
- configure the orderflow FastAPI app to attach the shared session store so bearer tokens can be validated
- add endpoint tests that cover unauthenticated, unauthorized, and admin access paths

## Testing
- pytest tests/services/analytics/test_orderflow_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e0fbfe6a90832189c861d47eaad09b