### PR TITLE
Refine latency metrics label cardinality

### DIFF
--- a/docs/slo.md
+++ b/docs/slo.md
@@ -14,19 +14,19 @@ This document defines the quantitative availability and responsiveness expectati
 | Model Canary Promotion | Completion time of canary to production promotion (`model_canary_promotion_duration_minutes`) | ≤ 45 minutes for 95% of promotions in 30-day window | `model_canary_promotion_slow` fires when 3 consecutive promotions exceed 30 minutes |
 
 ## Policy Latency
-- **Measurement**: Prometheus histogram `policy_latency_ms` tagged by `symbol` and `account_id` tracks end-to-end policy evaluation time.
+- **Measurement**: Prometheus histogram `policy_latency_ms` tagged by `symbol_tier` and `account_segment` tracks end-to-end policy evaluation time without exploding series cardinality.
 - **Target**: Keep the rolling 5-minute p95 ≤ 200 ms to prevent backlog in the decisioning pipeline.
 - **Alerting**: `policy_latency_p95_slo_breach` triggers when p95 latency breaches 200 ms for two of the last three evaluations.
 - **Runbooks**: Use [`docs/runbooks/policy_latency.md`](runbooks/policy_latency.md) for triage steps.
 
 ## Risk Latency
-- **Measurement**: Histogram `risk_latency_ms` captures validation latency per order candidate across risk controls.
+- **Measurement**: Histogram `risk_latency_ms` captures validation latency per order candidate, aggregated by `symbol_tier` and `account_segment`.
 - **Target**: Maintain rolling 5-minute p95 ≤ 200 ms to ensure OMS submissions are not blocked.
 - **Alerting**: `risk_latency_p95_slo_breach` fires when p95 latency is above 200 ms for two of the last three intervals.
 - **Runbooks**: Follow [`docs/runbooks/risk_latency.md`](runbooks/risk_latency.md).
 
 ## OMS Latency
-- **Measurement**: Histogram `oms_latency_ms` records submission latency to external venues, keyed by symbol and account.
+- **Measurement**: Histogram `oms_latency_ms` records submission latency to external venues, keyed by `symbol_tier` and `account_segment`.
 - **Target**: Hold the rolling 5-minute p95 ≤ 500 ms to absorb market spikes without missing fills.
 - **Alerting**: `oms_latency_p95_slo_breach` fires when the rolling p95 is above 500 ms for two of the last three evaluations.
 - **Runbooks**: See [`docs/runbooks/oms_latency.md`](runbooks/oms_latency.md) and [`docs/runbooks/kill_switch_activation.md`](runbooks/kill_switch_activation.md) for remediation guidance.

--- a/ops/observability/grafana/latency-overview-dashboard.json
+++ b/ops/observability/grafana/latency-overview-dashboard.json
@@ -61,8 +61,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "policy p50 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.50, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "policy p50 {{symbol_tier}}/{{account_segment}}",
           "refId": "A"
         },
         {
@@ -71,8 +71,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "policy p95 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.95, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "policy p95 {{symbol_tier}}/{{account_segment}}",
           "refId": "B"
         },
         {
@@ -81,8 +81,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "policy p99 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.99, sum(rate(policy_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "policy p99 {{symbol_tier}}/{{account_segment}}",
           "refId": "C"
         }
       ],
@@ -126,8 +126,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "risk p50 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.50, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "risk p50 {{symbol_tier}}/{{account_segment}}",
           "refId": "A"
         },
         {
@@ -136,8 +136,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "risk p95 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.95, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "risk p95 {{symbol_tier}}/{{account_segment}}",
           "refId": "B"
         },
         {
@@ -146,8 +146,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "risk p99 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.99, sum(rate(risk_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "risk p99 {{symbol_tier}}/{{account_segment}}",
           "refId": "C"
         }
       ],
@@ -191,8 +191,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "oms p50 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.50, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "oms p50 {{symbol_tier}}/{{account_segment}}",
           "refId": "A"
         },
         {
@@ -201,8 +201,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "oms p95 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.95, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "oms p95 {{symbol_tier}}/{{account_segment}}",
           "refId": "B"
         },
         {
@@ -211,8 +211,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol, account_id))",
-          "legendFormat": "oms p99 {{symbol}}/{{account_id}}",
+          "expr": "histogram_quantile(0.99, sum(rate(oms_latency_ms_bucket[$__rate_interval])) by (le, symbol_tier, account_segment))",
+          "legendFormat": "oms p99 {{symbol_tier}}/{{account_segment}}",
           "refId": "C"
         }
       ],

--- a/tests/test_latency_metrics.py
+++ b/tests/test_latency_metrics.py
@@ -1,0 +1,65 @@
+import logging
+
+from prometheus_client import CollectorRegistry
+
+from ops.observability.latency_metrics import LatencyMetrics, LatencySnapshot
+
+
+def test_observe_normalises_labels_and_records_latency() -> None:
+    metrics = LatencyMetrics(registry=CollectorRegistry())
+
+    snapshot = metrics.observe(
+        "policy_latency_ms",
+        symbol="BTC",
+        account_id="inst-123",
+        latency_ms=42.0,
+    )
+
+    assert isinstance(snapshot, LatencySnapshot)
+    windows = metrics._windows["policy_latency_ms"]  # noqa: SLF001 - internal assertion
+    assert ("mega_cap", "institutional") in windows
+
+    alert_value = metrics.registry.get_sample_value(
+        "latency_p95_alert",
+        {"metric": "policy_latency_ms", "symbol_tier": "mega_cap", "account_segment": "institutional"},
+    )
+    assert alert_value == 0
+
+
+def test_observe_buckets_new_symbols() -> None:
+    metrics = LatencyMetrics(registry=CollectorRegistry())
+
+    metrics.observe(
+        "policy_latency_ms",
+        symbol="newcoin",
+        account_id="ret-001",
+        latency_ms=10.0,
+    )
+
+    windows = metrics._windows["policy_latency_ms"]  # noqa: SLF001 - internal assertion
+    assert ("long_tail", "retail") in windows
+
+
+def test_observe_discards_disallowed_pairs(caplog) -> None:
+    metrics = LatencyMetrics(
+        registry=CollectorRegistry(),
+        allowed_label_pairs={("mega_cap", "institutional")},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        snapshot = metrics.observe(
+            "policy_latency_ms",
+            symbol="SOL",
+            account_id="ret-777",
+            latency_ms=15.0,
+        )
+
+    assert snapshot == LatencySnapshot(0.0, 0.0, 0.0)
+    assert ("major", "retail") not in metrics._windows["policy_latency_ms"]  # noqa: SLF001
+    assert any("Discarding latency sample" in message for message in caplog.messages)
+
+    discarded = metrics.registry.get_sample_value(
+        "latency_discarded_label_pairs_total",
+        {"metric": "policy_latency_ms", "symbol_tier": "major", "account_segment": "retail"},
+    )
+    assert discarded == 1


### PR DESCRIPTION
## Summary
- replace raw symbol/account labels with bounded symbol tier and account segment buckets in latency metrics and discard unsupported label pairs
- update dashboards and SLO documentation to reference the new bounded latency labels
- add regression tests that cover the label normalisation and rejection paths to prevent cardinality explosions

## Testing
- pytest tests/test_latency_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68e10899d2b08321b48bec0ba3f6bb36