### PR TITLE
Delay analytics DB initialisation until FastAPI startup

### DIFF
--- a/services/analytics/volatility_service.py
+++ b/services/analytics/volatility_service.py
@@ -7,9 +7,9 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Generator, List, Sequence
+from typing import Any, Iterator, List, Optional, Sequence
 
-from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 from prometheus_client import Gauge
 from alembic import command
@@ -88,22 +88,26 @@ def _normalise_database_url(url: str) -> str:
     return url
 
 
-DATABASE_URL: URL = _require_database_url()
-ENGINE: Engine = create_engine(
-    DATABASE_URL.render_as_string(hide_password=False),
-    **_engine_options(DATABASE_URL),
-)
-SessionLocal = sessionmaker(bind=ENGINE, autoflush=False, expire_on_commit=False, future=True)
+DATABASE_URL: Optional[URL] = None
+ENGINE: Optional[Engine] = None
+SessionFactory: Optional[sessionmaker] = None
+
+
+def _create_engine(url: URL) -> Engine:
+    return create_engine(
+        url.render_as_string(hide_password=False),
+        **_engine_options(url),
+    )
 
 _MIGRATIONS_PATH = Path(__file__).resolve().parents[2] / "data" / "migrations"
 
 
-def run_migrations() -> None:
+def run_migrations(url: URL) -> None:
     """Apply all outstanding Timescale migrations for analytics data."""
 
     config = Config()
     config.set_main_option("script_location", str(_MIGRATIONS_PATH))
-    config.set_main_option("sqlalchemy.url", DATABASE_URL.render_as_string(hide_password=False))
+    config.set_main_option("sqlalchemy.url", url.render_as_string(hide_password=False))
     config.attributes["configure_logger"] = False
 
     command.upgrade(config, "head")
@@ -173,6 +177,9 @@ class VolatilityResponse(BaseModel):
 
 
 app = FastAPI(title="Volatility Analytics Service")
+app.state.analytics_database_url = None
+app.state.analytics_engine = None
+app.state.analytics_sessionmaker = None
 metrics.setup_metrics(app, service_name="volatility-service")
 
 
@@ -194,11 +201,39 @@ def _volatility_gauge() -> Gauge:
 
 @app.on_event("startup")
 def _on_startup() -> None:
-    run_migrations()
+    """Initialise database connectivity and migrations when the app boots."""
+
+    global DATABASE_URL, ENGINE, SessionFactory
+
+    url = _require_database_url()
+    engine = _create_engine(url)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    VolatilityMetric.__table__.create(bind=engine, checkfirst=True)
+    run_migrations(url)
+
+    DATABASE_URL = url
+    ENGINE = engine
+    SessionFactory = session_factory
+
+    app.state.analytics_database_url = url
+    app.state.analytics_engine = engine
+    app.state.analytics_sessionmaker = session_factory
 
 
-def get_session() -> Generator[Session, None, None]:
-    session = SessionLocal()
+def get_session(request: Request) -> Iterator[Session]:
+    session_factory: Optional[sessionmaker] = getattr(request.app.state, "analytics_sessionmaker", None)
+
+    if session_factory is None:
+        session_factory = SessionFactory
+
+    if session_factory is None:
+        raise RuntimeError(
+            "Analytics database session factory is not initialised. Ensure the startup event has run and the "
+            "ANALYTICS_DATABASE_URL environment variable is configured."
+        )
+
+    session = session_factory()
     try:
         yield session
     finally:


### PR DESCRIPTION
## Summary
- move the seasonality analytics service database URL resolution and engine/sessionmaker construction into a startup hook that also creates required metadata at runtime
- initialise the volatility analytics service database connection inside the startup event and persist the engine/session factory on the FastAPI state
- update session dependencies to read the session factory from application state and emit descriptive configuration errors when startup has not prepared the database

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2cef29d208321950eeb5d9210afea