### PR TITLE
Document UI deployment process and configure Helm defaults

### DIFF
--- a/deploy/helm/aether-platform/values.yaml
+++ b/deploy/helm/aether-platform/values.yaml
@@ -1010,7 +1010,16 @@ ui:
     repository: ghcr.io/aether/aether-2-ui
     tag: latest
   containerPort: 8080
-  env: []
+  env:
+    # The UI consumes the public API endpoint during build/runtime. Keep the
+    # canonical URL in sync with the risk API ingress so the compiled assets
+    # point at the correct backend cluster.
+    - name: NEXT_PUBLIC_API_BASE_URL
+      value: https://risk.aether.example.com
+    # Some build variants still look for a Vite-style variable; surface the
+    # same value to simplify the production pipeline defaults.
+    - name: VITE_API_BASE_URL
+      value: https://risk.aether.example.com
   service:
     port: 80
     targetPort: http

--- a/docs/runbooks/operations.md
+++ b/docs/runbooks/operations.md
@@ -76,3 +76,13 @@ This runbook describes the day-2 operational workflows for the Aether risk platf
 - When coordinating incident mitigations, obtain an admin session from the authentication service
   and re-use that token across CLI `curl` probes or workflow automations interacting with the
   orchestrator.
+
+## 7. UI deployment coordination
+- Backend releases that alter API surfaces must be accompanied by a UI roll-out.
+  Follow the [UI deployment runbook](./ui-deployment.md) to build the
+  `ghcr.io/aether/aether-2-ui` image with the correct `NEXT_PUBLIC_API_BASE_URL`
+  and `VITE_API_BASE_URL` values (defaulting to
+  `https://risk.aether.example.com`).
+- After ArgoCD/Helm syncs, verify `https://ui.aether.example.com` hits the
+  expected backend ingress and that browser console/network traces remain free
+  from CORS or authentication errors.

--- a/docs/runbooks/ui-deployment.md
+++ b/docs/runbooks/ui-deployment.md
@@ -1,0 +1,64 @@
+# UI Deployment Runbook
+
+This runbook documents how to build and deploy the [Aether-2-UI](https://github.com/CMS-InfoSec/Aether-2-UI)
+frontend so that it targets the production backend services that ship with this
+repository.
+
+## 1. Build the UI container
+
+1. Clone the UI repository and install dependencies:
+   ```bash
+   git clone git@github.com:CMS-InfoSec/Aether-2-UI.git
+   cd Aether-2-UI
+   pnpm install
+   ```
+2. Set the public API base URL so the compiled assets point at the production
+   ingress. The backend risk API is exposed at
+   `https://risk.aether.example.com` by default.
+   ```bash
+   export NEXT_PUBLIC_API_BASE_URL="https://risk.aether.example.com"
+   export VITE_API_BASE_URL="https://risk.aether.example.com"
+   ```
+3. Build and publish the container image:
+   ```bash
+   pnpm run build
+   pnpm run docker:build -- --tag ghcr.io/aether/aether-2-ui:<release>
+   docker push ghcr.io/aether/aether-2-ui:<release>
+   ```
+
+## 2. Update the Helm release
+
+1. In this repository, bump the UI image tag and, if required, override the API
+   base URL in `deploy/helm/aether-platform/values.yaml`:
+   ```yaml
+   ui:
+     image:
+       tag: <release>
+     env:
+       - name: NEXT_PUBLIC_API_BASE_URL
+         value: https://risk.aether.example.com
+       - name: VITE_API_BASE_URL
+         value: https://risk.aether.example.com
+   ```
+2. Deploy the update via Helm/ArgoCD:
+   ```bash
+   helm upgrade aether-platform deploy/helm/aether-platform -n aether-prod \
+     -f deploy/helm/aether-platform/values.yaml
+   ```
+   or sync the `aether-platform` application in ArgoCD if using GitOps.
+
+## 3. Post-deployment validation
+
+* Browse to `https://ui.aether.example.com` and confirm the UI loads without
+  console errors.
+* Exercise authenticated workflows that call the backend (e.g. loading account
+  summaries, OMS screens) and verify the network requests target
+  `https://risk.aether.example.com`.
+* Inspect the UI deployment logs for configuration issues:
+  ```bash
+  kubectl logs deploy/aether-2-ui -n aether-prod
+  ```
+
+Document any deviations (different ingress host names, alternative registries,
+etc.) alongside the release manifest so the build pipeline stays reproducible.
+


### PR DESCRIPTION
## Summary
- add a UI deployment runbook covering build, configuration, and validation steps
- reference the new runbook from the operations guide so backend releases coordinate with the UI
- set default API base URL environment variables for the UI Helm values so it targets the risk API ingress

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2e9d430e88321bf2277037416d0d9