### PR TITLE
Persist cost efficiency metrics in shared store

### DIFF
--- a/cost_efficiency.py
+++ b/cost_efficiency.py
@@ -1,4 +1,3 @@
-
 """Lightweight helpers exposing infrastructure cost efficiency telemetry.
 
 This module intentionally keeps the interface extremely small so that other
@@ -6,21 +5,82 @@ services can stub the data source during tests.  The :mod:`cost_throttler`
 module depends on :func:`get_cost_metrics` to decide whether operational costs
 are out of line with the recent profitability for an account.
 
-The helpers here can easily be swapped out for a real implementation that
-queries a data warehouse or metrics backend.  For the test environment we keep
-the information entirely in memory and provide convenience setters.
-
+The helpers now persist to the shared Timescale/Postgres repository via
+``services.common.cost_efficiency_store`` while still providing an in-memory
+fallback for unit tests.
 """
 
 from __future__ import annotations
 
 
+import os
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Dict, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+_REPO_ROOT = str(Path(__file__).resolve().parent)
+if _REPO_ROOT in sys.path:
+    sys.path.remove(_REPO_ROOT)
+sys.path.insert(0, _REPO_ROOT)
+
+_loaded_services = sys.modules.get("services")
+if _loaded_services is not None:
+    module_path = getattr(_loaded_services, "__file__", "")
+    if module_path and not module_path.startswith(_REPO_ROOT):
+        sys.modules.pop("services", None)
+
+try:
+    from services.common.cost_efficiency_store import (
+        CostEfficiencyRecord,
+        InMemoryCostEfficiencyStore,
+        configure_cost_efficiency_store,
+        get_cost_efficiency_store,
+    )
+except ModuleNotFoundError:
+    base_path = Path(__file__).resolve().parent
+    services_path = base_path / "services"
+    services_module = sys.modules.get("services")
+    module_file = getattr(services_module, "__file__", None)
+    if services_module is None or module_file is None or not module_file.startswith(str(services_path)):
+        services_spec = importlib.util.spec_from_file_location("services", services_path / "__init__.py")
+        if services_spec is None or services_spec.loader is None:  # pragma: no cover - defensive guard
+            raise
+        services_module = importlib.util.module_from_spec(services_spec)
+        services_module.__path__ = [str(services_path)]
+        sys.modules["services"] = services_module
+        services_spec.loader.exec_module(services_module)
+
+    common_module = sys.modules.get("services.common")
+    if common_module is None:
+        common_spec = importlib.machinery.ModuleSpec(
+            "services.common", loader=None, is_package=True
+        )
+        common_module = importlib.util.module_from_spec(common_spec)
+        common_module.__path__ = [str(services_path / "common")]
+        sys.modules["services.common"] = common_module
+
+    module_path = services_path / "common" / "cost_efficiency_store.py"
+    spec = importlib.util.spec_from_file_location(
+        "services.common.cost_efficiency_store",
+        module_path,
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("services.common.cost_efficiency_store", module)
+    spec.loader.exec_module(module)
+    CostEfficiencyRecord = module.CostEfficiencyRecord  # type: ignore[attr-defined]
+    InMemoryCostEfficiencyStore = module.InMemoryCostEfficiencyStore  # type: ignore[attr-defined]
+    configure_cost_efficiency_store = module.configure_cost_efficiency_store  # type: ignore[attr-defined]
+    get_cost_efficiency_store = module.get_cost_efficiency_store  # type: ignore[attr-defined]
 
 __all__ = [
     "CostEfficiencyMetrics",
+    "CostMetricsSnapshot",
     "get_cost_metrics",
     "set_cost_metrics",
     "clear_cost_metrics",
@@ -36,19 +96,109 @@ class CostEfficiencyMetrics:
     observed_at: Optional[datetime] = None
 
 
-_METRICS: Dict[str, CostEfficiencyMetrics] = {}
+@dataclass(frozen=True)
+class CostMetricsSnapshot:
+    """Envelope returned by :func:`get_cost_metrics` providing metadata."""
+
+    account_id: str
+    metrics: Optional[CostEfficiencyMetrics]
+    retrieved_at: datetime
+    stored_at: Optional[datetime]
+
+    @property
+    def observed_at(self) -> Optional[datetime]:
+        if self.metrics is None:
+            return None
+        return self.metrics.observed_at
+
+    @property
+    def age(self) -> Optional[timedelta]:
+        observed = self.observed_at
+        if observed is None:
+            return None
+        return self.retrieved_at - observed
+
+    def is_stale(self, max_age_seconds: Optional[float] = None) -> bool:
+        metrics = self.metrics
+        if metrics is None:
+            return True
+        age = self.age
+        if age is None:
+            return False
+        if max_age_seconds is None:
+            max_age_seconds = _stale_threshold_seconds()
+        try:
+            max_age = float(max_age_seconds)
+        except (TypeError, ValueError):
+            max_age = 0.0
+        if max_age <= 0:
+            return False
+        return age.total_seconds() > max_age
+
+
+def _stale_threshold_seconds() -> float:
+    value = os.getenv("COST_METRICS_MAX_AGE_SECONDS", "900")
+    try:
+        return max(float(value), 0.0)
+    except (TypeError, ValueError):
+        return 900.0
+
+
+def _ensure_store_initialised() -> None:
+    # When running in isolated unit tests ``configure_cost_efficiency_store``
+    # may not have been invoked.  Ensure a fallback store exists.
+    store = get_cost_efficiency_store()
+    if isinstance(store, InMemoryCostEfficiencyStore):
+        return
+    # The default store is already configured during module import, but a
+    # misbehaving test could have replaced it with ``None``. Guard against it.
+    if store is None:  # pragma: no cover - defensive guard
+        configure_cost_efficiency_store(InMemoryCostEfficiencyStore())
+
+
+def _record_to_metrics(account_id: str, record: Optional[CostEfficiencyRecord]) -> CostMetricsSnapshot:
+    retrieved_at = datetime.now(timezone.utc)
+    if record is None:
+        return CostMetricsSnapshot(
+            account_id=account_id,
+            metrics=None,
+            retrieved_at=retrieved_at,
+            stored_at=None,
+        )
+    metrics = CostEfficiencyMetrics(
+        infra_cost=record.infra_cost,
+        recent_pnl=record.recent_pnl,
+        observed_at=record.observed_at,
+    )
+    return CostMetricsSnapshot(
+        account_id=account_id,
+        metrics=metrics,
+        retrieved_at=retrieved_at,
+        stored_at=record.stored_at,
+    )
 
 
 def set_cost_metrics(account_id: str, metrics: CostEfficiencyMetrics) -> None:
-    """Store ``metrics`` for ``account_id`` in the in-memory registry."""
+    """Persist ``metrics`` for ``account_id`` via the configured repository."""
 
-    _METRICS[account_id] = metrics
+    _ensure_store_initialised()
+    store = get_cost_efficiency_store()
+    observed_at = metrics.observed_at or datetime.now(timezone.utc)
+    store.upsert(
+        account_id,
+        infra_cost=float(metrics.infra_cost),
+        recent_pnl=float(metrics.recent_pnl),
+        observed_at=observed_at,
+    )
 
 
-def get_cost_metrics(account_id: str) -> Optional[CostEfficiencyMetrics]:
+def get_cost_metrics(account_id: str) -> CostMetricsSnapshot:
     """Return the most recent cost efficiency metrics for ``account_id``."""
 
-    return _METRICS.get(account_id)
+    _ensure_store_initialised()
+    store = get_cost_efficiency_store()
+    record = store.fetch(account_id)
+    return _record_to_metrics(account_id, record)
 
 
 def clear_cost_metrics() -> None:
@@ -57,6 +207,7 @@ def clear_cost_metrics() -> None:
     This is primarily useful for tests where isolated state is expected.
     """
 
-    _METRICS.clear()
+    _ensure_store_initialised()
+    get_cost_efficiency_store().clear()
 
 

--- a/cost_throttler.py
+++ b/cost_throttler.py
@@ -122,7 +122,11 @@ class CostThrottler:
         return status
 
     def evaluate(self, account_id: str) -> ThrottleStatus:
-        metrics = self._extract_metrics(get_cost_metrics(account_id))
+        snapshot = get_cost_metrics(account_id)
+        if snapshot.metrics is None or snapshot.is_stale():
+            return self.get_status(account_id)
+
+        metrics = self._extract_metrics(snapshot.metrics)
         if metrics is None:
             return self.get_status(account_id)
 
@@ -133,7 +137,7 @@ class CostThrottler:
         else:
             cost_ratio = infra_cost / pnl_reference
 
-        now = datetime.now(timezone.utc)
+        now = snapshot.retrieved_at
         if cost_ratio >= self._ratio_threshold:
             action = self._determine_action(cost_ratio)
             reason = (

--- a/services/common/cost_efficiency_store.py
+++ b/services/common/cost_efficiency_store.py
@@ -1,0 +1,245 @@
+"""Repository for persisting cost efficiency metrics in Timescale/Postgres.
+
+The repository exposes a very small interface that allows callers to
+upsert and retrieve infrastructure cost metrics keyed by ``account_id``.
+Implementations default to using the shared Timescale/Postgres cluster via
+``psycopg`` but transparently fall back to an in-memory store when the
+driver or connection string are unavailable.  This keeps unit tests fast
+while still exercising the same code paths that production will use.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Optional, Protocol
+
+try:  # pragma: no cover - psycopg may be absent in lightweight test envs
+    import psycopg
+    from psycopg.rows import dict_row
+except Exception:  # pragma: no cover - allow tests to run without psycopg
+    psycopg = None  # type: ignore[assignment]
+    dict_row = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cost_efficiency_metrics (
+    account_id TEXT PRIMARY KEY,
+    infra_cost DOUBLE PRECISION NOT NULL,
+    recent_pnl DOUBLE PRECISION NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    stored_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
+_UPSERT_SQL = """
+INSERT INTO cost_efficiency_metrics (account_id, infra_cost, recent_pnl, observed_at, stored_at)
+VALUES (%(account_id)s, %(infra_cost)s, %(recent_pnl)s, %(observed_at)s, %(stored_at)s)
+ON CONFLICT (account_id) DO UPDATE
+SET infra_cost = EXCLUDED.infra_cost,
+    recent_pnl = EXCLUDED.recent_pnl,
+    observed_at = EXCLUDED.observed_at,
+    stored_at = EXCLUDED.stored_at
+RETURNING account_id, infra_cost, recent_pnl, observed_at, stored_at
+"""
+
+_SELECT_SQL = """
+SELECT account_id, infra_cost, recent_pnl, observed_at, stored_at
+FROM cost_efficiency_metrics
+WHERE account_id = %(account_id)s
+"""
+
+_DELETE_ONE_SQL = "DELETE FROM cost_efficiency_metrics WHERE account_id = %(account_id)s"
+_DELETE_ALL_SQL = "DELETE FROM cost_efficiency_metrics"
+
+
+def _normalize_timestamp(value: datetime) -> datetime:
+    """Ensure ``value`` is timezone aware in UTC."""
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class CostEfficiencyRecord:
+    """Persistent representation of cost efficiency metrics."""
+
+    account_id: str
+    infra_cost: float
+    recent_pnl: float
+    observed_at: datetime
+    stored_at: datetime
+
+
+class CostEfficiencyStore(Protocol):
+    """Protocol describing store behaviours required by the service."""
+
+    def fetch(self, account_id: str) -> Optional[CostEfficiencyRecord]:
+        """Return the latest metrics for ``account_id`` if present."""
+
+    def upsert(
+        self, account_id: str, *, infra_cost: float, recent_pnl: float, observed_at: datetime
+    ) -> CostEfficiencyRecord:
+        """Persist metrics for ``account_id`` returning the stored record."""
+
+    def clear(self, account_id: Optional[str] = None) -> None:
+        """Remove stored metrics either for ``account_id`` or entirely."""
+
+
+class InMemoryCostEfficiencyStore:
+    """Thread-safe in-memory store used for tests and fallbacks."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, CostEfficiencyRecord] = {}
+        self._lock = RLock()
+
+    def fetch(self, account_id: str) -> Optional[CostEfficiencyRecord]:
+        with self._lock:
+            return self._records.get(account_id)
+
+    def upsert(
+        self, account_id: str, *, infra_cost: float, recent_pnl: float, observed_at: datetime
+    ) -> CostEfficiencyRecord:
+        stored_at = datetime.now(timezone.utc)
+        record = CostEfficiencyRecord(
+            account_id=account_id,
+            infra_cost=float(infra_cost),
+            recent_pnl=float(recent_pnl),
+            observed_at=_normalize_timestamp(observed_at),
+            stored_at=stored_at,
+        )
+        with self._lock:
+            self._records[account_id] = record
+        return record
+
+    def clear(self, account_id: Optional[str] = None) -> None:
+        with self._lock:
+            if account_id is None:
+                self._records.clear()
+            else:
+                self._records.pop(account_id, None)
+
+
+class TimescaleCostEfficiencyStore:
+    """Repository backed by the shared Timescale/Postgres cluster."""
+
+    def __init__(self, dsn: Optional[str] = None) -> None:
+        self._dsn = dsn or os.getenv("COST_EFFICIENCY_DSN") or os.getenv("TIMESCALE_DSN")
+        self._fallback = InMemoryCostEfficiencyStore()
+
+    def _driver_available(self) -> bool:
+        return bool(psycopg) and bool(self._dsn)
+
+    def _execute(self, sql: str, params: Optional[dict[str, object]] = None) -> list[dict[str, object]]:
+        if not self._driver_available():
+            return []
+
+        assert psycopg is not None  # Satisfy type checkers
+        try:
+            with psycopg.connect(self._dsn, autocommit=True) as conn:  # type: ignore[arg-type]
+                with conn.cursor(row_factory=dict_row) as cur:  # type: ignore[misc]
+                    cur.execute(_CREATE_TABLE_SQL)
+                    cur.execute(sql, params or {})
+                    if cur.description is None:
+                        return []
+                    return list(cur.fetchall())
+        except Exception:  # pragma: no cover - depends on external service
+            logger.warning("Falling back to in-memory cost efficiency store", exc_info=True)
+            return []
+
+    def fetch(self, account_id: str) -> Optional[CostEfficiencyRecord]:
+        rows = self._execute(_SELECT_SQL, {"account_id": account_id})
+        if rows:
+            row = rows[0]
+            return CostEfficiencyRecord(
+                account_id=str(row["account_id"]),
+                infra_cost=float(row["infra_cost"]),
+                recent_pnl=float(row["recent_pnl"]),
+                observed_at=_normalize_timestamp(row["observed_at"]),
+                stored_at=_normalize_timestamp(row["stored_at"]),
+            )
+        # fall back to in-memory record
+        return self._fallback.fetch(account_id)
+
+    def upsert(
+        self, account_id: str, *, infra_cost: float, recent_pnl: float, observed_at: datetime
+    ) -> CostEfficiencyRecord:
+        stored_at = datetime.now(timezone.utc)
+        params = {
+            "account_id": account_id,
+            "infra_cost": float(infra_cost),
+            "recent_pnl": float(recent_pnl),
+            "observed_at": _normalize_timestamp(observed_at),
+            "stored_at": stored_at,
+        }
+        rows = self._execute(_UPSERT_SQL, params)
+        if rows:
+            row = rows[0]
+            record = CostEfficiencyRecord(
+                account_id=str(row["account_id"]),
+                infra_cost=float(row["infra_cost"]),
+                recent_pnl=float(row["recent_pnl"]),
+                observed_at=_normalize_timestamp(row["observed_at"]),
+                stored_at=_normalize_timestamp(row["stored_at"]),
+            )
+        else:
+            record = self._fallback.upsert(
+                account_id,
+                infra_cost=float(infra_cost),
+                recent_pnl=float(recent_pnl),
+                observed_at=_normalize_timestamp(observed_at),
+            )
+        # Keep fallback updated so reads succeed if the DB becomes unavailable
+        self._fallback.upsert(
+            account_id,
+            infra_cost=record.infra_cost,
+            recent_pnl=record.recent_pnl,
+            observed_at=record.observed_at,
+        )
+        return CostEfficiencyRecord(
+            account_id=record.account_id,
+            infra_cost=record.infra_cost,
+            recent_pnl=record.recent_pnl,
+            observed_at=record.observed_at,
+            stored_at=_normalize_timestamp(record.stored_at),
+        )
+
+    def clear(self, account_id: Optional[str] = None) -> None:
+        if account_id is None:
+            self._execute(_DELETE_ALL_SQL)
+        else:
+            self._execute(_DELETE_ONE_SQL, {"account_id": account_id})
+        self._fallback.clear(account_id)
+
+
+_STORE: CostEfficiencyStore = TimescaleCostEfficiencyStore()
+
+
+def configure_cost_efficiency_store(store: CostEfficiencyStore) -> None:
+    """Override the global store implementation (useful for tests)."""
+
+    global _STORE
+    _STORE = store
+
+
+def get_cost_efficiency_store() -> CostEfficiencyStore:
+    """Return the configured store implementation."""
+
+    return _STORE
+
+
+__all__ = [
+    "CostEfficiencyRecord",
+    "CostEfficiencyStore",
+    "InMemoryCostEfficiencyStore",
+    "TimescaleCostEfficiencyStore",
+    "configure_cost_efficiency_store",
+    "get_cost_efficiency_store",
+]
+

--- a/tests/risk/test_cost_throttler.py
+++ b/tests/risk/test_cost_throttler.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+import os
+from datetime import datetime, timedelta, timezone
 
 from cost_efficiency import (
     CostEfficiencyMetrics,
@@ -48,4 +49,63 @@ def test_cost_throttler_transitions_between_states() -> None:
 
     logs = get_throttle_log()
     assert any(entry["account_id"] == "acct-1" and entry["reason"] == "throttle_cleared" for entry in logs)
+
+
+def test_cost_throttler_ignores_stale_metrics() -> None:
+    throttler = CostThrottler(ratio_threshold=0.5)
+    clear_cost_metrics()
+    clear_throttle_log()
+
+    original_threshold = os.environ.get("COST_METRICS_MAX_AGE_SECONDS")
+    os.environ["COST_METRICS_MAX_AGE_SECONDS"] = "1"
+    try:
+        set_cost_metrics(
+            "acct-2",
+            CostEfficiencyMetrics(
+                infra_cost=700.0,
+                recent_pnl=1000.0,
+                observed_at=datetime.now(timezone.utc),
+            ),
+        )
+        status = throttler.evaluate("acct-2")
+        assert status.active is True
+
+        set_cost_metrics(
+            "acct-2",
+            CostEfficiencyMetrics(
+                infra_cost=100.0,
+                recent_pnl=1000.0,
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+            ),
+        )
+
+        status = throttler.evaluate("acct-2")
+        assert status.active is True
+    finally:
+        if original_threshold is None:
+            os.environ.pop("COST_METRICS_MAX_AGE_SECONDS", None)
+        else:
+            os.environ["COST_METRICS_MAX_AGE_SECONDS"] = original_threshold
+
+
+def test_cost_throttler_survives_restart() -> None:
+    throttler = CostThrottler(ratio_threshold=0.5)
+    clear_cost_metrics()
+    clear_throttle_log()
+
+    set_cost_metrics(
+        "acct-3",
+        CostEfficiencyMetrics(
+            infra_cost=800.0,
+            recent_pnl=1000.0,
+            observed_at=datetime.now(timezone.utc),
+        ),
+    )
+    status = throttler.evaluate("acct-3")
+    assert status.active is True
+
+    # Simulate a process restart by constructing a new throttler without touching the store.
+    restarted = CostThrottler(ratio_threshold=0.5)
+    status_after_restart = restarted.evaluate("acct-3")
+    assert status_after_restart.active is True
 


### PR DESCRIPTION
## Summary
- add a Timescale/Postgres-backed cost efficiency repository with an in-memory fallback
- update the cost_efficiency helper API to return metadata-rich snapshots and clear stale data
- adjust the cost throttler to honour stale metrics and add restart-focused regression tests

## Testing
- pytest tests/risk/test_cost_throttler.py

------
https://chatgpt.com/codex/tasks/task_e_68e0fb31db888321a4a1f4baeaf3d7b0