### PR TITLE
Enforce explicit accounts database DSNs

### DIFF
--- a/accounts/service.py
+++ b/accounts/service.py
@@ -1,7 +1,5 @@
 """Accounts service coordinating admin profiles and approval workflows."""
 from __future__ import annotations
-
-import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -15,6 +13,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, rela
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql import func
 
+from shared.accounts_config import resolve_accounts_database_url
 from shared.audit import SensitiveActionRecorder
 
 
@@ -22,19 +21,8 @@ class Base(DeclarativeBase):
     """Base declarative class for the accounts service ORM models."""
 
 
-DEFAULT_DATABASE_URL = "sqlite:///./accounts.db"
-
-
 def _database_url() -> str:
-    url = (
-        os.getenv("ACCOUNTS_DATABASE_URL")
-        or os.getenv("TIMESCALE_DSN")
-        or os.getenv("DATABASE_URL")
-        or DEFAULT_DATABASE_URL
-    )
-    if url.startswith("postgresql://"):
-        return url.replace("postgresql://", "postgresql+psycopg2://", 1)
-    return url
+    return resolve_accounts_database_url()
 
 
 def _engine_options(url: str) -> dict[str, object]:

--- a/docs/config/oms-session-store.md
+++ b/docs/config/oms-session-store.md
@@ -13,7 +13,9 @@ SESSION_REDIS_URL=redis://redis:6379/0
 
 At runtime the OMS will refuse to start unless `SESSION_REDIS_URL` is
 defined. The `SESSION_TTL_MINUTES` variable still controls how long each
-session remains valid (default: 60 minutes).
+session remains valid (default: 60 minutes) and must be configured as a
+strictly positive integer so that administrator sessions do not expire
+immediately due to misconfiguration.
 
 For local testing you may use an in-memory store by explicitly setting
 `SESSION_REDIS_URL=memory://<name>`, but this configuration does **not**

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -44,6 +44,7 @@ import yaml
 
 from services.k8s_sync_service import sync_account_secret
 from services.kraken_test_service import test_kraken_connection
+from shared.accounts_config import resolve_accounts_database_url
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,17 +55,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _database_url() -> str:
-    url = (
-        os.getenv("ACCOUNTS_DATABASE_URL")
-        or os.getenv("TIMESCALE_DSN")
-        or os.getenv("DATABASE_URL")
-        or "sqlite:///./accounts.db"
-    )
-    if url.startswith("postgresql://"):
-        return url.replace("postgresql://", "postgresql+psycopg2://", 1)
-    if url.startswith("postgres://"):
-        return url.replace("postgres://", "postgresql+psycopg2://", 1)
-    return url
+    return resolve_accounts_database_url()
 
 
 def _engine_options(url: str) -> dict[str, Any]:

--- a/services/analytics/orderflow_service.py
+++ b/services/analytics/orderflow_service.py
@@ -37,6 +37,7 @@ from services.analytics.market_data_store import (
 from services.common.config import get_timescale_session
 from services.common import security
 from services.common.security import require_admin_account
+from shared.session_config import load_session_ttl_minutes
 
 try:  # pragma: no cover - optional dependency during CI
     import psycopg
@@ -514,12 +515,12 @@ def _configure_session_store(application: FastAPI) -> SessionStoreProtocol:
         return existing
 
     redis_url = (os.getenv("SESSION_REDIS_URL") or "").strip()
-    ttl_minutes = int(os.getenv("SESSION_TTL_MINUTES", "60"))
+    ttl_minutes = load_session_ttl_minutes()
 
     if not redis_url:
         LOGGER.info("SESSION_REDIS_URL not configured. Using in-memory session store.")
         store: SessionStoreProtocol = InMemorySessionStore(ttl_minutes=ttl_minutes)
-    elif redis_url.startswith("memory://"):
+    elif redis_url.lower().startswith("memory://"):
         store = InMemorySessionStore(ttl_minutes=ttl_minutes)
     else:
         store = build_session_store_from_url(redis_url, ttl_minutes=ttl_minutes)

--- a/shared/accounts_config.py
+++ b/shared/accounts_config.py
@@ -1,0 +1,52 @@
+"""Configuration helpers for the accounts services."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+from shared.postgres import normalize_sqlalchemy_dsn
+
+_SQLITE_FLAG = "ACCOUNTS_ALLOW_SQLITE_FOR_TESTS"
+_DRIVER_ENV = "ACCOUNTS_SQLALCHEMY_DRIVER"
+_DSN_ENV_KEYS = ("ACCOUNTS_DATABASE_URL", "TIMESCALE_DSN", "DATABASE_URL")
+
+
+def _coerce_env(env: Mapping[str, str] | None) -> Mapping[str, str]:
+    if env is None:
+        return os.environ
+    return env
+
+
+def resolve_accounts_database_url(*, env: Mapping[str, str] | None = None) -> str:
+    """Return a normalised SQLAlchemy DSN for the accounts persistence layer."""
+
+    source = _coerce_env(env)
+    allow_sqlite = source.get(_SQLITE_FLAG) == "1"
+    driver = (source.get(_DRIVER_ENV) or "psycopg2").strip() or "psycopg2"
+
+    for key in _DSN_ENV_KEYS:
+        raw = source.get(key)
+        if raw is None:
+            continue
+        value = str(raw).strip()
+        if not value:
+            raise RuntimeError(
+                f"{key} is set but empty; configure a valid PostgreSQL/Timescale DSN."
+            )
+        label = "Accounts database DSN" if key == "ACCOUNTS_DATABASE_URL" else f"{key} DSN"
+        return normalize_sqlalchemy_dsn(
+            value,
+            driver=driver,
+            allow_sqlite=allow_sqlite,
+            label=label,
+        )
+
+    raise RuntimeError(
+        "Accounts database DSN is not configured. Set ACCOUNTS_DATABASE_URL or provide "
+        "TIMESCALE_DSN/DATABASE_URL."
+    )
+
+
+__all__ = ["resolve_accounts_database_url"]
+

--- a/shared/postgres.py
+++ b/shared/postgres.py
@@ -1,0 +1,82 @@
+"""Shared helpers for normalising PostgreSQL/Timescale connection strings."""
+
+from __future__ import annotations
+
+_SUPPORTED_POSTGRES_SCHEMES = {
+    "postgres",
+    "postgresql",
+    "timescale",
+    "postgresql+psycopg",
+    "postgresql+psycopg2",
+}
+
+_SUPPORTED_SQLITE_SCHEMES = {
+    "sqlite",
+    "sqlite+pysqlite",
+}
+
+
+def normalize_postgres_dsn(raw_dsn: str, *, allow_sqlite: bool = True, label: str = "Timescale DSN") -> str:
+    """Coerce supported connection schemes to variants psycopg understands.
+
+    Parameters
+    ----------
+    raw_dsn:
+        Raw URI sourced from configuration.
+    allow_sqlite:
+        Whether sqlite DSNs are permitted for local development/tests.
+    label:
+        Human friendly descriptor included in error messages.
+    """
+
+    stripped = raw_dsn.strip()
+    if not stripped:
+        raise RuntimeError(f"{label} cannot be empty once configured.")
+
+    scheme, separator, remainder = stripped.partition("://")
+    if not separator:
+        raise RuntimeError(
+            f"{label} must include a URI scheme such as postgresql:// or sqlite://."
+        )
+
+    normalized_scheme = scheme.lower()
+    if normalized_scheme in _SUPPORTED_POSTGRES_SCHEMES:
+        return f"postgresql://{remainder}"
+
+    if allow_sqlite and normalized_scheme in _SUPPORTED_SQLITE_SCHEMES:
+        return f"{normalized_scheme}://{remainder}"
+
+    if allow_sqlite:
+        raise RuntimeError(
+            f"{label} must use a PostgreSQL/Timescale compatible scheme or sqlite:// for testing."
+        )
+    raise RuntimeError(
+        f"{label} must use a PostgreSQL/Timescale compatible scheme."
+    )
+
+
+def normalize_sqlalchemy_dsn(
+    raw_dsn: str,
+    *,
+    driver: str = "psycopg2",
+    allow_sqlite: bool = True,
+    label: str = "Timescale DSN",
+) -> str:
+    """Normalize a PostgreSQL/Timescale DSN for SQLAlchemy engines.
+
+    ``normalize_postgres_dsn`` ensures the scheme is compatible with psycopg, but
+    SQLAlchemy requires the driver name to be embedded in the URI.  This helper
+    reuses the shared normaliser and, when targeting PostgreSQL, inserts the
+    configured driver while preserving sqlite URLs for test environments.
+    """
+
+    normalized = normalize_postgres_dsn(
+        raw_dsn, allow_sqlite=allow_sqlite, label=label
+    )
+    if normalized.startswith("postgresql://"):
+        driver_name = driver.strip() or "psycopg2"
+        return normalized.replace("postgresql://", f"postgresql+{driver_name}://", 1)
+    return normalized
+
+
+__all__ = ["normalize_postgres_dsn", "normalize_sqlalchemy_dsn"]

--- a/shared/session_config.py
+++ b/shared/session_config.py
@@ -1,0 +1,71 @@
+"""Utilities for shared session configuration across services."""
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+
+class _EnvMapping(Mapping[str, str]):
+    """A mapping wrapper ensuring string access to environment variables."""
+
+    def __init__(self, data: Mapping[str, str]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> str:
+        return str(self._data[key])
+
+    def __iter__(self):  # type: ignore[override]
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+def _coerce_env(env: Mapping[str, str] | None) -> Mapping[str, str]:
+    if env is None:
+        return _EnvMapping(os.environ)
+    return env
+
+
+def load_session_ttl_minutes(
+    *, env: Mapping[str, str] | None = None, default: int = 60
+) -> int:
+    """Return a positive TTL in minutes for administrator sessions.
+
+    The helper centralises parsing of the ``SESSION_TTL_MINUTES`` environment
+    variable so all services enforce the same validation semantics.  Any value
+    that cannot be parsed as a strictly positive integer triggers a
+    ``RuntimeError`` so misconfigurations fail fast during startup instead of
+    yielding sessions that expire immediately.
+    """
+
+    if default <= 0:
+        raise RuntimeError("Session TTL default must be a positive integer.")
+
+    source = _coerce_env(env)
+    raw_value = source.get("SESSION_TTL_MINUTES")
+    if raw_value is None:
+        return default
+
+    value = str(raw_value).strip()
+    if not value:
+        raise RuntimeError(
+            "SESSION_TTL_MINUTES must be a positive integer representing minutes."
+        )
+
+    try:
+        ttl = int(value, 10)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(
+            "SESSION_TTL_MINUTES must be a positive integer representing minutes."
+        ) from exc
+
+    if ttl <= 0:
+        raise RuntimeError(
+            "SESSION_TTL_MINUTES must be a positive integer representing minutes."
+        )
+
+    return ttl
+
+
+__all__ = ["load_session_ttl_minutes"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ os.environ.setdefault("AUTH_DATABASE_URL", "sqlite:////tmp/aether-auth-test.db")
 
 os.environ.setdefault("SESSION_REDIS_URL", "memory://oms-test")
 
+os.environ.setdefault("TIMESCALE_DSN", "postgresql://localhost:5432/aether_test")
+
 
 
 

--- a/tests/integration/test_account_service.py
+++ b/tests/integration/test_account_service.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 def account_module(monkeypatch):
     key = Fernet.generate_key().decode("ascii")
     monkeypatch.setenv("ACCOUNT_ENCRYPTION_KEY", key)
+    monkeypatch.setenv("ACCOUNTS_ALLOW_SQLITE_FOR_TESTS", "1")
     monkeypatch.setenv("ACCOUNTS_DATABASE_URL", "sqlite:///:memory:")
     root = Path(__file__).resolve().parents[2]
     root_str = str(root)

--- a/tests/services/common/test_config.py
+++ b/tests/services/common/test_config.py
@@ -1,0 +1,82 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module spec for {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+for module_name, module_path in (
+    ("services", ROOT / "services" / "__init__.py"),
+    ("services.common", ROOT / "services" / "common" / "__init__.py"),
+    ("services.common.config", ROOT / "services" / "common" / "config.py"),
+):
+    if module_name not in sys.modules:
+        _load_module(module_name, module_path)
+
+
+import services.common.config as config
+
+
+@pytest.fixture(autouse=True)
+def _clear_timescale_cache():
+    config.get_timescale_session.cache_clear()
+    try:
+        yield
+    finally:
+        config.get_timescale_session.cache_clear()
+
+
+def test_get_timescale_session_requires_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.delenv("AETHER_COMPANY_TIMESCALE_DSN", raising=False)
+
+    with pytest.raises(RuntimeError, match="Timescale DSN is not configured"):
+        config.get_timescale_session("company")
+
+
+def test_get_timescale_session_uses_account_specific_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://global.example/aether")
+    monkeypatch.setenv(
+        "AETHER_DIRECTOR1_TIMESCALE_DSN",
+        "sqlite:///tmp/director1.db",
+    )
+
+    session = config.get_timescale_session("director1")
+    assert session.dsn == "sqlite:///tmp/director1.db"
+
+
+def test_get_timescale_session_normalizes_postgres_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "Postgres://user:pass@host:5432/db")
+
+    session = config.get_timescale_session("company")
+    assert session.dsn == "postgresql://user:pass@host:5432/db"
+
+
+def test_get_timescale_session_allows_sqlite_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.setenv("AETHER_COMPANY_TIMESCALE_DSN", "SQLite+PySQLite:///:memory:")
+
+    session = config.get_timescale_session("company")
+    assert session.dsn == "sqlite+pysqlite:///:memory:"
+
+
+def test_get_timescale_session_rejects_unsupported_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "mysql://user:pass@host:3306/db")
+
+    with pytest.raises(RuntimeError, match="Timescale DSN must use a PostgreSQL/Timescale"):
+        config.get_timescale_session("company")

--- a/tests/services/oms/test_circuit_breaker_store.py
+++ b/tests/services/oms/test_circuit_breaker_store.py
@@ -1,0 +1,83 @@
+"""Regression tests for the OMS circuit breaker persistence backend."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Tuple
+
+import pytest
+
+from common.utils.redis import InMemoryRedis
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure Redis-related environment variables do not leak across tests."""
+
+    for key in (
+        "OMS_CIRCUIT_BREAKER_REDIS_URL",
+        "SESSION_REDIS_URL",
+        "SESSION_STORE_URL",
+        "SESSION_BACKEND_DSN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture()
+def store_module(monkeypatch: pytest.MonkeyPatch):
+    """Import a fresh copy of the circuit breaker store module for each test."""
+
+    monkeypatch.syspath_prepend(str(ROOT))
+    for name in (
+        "services.oms.circuit_breaker_store",
+        "services.oms",
+        "services",
+    ):
+        sys.modules.pop(name, None)
+    return importlib.import_module("services.oms.circuit_breaker_store")
+
+
+def test_create_default_client_requires_configuration(store_module) -> None:
+    """The store must fail fast when no Redis DSN is configured."""
+
+    with pytest.raises(RuntimeError, match="requires a Redis URL"):
+        store_module.CircuitBreakerStateStore._create_default_client()
+
+
+def test_create_default_client_rejects_blank_configuration(
+    store_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMS_CIRCUIT_BREAKER_REDIS_URL", "   ")
+
+    with pytest.raises(RuntimeError, match="requires a Redis URL"):
+        store_module.CircuitBreakerStateStore._create_default_client()
+
+
+def test_create_default_client_supports_memory_scheme(
+    store_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMS_CIRCUIT_BREAKER_REDIS_URL", "memory://stub")
+
+    client = store_module.CircuitBreakerStateStore._create_default_client()
+    assert isinstance(client, InMemoryRedis)
+
+
+def test_create_default_client_rejects_stub_when_not_memory(
+    store_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMS_CIRCUIT_BREAKER_REDIS_URL", "redis://cache:6379/0")
+
+    def _fake_create(url: str, *, decode_responses: bool, logger: Any) -> Tuple[object, bool]:
+        assert url == "redis://cache:6379/0"
+        assert decode_responses is True
+        return object(), True
+
+    monkeypatch.setattr(
+        store_module, "create_redis_from_url", _fake_create
+    )
+
+    with pytest.raises(RuntimeError, match="could not connect to Redis"):
+        store_module.CircuitBreakerStateStore._create_default_client()

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Iterable, Mapping
 
@@ -8,6 +9,9 @@ from sqlalchemy.orm import sessionmaker
 
 from shared.audit import AuditLogStore, SensitiveActionRecorder, TimescaleAuditLogger
 from shared.correlation import CorrelationContext
+
+os.environ.setdefault("ACCOUNTS_ALLOW_SQLITE_FOR_TESTS", "1")
+os.environ.setdefault("ACCOUNTS_DATABASE_URL", "sqlite:///:memory:")
 
 from accounts.service import AccountsRepository, AccountsService, AdminProfile, Base
 

--- a/tests/test_accounts_config.py
+++ b/tests/test_accounts_config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from shared.accounts_config import resolve_accounts_database_url
+
+
+def test_accounts_database_url_requires_configuration() -> None:
+    with pytest.raises(RuntimeError, match="Accounts database DSN is not configured"):
+        resolve_accounts_database_url(env={})
+
+
+def test_accounts_database_url_rejects_blank_values() -> None:
+    with pytest.raises(RuntimeError, match="is set but empty"):
+        resolve_accounts_database_url(env={"ACCOUNTS_DATABASE_URL": "   "})
+
+
+def test_accounts_database_url_normalizes_postgres_scheme() -> None:
+    url = resolve_accounts_database_url(env={"ACCOUNTS_DATABASE_URL": "postgres://user:pass@localhost/db"})
+    assert url == "postgresql+psycopg2://user:pass@localhost/db"
+
+
+def test_accounts_database_url_allows_sqlite_when_flag_enabled(tmp_path) -> None:
+    db_path = tmp_path / "accounts.db"
+    url = resolve_accounts_database_url(
+        env={
+            "ACCOUNTS_DATABASE_URL": f"sqlite:///{db_path}",
+            "ACCOUNTS_ALLOW_SQLITE_FOR_TESTS": "1",
+        }
+    )
+    assert url == f"sqlite:///{db_path}"
+
+
+def test_accounts_database_url_honours_fallback_envs() -> None:
+    url = resolve_accounts_database_url(env={"TIMESCALE_DSN": "postgresql://example.com/aether"})
+    assert url == "postgresql+psycopg2://example.com/aether"
+
+
+def test_accounts_database_url_uses_configured_driver() -> None:
+    url = resolve_accounts_database_url(
+        env={
+            "ACCOUNTS_DATABASE_URL": "postgresql://example.com/aether",
+            "ACCOUNTS_SQLALCHEMY_DRIVER": "psycopg",
+        }
+    )
+    assert url == "postgresql+psycopg://example.com/aether"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import types
 
@@ -125,6 +126,10 @@ class RedisSessionStore(SessionStoreProtocol):  # pragma: no cover - structural 
         self.ttl_minutes = ttl_minutes
 
 
+def build_session_store_from_url(redis_url: str, *, ttl_minutes: int = 60) -> RedisSessionStore:
+    return RedisSessionStore(client={"url": redis_url}, ttl_minutes=ttl_minutes)
+
+
 class PostgresAdminRepository(AdminRepositoryProtocol):
     def __init__(self, dsn: str) -> None:  # pragma: no cover - behaviour not under test
         self.dsn = dsn
@@ -149,6 +154,7 @@ auth_service_module.AuthService = AuthService  # type: ignore[attr-defined]
 auth_service_module.SessionStoreProtocol = SessionStoreProtocol  # type: ignore[attr-defined]
 auth_service_module.InMemorySessionStore = InMemorySessionStore  # type: ignore[attr-defined]
 auth_service_module.RedisSessionStore = RedisSessionStore  # type: ignore[attr-defined]
+auth_service_module.build_session_store_from_url = build_session_store_from_url  # type: ignore[attr-defined]
 auth_service_module.SessionStore = SessionStore  # type: ignore[attr-defined]
 _install_module("auth.service", auth_service_module)
 
@@ -223,6 +229,31 @@ class CorrelationIdMiddleware:  # pragma: no cover - structural stub
 shared_correlation_module.CorrelationIdMiddleware = CorrelationIdMiddleware  # type: ignore[attr-defined]
 _install_module("shared.correlation", shared_correlation_module)
 
+shared_session_config_module = types.ModuleType("shared.session_config")
+
+
+def load_session_ttl_minutes(*, env=None, default: int = 60):  # pragma: no cover - helper stub
+    source = env or os.environ
+    raw = source.get("SESSION_TTL_MINUTES")
+    if raw is None:
+        if default <= 0:
+            raise RuntimeError("Session TTL default must be a positive integer.")
+        return default
+    value = str(raw).strip()
+    if not value:
+        raise RuntimeError("SESSION_TTL_MINUTES must be a positive integer representing minutes.")
+    try:
+        ttl = int(value)
+    except ValueError as exc:  # pragma: no cover - behaviour not under test
+        raise RuntimeError("SESSION_TTL_MINUTES must be a positive integer representing minutes.") from exc
+    if ttl <= 0:
+        raise RuntimeError("SESSION_TTL_MINUTES must be a positive integer representing minutes.")
+    return ttl
+
+
+shared_session_config_module.load_session_ttl_minutes = load_session_ttl_minutes  # type: ignore[attr-defined]
+_install_module("shared.session_config", shared_session_config_module)
+
 
 # Scaling controller infrastructure.
 scaling_controller_module = types.ModuleType("scaling_controller")
@@ -272,15 +303,94 @@ def test_create_app_uses_postgres_repository_when_dsn(monkeypatch: pytest.Monkey
     assert created["dsn"] == "postgresql://example.com/admin"
 
 
+def test_create_app_normalizes_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_POSTGRES_DSN", "timescale://tenant:pass@example.com/admin")
+
+    captured: dict[str, str] = {}
+
+    class DummyPostgresRepository(app_module.InMemoryAdminRepository):
+        def __init__(self, dsn: str) -> None:
+            super().__init__()
+            captured["dsn"] = dsn
+
+    monkeypatch.setattr(app_module, "PostgresAdminRepository", DummyPostgresRepository)
+
+    session_store = InMemorySessionStore()
+    application = app_module.create_app(session_store=session_store)
+
+    assert isinstance(application.state.admin_repository, DummyPostgresRepository)
+    assert captured["dsn"].startswith("postgresql://")
+
+
+def test_create_app_normalizes_sqlalchemy_style_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "ADMIN_POSTGRES_DSN",
+        "postgresql+psycopg://tenant:pass@example.com/admin",
+    )
+
+    captured: dict[str, str] = {}
+
+    class DummyPostgresRepository(app_module.InMemoryAdminRepository):
+        def __init__(self, dsn: str) -> None:
+            super().__init__()
+            captured["dsn"] = dsn
+
+    monkeypatch.setattr(app_module, "PostgresAdminRepository", DummyPostgresRepository)
+
+    session_store = InMemorySessionStore()
+    application = app_module.create_app(session_store=session_store)
+
+    assert isinstance(application.state.admin_repository, DummyPostgresRepository)
+    assert captured["dsn"].startswith("postgresql://")
+
+
+def test_create_app_normalizes_postgresql_scheme_casing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "ADMIN_POSTGRES_DSN",
+        "  PostgreSQL://tenant:pass@example.com/admin?sslmode=require  ",
+    )
+
+    captured: dict[str, str] = {}
+
+    class DummyPostgresRepository(app_module.InMemoryAdminRepository):
+        def __init__(self, dsn: str) -> None:
+            super().__init__()
+            captured["dsn"] = dsn
+
+    monkeypatch.setattr(app_module, "PostgresAdminRepository", DummyPostgresRepository)
+
+    session_store = InMemorySessionStore()
+    application = app_module.create_app(session_store=session_store)
+
+    assert isinstance(application.state.admin_repository, DummyPostgresRepository)
+    assert captured["dsn"] == "postgresql://tenant:pass@example.com/admin?sslmode=require"
+
+
 def test_create_app_requires_dsn_when_not_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ADMIN_POSTGRES_DSN", raising=False)
     monkeypatch.delenv("ADMIN_DATABASE_DSN", raising=False)
     monkeypatch.delenv("ADMIN_DB_DSN", raising=False)
 
+    repository = app_module.InMemoryAdminRepository()
+    application = app_module.create_app(
+        admin_repository=repository, session_store=InMemorySessionStore()
+    )
 
-    application = app_module.create_app(session_store=InMemorySessionStore())
+    assert application.state.admin_repository is repository
 
-    assert isinstance(application.state.admin_repository, app_module.InMemoryAdminRepository)
+
+def test_create_app_rejects_unsupported_admin_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_POSTGRES_DSN", "mysql://example.com/admin")
+
+    with pytest.raises(RuntimeError, match="requires a Postgres/Timescale DSN"):
+        app_module.create_app(session_store=InMemorySessionStore())
+
+
+def test_create_app_rejects_blank_admin_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_POSTGRES_DSN", "   ")
+
+    with pytest.raises(RuntimeError, match="requires a DSN with an explicit scheme"):
+        app_module.create_app(session_store=InMemorySessionStore())
 
 
 def test_create_app_requires_session_store_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -289,5 +399,28 @@ def test_create_app_requires_session_store_dsn(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv("SESSION_BACKEND_DSN", raising=False)
 
     with pytest.raises(RuntimeError, match="Session store misconfigured"):
-        app_module.create_app()
+        app_module.create_app(admin_repository=app_module.InMemoryAdminRepository())
+
+
+def test_create_app_rejects_non_integer_session_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://admin-platform-test")
+    monkeypatch.setenv("SESSION_TTL_MINUTES", "not-a-number")
+
+    with pytest.raises(RuntimeError, match="SESSION_TTL_MINUTES must be a positive integer"):
+        app_module.create_app(admin_repository=app_module.InMemoryAdminRepository())
+
+
+def test_create_app_rejects_non_positive_session_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://admin-platform-test")
+    monkeypatch.setenv("SESSION_TTL_MINUTES", "0")
+
+    with pytest.raises(RuntimeError, match="SESSION_TTL_MINUTES must be a positive integer"):
+        app_module.create_app(admin_repository=app_module.InMemoryAdminRepository())
+
+
+def test_create_app_rejects_blank_session_store_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_REDIS_URL", "   ")
+
+    with pytest.raises(RuntimeError, match="Session store misconfigured"):
+        app_module.create_app(admin_repository=app_module.InMemoryAdminRepository())
 

--- a/tests/test_session_config.py
+++ b/tests/test_session_config.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+
+from shared.session_config import load_session_ttl_minutes
+
+
+def test_load_session_ttl_minutes_defaults_to_sixty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SESSION_TTL_MINUTES", raising=False)
+    assert load_session_ttl_minutes() == 60
+
+
+def test_load_session_ttl_minutes_rejects_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_TTL_MINUTES", "abc")
+    with pytest.raises(RuntimeError, match="positive integer"):
+        load_session_ttl_minutes()
+
+
+def test_load_session_ttl_minutes_rejects_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_TTL_MINUTES", "0")
+    with pytest.raises(RuntimeError, match="positive integer"):
+        load_session_ttl_minutes()


### PR DESCRIPTION
## Summary
- add a shared resolver that normalizes accounts database DSNs and fails fast instead of silently falling back to sqlite
- update the accounts services to require the resolver so production deploys only connect with explicit PostgreSQL/Timescale URLs
- extend the unit and integration test suites to cover the new configuration semantics and opt in to sqlite in the harness

## Testing
- pytest tests/test_accounts_config.py tests/test_accounts.py tests/integration/test_account_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e7fd09c48321a7663895acd24340