### PR TITLE
Defer seasonality session store configuration to startup

### DIFF
--- a/services/analytics/seasonality_service.py
+++ b/services/analytics/seasonality_service.py
@@ -427,7 +427,15 @@ def _configure_session_store(application: FastAPI) -> SessionStoreProtocol:
     return store
 
 
-SESSION_STORE = _configure_session_store(app)
+SESSION_STORE: SessionStoreProtocol | None = None
+
+
+@app.on_event("startup")
+def _initialise_session_store() -> None:
+    """Initialise the session backend once the FastAPI app starts."""
+
+    global SESSION_STORE
+    SESSION_STORE = _configure_session_store(app)
 
 
 @app.get("/seasonality/dayofweek", response_model=DayOfWeekResponse)


### PR DESCRIPTION
## Summary
- defer seasonality service session store configuration until the FastAPI startup event so imports no longer require runtime secrets
- keep the configured store on `app.state`, wire it into the global security default, and expose it via the module-level `SESSION_STORE`

## Testing
- pytest tests/test_seasonality_service.py -q *(fails: Seasonality service requires a PostgreSQL/Timescale DSN; received driver 'sqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce94bbe083219a99f2f8b36b6906