### PR TITLE
Defer auth service configuration to startup

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -93,8 +93,11 @@ def test_auth_service_requires_jwt_secret(monkeypatch: pytest.MonkeyPatch, tmp_p
     _install_dependency_stubs(monkeypatch)
     _clear_auth_service_module()
 
+    module = importlib.import_module("auth_service")
+    app = module.get_application()
+
     with pytest.raises(RuntimeError):
-        importlib.import_module("auth_service")
+        asyncio.run(app.router.startup())
 
     _clear_auth_service_module()
 
@@ -189,6 +192,7 @@ def test_authenticate_emits_role_specific_token(
             providers=providers,
             mfa=DummyMFA(),
             sessions=DummySessions(),
+            jwt_secret="test-secret",
         )
     )
 
@@ -206,14 +210,20 @@ def test_auth_service_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> 
     _install_dependency_stubs(monkeypatch)
     _clear_auth_service_module()
 
+    module = importlib.import_module("auth_service")
+    app = module.get_application()
+
     with pytest.raises(RuntimeError):
-        importlib.import_module("auth_service")
+        asyncio.run(app.router.startup())
 
     _clear_auth_service_module()
     monkeypatch.setenv("AUTH_DATABASE_URL", "sqlite:///./auth_sessions.db")
 
+    module = importlib.import_module("auth_service")
+    second_app = module.get_application()
+
     with pytest.raises(RuntimeError):
-        importlib.import_module("auth_service")
+        asyncio.run(second_app.router.startup())
 
     _clear_auth_service_module()
 


### PR DESCRIPTION
## Summary
- defer JWT secret and database initialisation until FastAPI startup so `auth_service` can be imported without configuration
- add request-scoped dependencies for the session repository/JWT secret and refresh unit tests to cover the new runtime errors

## Testing
- pytest tests/test_auth_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e0568e643c83218291f5f98389231c