### PR TITLE
feat: require managed database for fees service

### DIFF
--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -397,7 +397,18 @@ backendServices:
       tag: latest
     replicaCount: 2
     containerPort: 8000
-    env: []
+    env:
+      - name: FEES_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: fees-service-database
+            key: dsn
+      - name: FEES_DB_SSLMODE
+        valueFrom:
+          secretKeyRef:
+            name: fees-service-database
+            key: sslmode
+            optional: true
     usesKrakenSecrets: true
     extraVolumeMounts: []
     extraVolumes: []

--- a/deploy/k8s/base/aether-services/deployment-fees.yaml
+++ b/deploy/k8s/base/aether-services/deployment-fees.yaml
@@ -43,6 +43,17 @@ spec:
               value: /var/run/secrets/kraken/director-1/credentials.json
             - name: AETHER_DIRECTOR_2_KRAKEN_SECRET_PATH
               value: /var/run/secrets/kraken/director-2/credentials.json
+            - name: FEES_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: fees-service-database
+                  key: dsn
+            - name: FEES_DB_SSLMODE
+              valueFrom:
+                secretKeyRef:
+                  name: fees-service-database
+                  key: sslmode
+                  optional: true
           readinessProbe:
             httpGet:
               path: /metrics

--- a/deploy/k8s/base/secrets/external-secrets.yaml
+++ b/deploy/k8s/base/secrets/external-secrets.yaml
@@ -110,6 +110,30 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: fees-service-database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aether-vault
+    kind: ClusterSecretStore
+  target:
+    name: fees-service-database
+    creationPolicy: Owner
+  data:
+    - secretKey: dsn
+      remoteRef:
+        key: trading/databases/fees-service
+        property: dsn
+    - secretKey: sslmode
+      remoteRef:
+        key: trading/databases/fees-service
+        property: sslmode
+      optional: true
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: fastapi-credentials
 spec:
   refreshInterval: 30m

--- a/tests/fees/__init__.py
+++ b/tests/fees/__init__.py
@@ -1,0 +1,14 @@
+"""Fees service test package configuration."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("FEES_DATABASE_URL", "postgresql://test:test@localhost:5432/fees_test")
+os.environ.pop("TIMESCALE_DSN", None)

--- a/tests/fees/conftest.py
+++ b/tests/fees/conftest.py
@@ -1,0 +1,109 @@
+"""Test configuration for the fees service suite."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from types import ModuleType
+
+_ORIGINAL_FEES_DSN = os.environ.get("FEES_DATABASE_URL")
+_ORIGINAL_TIMESCALE_DSN = os.environ.get("TIMESCALE_DSN")
+
+os.environ["FEES_DATABASE_URL"] = os.environ.get(
+    "FEES_DATABASE_URL", "postgresql://test:test@localhost:5432/fees_test"
+)
+os.environ.pop("TIMESCALE_DSN", None)
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_module(name: str, path: Path, package: bool = False) -> ModuleType:
+    search_locations = [str(path.parent)] if package else None
+    spec = importlib.util.spec_from_file_location(name, path, submodule_search_locations=search_locations)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"Failed to load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    if package:
+        module.__path__ = [str(path.parent)]
+    module.__spec__ = spec
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SERVICES_ROOT = ROOT / "services"
+_load_module("services", SERVICES_ROOT / "__init__.py", package=True)
+_load_module("services.common", SERVICES_ROOT / "common" / "__init__.py", package=True)
+_load_module("services.common.security", SERVICES_ROOT / "common" / "security.py")
+_load_module("services.common.adapters", SERVICES_ROOT / "common" / "adapters.py")
+
+@pytest.fixture(scope="session", autouse=True)
+def fees_test_database(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Provide an isolated SQLite database for the fees test suite."""
+
+    import services.fees.fee_service as fee_service
+
+    db_path = tmp_path_factory.mktemp("fees_service") / "fees.db"
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(
+        url,
+        future=True,
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+
+    fee_service.ENGINE.dispose()
+    fee_service.ENGINE = engine
+    fee_service.SessionLocal = session_factory
+    fee_service.DATABASE_URL = url
+    fee_service.Base.metadata.drop_all(bind=engine)
+    fee_service.Base.metadata.create_all(bind=engine)
+
+    try:
+        yield
+    finally:
+        session_factory.close_all()
+        engine.dispose()
+
+        if _ORIGINAL_FEES_DSN is None:
+            os.environ.pop("FEES_DATABASE_URL", None)
+        else:
+            os.environ["FEES_DATABASE_URL"] = _ORIGINAL_FEES_DSN
+
+        if _ORIGINAL_TIMESCALE_DSN is None:
+            os.environ.pop("TIMESCALE_DSN", None)
+        else:
+            os.environ["TIMESCALE_DSN"] = _ORIGINAL_TIMESCALE_DSN
+
+
+@pytest.fixture
+def fees_main_module() -> ModuleType:
+    """Return the lazily imported fees FastAPI module."""
+
+    return importlib.import_module("services.fees.main")
+
+
+@pytest.fixture
+def fees_app(fees_main_module: ModuleType):
+    return fees_main_module.app
+
+
+@pytest.fixture
+def fee_service_module() -> ModuleType:
+    return importlib.import_module("services.fees.fee_service")

--- a/tests/fees/test_fee_service_security.py
+++ b/tests/fees/test_fee_service_security.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+from typing import Iterator
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from typing import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
 
-from services.fees.main import app
-
 
 @pytest.fixture(name="client")
-def client_fixture() -> Iterator[TestClient]:
-    with TestClient(app) as client:
+def client_fixture(fees_app) -> Iterator[TestClient]:
+    with TestClient(fees_app) as client:
         yield client
 
 

--- a/tests/integration/test_fees_persistence.py
+++ b/tests/integration/test_fees_persistence.py
@@ -1,0 +1,165 @@
+"""Integration tests validating persistence for the fees service."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import List, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit, quote_plus
+
+import pytest
+from sqlalchemy import select
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg is required for fees integration tests")
+
+pytestmark = pytest.mark.integration
+
+_FEES_TEST_DSN = os.getenv("AETHER_FEES_TEST_DSN") or os.getenv("AETHER_TIMESCALE_TEST_DSN")
+if not _FEES_TEST_DSN:
+    pytest.skip(
+        "AETHER_FEES_TEST_DSN or AETHER_TIMESCALE_TEST_DSN must be set for fees integration tests",
+        allow_module_level=True,
+    )
+
+
+def _with_schema(dsn: str, schema: str) -> str:
+    parts = urlsplit(dsn)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["options"] = f"-csearch_path={schema}"
+    new_query = urlencode(query, doseq=True, quote_via=quote_plus)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+
+
+def _load_fees_module(name: str) -> ModuleType:
+    module_path = Path(__file__).resolve().parents[2] / "services" / "fees" / "fee_service.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load fees service module for tests")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+@dataclass
+class FeesModuleFactory:
+    database_url: str
+    loaded: List[Tuple[str, ModuleType]] = field(default_factory=list)
+
+    def load(self, alias: str | None = None) -> ModuleType:
+        name = alias or f"fees_instance_{uuid.uuid4().hex[:8]}"
+        if name in sys.modules:
+            sys.modules.pop(name, None)
+        os.environ["FEES_DATABASE_URL"] = self.database_url
+        os.environ.pop("TIMESCALE_DSN", None)
+        module = _load_fees_module(name)
+        self.loaded.append((name, module))
+        return module
+
+    def unload(self, alias: str) -> None:
+        for index, (name, module) in enumerate(list(self.loaded)):
+            if name != alias:
+                continue
+            session_local = getattr(module, "SessionLocal", None)
+            if session_local is not None and hasattr(session_local, "close_all"):
+                session_local.close_all()
+            engine = getattr(module, "ENGINE", None)
+            if engine is not None:
+                engine.dispose()
+            sys.modules.pop(name, None)
+            self.loaded.pop(index)
+            break
+
+
+@pytest.fixture
+def fees_environment() -> FeesModuleFactory:
+    schema = f"fees_int_{uuid.uuid4().hex[:8]}"
+    database_url = _with_schema(_FEES_TEST_DSN, schema)
+
+    with psycopg.connect(_FEES_TEST_DSN) as conn:  # type: ignore[arg-type]
+        with conn.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+            cursor.execute(f'CREATE SCHEMA "{schema}"')
+        conn.commit()
+
+    factory = FeesModuleFactory(database_url=database_url)
+    original_url = os.environ.get("FEES_DATABASE_URL")
+    original_timescale = os.environ.get("TIMESCALE_DSN")
+
+    try:
+        yield factory
+    finally:
+        for name, module in list(factory.loaded):
+            session_local = getattr(module, "SessionLocal", None)
+            if session_local is not None and hasattr(session_local, "close_all"):
+                session_local.close_all()
+            engine = getattr(module, "ENGINE", None)
+            if engine is not None:
+                engine.dispose()
+            sys.modules.pop(name, None)
+        factory.loaded.clear()
+
+        if original_url is None:
+            os.environ.pop("FEES_DATABASE_URL", None)
+        else:
+            os.environ["FEES_DATABASE_URL"] = original_url
+
+        if original_timescale is None:
+            os.environ.pop("TIMESCALE_DSN", None)
+        else:
+            os.environ["TIMESCALE_DSN"] = original_timescale
+
+        with psycopg.connect(_FEES_TEST_DSN) as conn:  # type: ignore[arg-type]
+            with conn.cursor() as cursor:
+                cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+            conn.commit()
+
+
+def test_fee_volume_persists_across_instances(fees_environment: FeesModuleFactory) -> None:
+    account_id = f"acct-{uuid.uuid4().hex[:8]}"
+
+    primary = fees_environment.load("fees_service_primary")
+    primary._on_startup()  # type: ignore[attr-defined]
+    with primary.SessionLocal() as session:
+        primary.update_account_volume_30d(
+            session,
+            account_id=account_id,
+            fill_notional_usd=12500.0,
+            fill_time=datetime.now(timezone.utc),
+            liquidity="maker",
+            actual_fee_usd=12.5,
+        )
+
+    peer = fees_environment.load("fees_service_peer")
+    peer._on_startup()  # type: ignore[attr-defined]
+    with peer.SessionLocal() as session:
+        record = session.get(peer.AccountVolume30d, account_id)
+        assert record is not None
+        assert float(record.notional_usd_30d) > 0
+
+    fees_environment.unload("fees_service_primary")
+    fees_environment.unload("fees_service_peer")
+
+    restart = fees_environment.load("fees_service_restart")
+    restart._on_startup()  # type: ignore[attr-defined]
+    with restart.SessionLocal() as session:
+        persisted = session.get(restart.AccountVolume30d, account_id)
+        assert persisted is not None
+        assert float(persisted.notional_usd_30d) > 0
+
+        fills = session.execute(
+            select(restart.AccountFill).where(restart.AccountFill.account_id == account_id)
+        ).scalars().all()
+        assert fills, "Expected fills to persist across service restarts"
+
+    fees_environment.unload("fees_service_restart")


### PR DESCRIPTION
## Summary
- require a managed PostgreSQL/Timescale DSN for the fees service and configure SQLAlchemy pooling/SSL defaults
- surface the shared credentials through the Helm values and Kubernetes manifests for the fees deployment
- add a persistence integration test plus pytest fixtures so the fees unit suite runs against an isolated SQLite database

## Testing
- pytest tests/fees -q *(fails: attribute adjustments still required for RedisFeastAdapter monkeypatches)*

------
https://chatgpt.com/codex/tasks/task_e_68e1098477ec83218b6cb213f2209c5f