### PR TITLE
Fix Decimal import in Kraken reconciliation reports

### DIFF
--- a/services/reports/kraken_reconciliation.py
+++ b/services/reports/kraken_reconciliation.py
@@ -7,12 +7,11 @@ import io
 import json
 import logging
 import threading
-
 import time
-
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_EVEN
 from typing import Any, Callable, Dict, Iterable, Iterator, Mapping, Optional, Protocol, Sequence
 
 try:  # pragma: no cover - optional dependency for tests


### PR DESCRIPTION
## Summary
- add the missing Decimal import and rounding constant to the Kraken reconciliation module

## Testing
- python -m compileall services/reports/kraken_reconciliation.py

------
https://chatgpt.com/codex/tasks/task_e_68e1083be79c8321a145634a76d3de8d