### PR TITLE
Refactor universe service database bootstrap

### DIFF
--- a/tests/unit/services/test_universe_service.py
+++ b/tests/unit/services/test_universe_service.py
@@ -55,6 +55,8 @@ def universe_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
             return vols
         return caps
 
+    monkeypatch.setattr(universe_service, "ENGINE", object())
+    monkeypatch.setattr(universe_service, "SessionLocal", object())
     monkeypatch.setattr(universe_service, "_latest_feature_map", fake_feature_map)
     monkeypatch.setattr(universe_service, "_kraken_volume_24h", lambda session: volumes)
     monkeypatch.setattr(universe_service, "_latest_manual_overrides", lambda session, migrate=False: overrides)

--- a/tests/universe/test_universe_service_startup.py
+++ b/tests/universe/test_universe_service_startup.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
 import importlib
-import importlib
 import sys
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.engine.url import make_url
 
 from services.universe import universe_service
 
 
 pytest.importorskip("sqlalchemy")
-
-if not hasattr(universe_service.ENGINE, "url"):
-    pytest.skip("sqlalchemy runtime support is required for universe service startup tests", allow_module_level=True)
-
 
 def _reload_universe_service():
     module_name = "services.universe.universe_service"
@@ -26,20 +22,52 @@ def _reload_universe_service():
 def test_universe_service_starts_with_default_psycopg2(monkeypatch):
     monkeypatch.delenv("TIMESCALE_DATABASE_URI", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv(
+        "UNIVERSE_DATABASE_URL",
+        "postgresql://timescale:password@localhost:5432/aether",
+    )
+
+    class _DummyEngine:
+        def __init__(self, url: str) -> None:
+            self.url = make_url(url)
+
+    monkeypatch.setattr(
+        "sqlalchemy.create_engine",
+        lambda url, **kwargs: _DummyEngine(url),
+        raising=False,
+    )
 
     universe_service = _reload_universe_service()
+    monkeypatch.setattr(universe_service, "run_migrations", lambda url=None: None)
 
     with TestClient(universe_service.app):
-        assert universe_service.ENGINE.url.drivername == "postgresql+psycopg2"
+        pass
+
+    assert universe_service.ENGINE is not None
+    assert universe_service.ENGINE.url.drivername == "postgresql+psycopg2"
 
 
 def test_universe_service_normalises_postgresql_urls(monkeypatch):
     monkeypatch.delenv("TIMESCALE_DATABASE_URI", raising=False)
     monkeypatch.setenv(
-        "DATABASE_URL",
-        "postgresql://timescale:password@localhost:5432/aether",
+        "UNIVERSE_DATABASE_URL",
+        "postgresql+psycopg://timescale:password@localhost:5432/aether",
+    )
+
+    class _DummyEngine:
+        def __init__(self, url: str) -> None:
+            self.url = make_url(url)
+
+    monkeypatch.setattr(
+        "sqlalchemy.create_engine",
+        lambda url, **kwargs: _DummyEngine(url),
+        raising=False,
     )
 
     universe_service = _reload_universe_service()
+    monkeypatch.setattr(universe_service, "run_migrations", lambda url=None: None)
 
+    universe_service.ensure_database()
+
+    assert universe_service.ENGINE is not None
     assert universe_service.ENGINE.url.drivername == "postgresql+psycopg2"


### PR DESCRIPTION
## Summary
- lazy-load the universe service database engine and session factory via a new `ensure_database` helper so the module imports without environment configuration
- guard migrations and session dependency wiring to use the lazily initialised state and skip when custom factories are injected
- update universe service tests to prime configuration during startup and add a JSONB compilation shim for SQLite-backed smoke tests

## Testing
- `PYTHONPATH=. pytest tests/unit/services/test_universe_service.py`
- `PYTHONPATH=. pytest tests/universe/test_universe_service_startup.py`
- `PYTHONPATH=. pytest tests/smoke/test_universe_service_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68e105b3713483219610bc0bd390a705