### PR TITLE
Require managed Timescale DSN for seasonality service

### DIFF
--- a/data/migrations/versions/0007_create_seasonality_metrics_table.py
+++ b/data/migrations/versions/0007_create_seasonality_metrics_table.py
@@ -1,0 +1,31 @@
+"""Create seasonality metrics persistence table."""
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS seasonality_metrics (
+    symbol TEXT NOT NULL,
+    period TEXT NOT NULL,
+    avg_return DOUBLE PRECISION NOT NULL,
+    avg_vol DOUBLE PRECISION NOT NULL,
+    avg_volume DOUBLE PRECISION NOT NULL,
+    ts TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (symbol, period)
+);
+"""
+
+
+def upgrade() -> None:
+    op.execute(CREATE_TABLE)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS seasonality_metrics;")

--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -310,6 +310,62 @@ backendServices:
     pdb:
       enabled: true
       maxUnavailable: 1
+  seasonality:
+    enabled: true
+    nameOverride: seasonality-service
+    image:
+      repository: ghcr.io/aether/seasonality-service
+      tag: latest
+    replicaCount: 2
+    containerPort: 8000
+    env:
+      - name: SEASONALITY_DATABASE_URI
+        valueFrom:
+          secretKeyRef:
+            name: seasonality-service-database
+            key: dsn
+      - name: SEASONALITY_DB_SSLMODE
+        value: require
+      - name: SEASONALITY_DB_POOL_SIZE
+        value: "20"
+      - name: SEASONALITY_DB_MAX_OVERFLOW
+        value: "10"
+      - name: SEASONALITY_DB_POOL_TIMEOUT
+        value: "30"
+      - name: SEASONALITY_DB_POOL_RECYCLE
+        value: "1800"
+    usesKrakenSecrets: false
+    extraVolumeMounts: []
+    extraVolumes: []
+    service:
+      port: 80
+      targetPort: http
+    ingress:
+      enabled: true
+      host: seasonality.aether.example.com
+      tlsSecret: seasonality-service-tls
+      annotations: {}
+    resources:
+      requests:
+        cpu: 150m
+        memory: 384Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 5
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 65
+    pdb:
+      enabled: true
+      maxUnavailable: 1
   oms:
     enabled: true
     nameOverride: oms-service

--- a/tests/smoke/test_seasonality_service_persistence.py
+++ b/tests/smoke/test_seasonality_service_persistence.py
@@ -1,0 +1,154 @@
+"""Smoke tests ensuring the seasonality service persists cached metrics."""
+from __future__ import annotations
+
+import importlib
+from importlib import util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine as _sa_create_engine, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.pool import StaticPool
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+pytest.importorskip("sqlalchemy")
+
+_REAL_CREATE_ENGINE = _sa_create_engine
+_SERVICE_MODULE = "services.analytics.seasonality_service"
+
+
+class _EngineProxy:
+    """Proxy object that mimics a PostgreSQL engine while using SQLite underneath."""
+
+    def __init__(self, inner: Engine) -> None:
+        self._inner = inner
+        self.url = make_url("postgresql+psycopg2://analytics:test@localhost/analytics")
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._inner, item)
+
+    def dispose(self) -> None:  # pragma: no cover - passthrough
+        self._inner.dispose()
+
+
+def _reload_service(monkeypatch: pytest.MonkeyPatch, sqlite_url: str) -> Any:
+    monkeypatch.setenv("SEASONALITY_DATABASE_URI", "postgresql://analytics:test@localhost/analytics")
+
+    def _patched_create_engine(url: str, **kwargs: Any) -> _EngineProxy:  # type: ignore[override]
+        assert url.startswith("postgresql")
+        inner = _REAL_CREATE_ENGINE(
+            sqlite_url,
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        return _EngineProxy(inner)
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _patched_create_engine, raising=False)
+
+    importlib.import_module("services")
+
+    analytics_pkg = "services.analytics"
+    if analytics_pkg not in sys.modules:
+        pkg_spec = util.spec_from_file_location(
+            analytics_pkg, ROOT / "services" / "analytics" / "__init__.py"
+        )
+        if pkg_spec and pkg_spec.loader:
+            package = util.module_from_spec(pkg_spec)
+            sys.modules[analytics_pkg] = package
+            pkg_spec.loader.exec_module(package)
+
+    if _SERVICE_MODULE in sys.modules:
+        del sys.modules[_SERVICE_MODULE]
+
+    spec = util.spec_from_file_location(
+        _SERVICE_MODULE, ROOT / "services" / "analytics" / "seasonality_service.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load seasonality service module for testing")
+
+    module = util.module_from_spec(spec)
+    sys.modules[_SERVICE_MODULE] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_ohlcv(module: Any) -> None:
+    with module.SessionLocal() as session:
+        base_time = datetime.now(timezone.utc) - timedelta(hours=6)
+        close = 30_000.0
+        for offset in range(24):
+            bucket_start = base_time + timedelta(hours=offset)
+            candle = module.OhlcvBar(
+                market="BTC-USD",
+                bucket_start=bucket_start,
+                open=close - 50 + offset,
+                high=close + 75 + offset,
+                low=close - 90,
+                close=close + offset * 20,
+                volume=1_000 + offset * 25,
+            )
+            session.merge(candle)
+        session.commit()
+
+
+@pytest.mark.smoke
+def test_seasonality_metrics_survive_service_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sqlite_path = tmp_path / "seasonality-analytics.db"
+    module = _reload_service(monkeypatch, f"sqlite:///{sqlite_path}")
+    module.OhlcvBase.metadata.create_all(bind=module.ENGINE)
+    module.MetricsBase.metadata.create_all(bind=module.ENGINE)
+    _seed_ohlcv(module)
+
+    with TestClient(module.app) as client:
+        response = client.get(
+            "/seasonality/session_liquidity",
+            params={"symbol": "BTC-USD"},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["symbol"] == "BTC-USD"
+        assert len(payload["metrics"]) == 3
+
+    with module.SessionLocal() as session:
+        stored = session.execute(select(module.SeasonalityMetric)).scalars().all()
+        assert stored
+        cached = {(row.symbol, row.period, round(row.avg_volume, 6)) for row in stored}
+
+    module.ENGINE.dispose()
+    if _SERVICE_MODULE in sys.modules:
+        del sys.modules[_SERVICE_MODULE]
+
+    module_reloaded = _reload_service(monkeypatch, f"sqlite:///{sqlite_path}")
+    module_reloaded.OhlcvBase.metadata.create_all(bind=module_reloaded.ENGINE)
+    module_reloaded.MetricsBase.metadata.create_all(bind=module_reloaded.ENGINE)
+
+    with module_reloaded.SessionLocal() as session:
+        persisted = session.execute(select(module_reloaded.SeasonalityMetric)).scalars().all()
+        assert {(row.symbol, row.period, round(row.avg_volume, 6)) for row in persisted} == cached
+
+    with TestClient(module_reloaded.app) as client:
+        response = client.get("/seasonality/current_session")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["reference_volume"] >= 0
+        assert payload["benchmark_volume"] >= 0
+
+    other_engine = _REAL_CREATE_ENGINE(f"sqlite:///{sqlite_path}", future=True)
+    try:
+        with other_engine.connect() as connection:
+            rows = connection.execute(text("SELECT symbol, period FROM seasonality_metrics"))
+            persisted = [tuple(row) for row in rows]
+        assert persisted
+    finally:
+        other_engine.dispose()


### PR DESCRIPTION
## Summary
- require a managed PostgreSQL/Timescale connection string for the seasonality analytics service and configure SQLAlchemy pooling/SSL options
- add a central Timescale migration for the `seasonality_metrics` table used to persist cached analytics
- pass the managed DSN to the service via Helm values and add a smoke test that verifies cached metrics survive a restart

## Testing
- pytest tests/smoke/test_seasonality_service_persistence.py


------
https://chatgpt.com/codex/tasks/task_e_68e0fd55c1608321bdc9efcd634d4059