### PR TITLE
Normalize Timescale DSN for admin repository

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,6 +72,12 @@ def _build_admin_repository_from_env() -> AdminRepositoryProtocol:
     if normalized.startswith("postgres://"):
         dsn = "postgresql://" + dsn.split("://", 1)[1]
         normalized = dsn.lower()
+    elif normalized.startswith("timescale://"):
+        # Timescale Cloud historically advertises a ``timescale://`` scheme even though
+        # the underlying driver expects a standard PostgreSQL DSN.  Psycopg will reject
+        # the vendor specific prefix, so normalise it before instantiating the repository.
+        dsn = "postgresql://" + dsn.split("://", 1)[1]
+        normalized = dsn.lower()
 
     allowed_prefixes = (
         "postgresql://",


### PR DESCRIPTION
## Summary
- normalize Timescale Cloud DSNs to the standard PostgreSQL prefix before creating the admin repository so psycopg can connect during startup
- extend the app factory tests with a regression case for the Timescale scheme and provide the missing session-store factory stub

## Testing
- pytest tests/test_app_factory.py::test_create_app_normalizes_timescale_scheme -q
- pytest tests/test_app_factory.py::test_create_app_uses_postgres_repository_when_dsn -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e7fd09c48321a7663895acd24340