### PR TITLE
Ensure precision metadata retains Decimal granularity

### DIFF
--- a/services/common/precision.py
+++ b/services/common/precision.py
@@ -75,7 +75,7 @@ class PrecisionMetadataProvider:
     # Public API
     # ------------------------------------------------------------------
 
-    async def get(self, symbol: str) -> Optional[Dict[str, float]]:
+    async def get(self, symbol: str) -> Optional[Dict[str, Decimal | str]]:
         """Return precision metadata for ``symbol`` if available."""
 
         normalized = _normalize_symbol(symbol)
@@ -91,7 +91,7 @@ class PrecisionMetadataProvider:
             return dict(entry) if entry else None
 
 
-    async def require(self, symbol: str) -> Dict[str, float]:
+    async def require(self, symbol: str) -> Dict[str, Decimal | str]:
 
         """Return precision metadata for ``symbol`` or raise."""
 
@@ -400,8 +400,8 @@ def _parse_asset_pairs(payload: Mapping[str, Any]) -> Tuple[Dict[str, Dict[str, 
 
         key = _normalize_symbol(native_pair)
         metadata = {
-            "tick": float(tick),
-            "lot": float(lot),
+            "tick": tick,
+            "lot": lot,
             "native_pair": native_pair,
         }
         parsed[key] = metadata

--- a/services/oms/main.py
+++ b/services/oms/main.py
@@ -1103,8 +1103,8 @@ def _extract_trades(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _snap(
-    value: float,
-    step: float,
+    value: float | Decimal,
+    step: float | Decimal,
     *,
     side: str,
     floor_quantity: bool = False,

--- a/tests/services/oms/test_place_order.py
+++ b/tests/services/oms/test_place_order.py
@@ -460,6 +460,11 @@ def test_snap_preserves_tick_multiples_for_non_decimal_steps() -> None:
     assert _snap(0.37, 0.25, side="sell", floor_quantity=True) == pytest.approx(0.25)
 
 
+def test_snap_preserves_satoshi_precision() -> None:
+    snapped = _snap(Decimal("0.123456789"), Decimal("0.00000001"), side="buy")
+    assert Decimal(str(snapped)) == Decimal("0.12345679")
+
+
 def test_place_order_snaps_take_profit_stop_loss_and_trailing(
     account_setup: Tuple[
         AccountContext,

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -338,8 +338,8 @@ def test_policy_decide_preserves_tick_precision(
 @pytest.mark.asyncio
 async def test_policy_resolves_precision_for_ada_pair() -> None:
     precision = await policy_service._resolve_precision("ADA-USD")
-    assert precision["tick"] == pytest.approx(0.0001)
-    assert precision["lot"] == pytest.approx(0.1)
+    assert precision["tick"] == Decimal("0.0001")
+    assert precision["lot"] == Decimal("0.1")
     assert precision["native_pair"] == "ADA/USD"
 
     snapped_price = policy_service._snap(0.256789, precision["tick"])
@@ -347,14 +347,23 @@ async def test_policy_resolves_precision_for_ada_pair() -> None:
 
     assert snapped_price == pytest.approx(0.2568)
     assert snapped_qty == pytest.approx(12.3)
-
-
-
-def test_policy_resolves_precision_for_eur_pair() -> None:
-    precision = policy_service._resolve_precision("BTC-EUR")
-    assert precision["tick"] == pytest.approx(0.5)
-    assert precision["lot"] == pytest.approx(0.0005)
+@pytest.mark.asyncio
+async def test_policy_resolves_precision_for_eur_pair() -> None:
+    precision = await policy_service._resolve_precision("BTC-EUR")
+    assert precision["tick"] == Decimal("0.5")
+    assert precision["lot"] == Decimal("0.0005")
     assert precision["native_pair"] == "XBT/EUR"
+
+
+@pytest.mark.asyncio
+async def test_policy_preserves_sub_satoshi_precision() -> None:
+    precision = await policy_service._resolve_precision("TST-USD")
+
+    assert precision["tick"] == Decimal("0.00000001")
+    assert precision["lot"] == Decimal("0.00000001")
+
+    snapped_qty = policy_service._snap(Decimal("0.123456789"), precision["lot"])
+    assert Decimal(str(snapped_qty)) == Decimal("0.12345679")
 
 
 


### PR DESCRIPTION
## Summary
- keep cached tick and lot precision values as Decimals instead of floats
- update policy and OMS snapping helpers to accept Decimal steps and preserve precision
- extend precision provider, policy, and OMS tests to cover 1e-8 lot-size regressions

## Testing
- pytest tests/services/common/test_precision_provider.py tests/test_policy_service_api.py tests/services/oms/test_place_order.py *(fails: missing optional services.common modules in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e105a7b5748321ac36c0c1b1361d1a