### PR TITLE
Add missing os import to orderflow service

### DIFF
--- a/services/analytics/orderflow_service.py
+++ b/services/analytics/orderflow_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import statistics
 from dataclasses import dataclass, asdict


### PR DESCRIPTION
## Summary
- add the os module to the analytics orderflow service imports so os.getenv calls resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1053513908321a2506d7275788cb0