### PR TITLE
Ensure linters fail CI when they fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
           if [ -f pyproject.toml ]; then pip install -e .[test]; fi
       - name: Run linters
         run: |
-          if [ -f pyproject.toml ]; then poe lint || true; fi
-          if [ -f Makefile ]; then make lint || true; fi
+          if [ -f pyproject.toml ] && command -v poe >/dev/null 2>&1; then poe lint; fi
+          if [ -f Makefile ]; then make lint; fi
       - name: Validate OMS NetworkPolicy manifest
         run: |
           pytest tests/test_networkpolicy_oms_manifest.py -q


### PR DESCRIPTION
## Summary
- run `poe lint` and `make lint` in CI without masking their exit codes while keeping file/command checks in place

## Testing
- `bash -c 'set -e; if [ -f Makefile ]; then make lint; else false; fi'`
- `echo $?`


------
https://chatgpt.com/codex/tasks/task_e_68e10ae4cd2c83218f7951b32c69a81f