### PR TITLE
Add asyncpg dependency aligned with Python support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6023,4 +6023,4 @@ test = ["httpx", "pytest", "pytest-asyncio"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "4676449ee3d17aa33b7c5a9bd6ac7dc740cd0012df4b190a275d8db86bd9d18b"
+content-hash = "acae63fce2515151310f5513c990208afbe6d55ab754562d6c56520b9c275be1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlalchemy==2.0.43",
     "psycopg[binary]==3.2.10",
     "psycopg2-binary==2.9.10",
+    "asyncpg==0.30.0",
     "timescale-vector==0.0.7",
     "aiokafka==0.12.0",
     "nats-py==2.11.0",


### PR DESCRIPTION
## Summary
- add asyncpg to the core dependency list with a version compatible with the supported Python releases
- refresh the Poetry lockfile to capture the new dependency metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10adeade08321898b4448638eac5b