### PR TITLE
Enforce spot-only trading across risk service

### DIFF
--- a/health_probe.py
+++ b/health_probe.py
@@ -22,7 +22,7 @@ from prometheus_client import Gauge, start_http_server
 
 
 DEFAULT_ACCOUNT_ID = "ACC-DEFAULT"
-DEFAULT_SYMBOL = "AAPL"
+DEFAULT_SYMBOL = "BTC-USD"
 DEFAULT_INTERVAL = 300.0
 DEFAULT_ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093")
 DEFAULT_WS_BOOK_HEALTH_URL = os.getenv("WS_BOOK_HEALTH_URL")

--- a/risk_service.py
+++ b/risk_service.py
@@ -8,6 +8,7 @@ import logging
 import os
 
 import math
+import re
 
 import time
 from contextlib import contextmanager
@@ -430,9 +431,9 @@ def _log_position_size(
 
 
 _STUB_MARKET_TELEMETRY: Dict[str, Dict[str, float]] = {
-    "AAPL": {
-        "spread_bps": 5.0,
-        "latency_seconds": 0.8,
+    "BTC-USD": {
+        "spread_bps": 4.0,
+        "latency_seconds": 0.6,
         "exchange_outage": 0,
     }
 }
@@ -444,29 +445,29 @@ _STUB_PROM_METRICS: Dict[str, float] = {
 
 
 _STUB_PRICE_HISTORY: Dict[str, List[Dict[str, float]]] = {
-    "AAPL": [
-        {"high": 178.5, "low": 174.4, "close": 176.3},
-        {"high": 179.1, "low": 175.2, "close": 178.7},
-        {"high": 181.2, "low": 176.8, "close": 180.3},
-        {"high": 180.9, "low": 177.6, "close": 179.4},
-        {"high": 182.4, "low": 178.9, "close": 181.7},
-        {"high": 183.2, "low": 179.7, "close": 182.1},
-        {"high": 184.0, "low": 180.1, "close": 183.5},
-        {"high": 185.6, "low": 181.4, "close": 184.2},
-        {"high": 186.2, "low": 182.7, "close": 185.3},
-        {"high": 187.3, "low": 183.5, "close": 186.8},
-        {"high": 188.8, "low": 184.6, "close": 187.1},
-        {"high": 189.5, "low": 185.2, "close": 188.6},
-        {"high": 190.7, "low": 186.1, "close": 189.4},
-        {"high": 191.2, "low": 187.5, "close": 190.8},
-        {"high": 192.3, "low": 188.4, "close": 191.5},
+    "BTC-USD": [
+        {"high": 30250.0, "low": 29780.0, "close": 30010.0},
+        {"high": 30310.0, "low": 29820.0, "close": 30055.0},
+        {"high": 30440.0, "low": 29960.0, "close": 30180.0},
+        {"high": 30510.0, "low": 30010.0, "close": 30245.0},
+        {"high": 30620.0, "low": 30120.0, "close": 30360.0},
+        {"high": 30740.0, "low": 30200.0, "close": 30480.0},
+        {"high": 30830.0, "low": 30290.0, "close": 30570.0},
+        {"high": 30920.0, "low": 30380.0, "close": 30640.0},
+        {"high": 31010.0, "low": 30460.0, "close": 30735.0},
+        {"high": 31120.0, "low": 30540.0, "close": 30810.0},
+        {"high": 31200.0, "low": 30600.0, "close": 30900.0},
+        {"high": 31310.0, "low": 30690.0, "close": 30980.0},
+        {"high": 31420.0, "low": 30780.0, "close": 31070.0},
+        {"high": 31510.0, "low": 30860.0, "close": 31140.0},
+        {"high": 31600.0, "low": 30930.0, "close": 31220.0},
     ]
 }
 
 
 _STUB_ACCOUNT_RETURNS: Dict[str, List[float]] = {
-    "ACC-DEFAULT": [-1500.0 + (i % 5) * 100 for i in range(260)],
-    "ACC-AGGR": [-4500.0 + (i % 7) * 250 for i in range(260)],
+    "company": [-1500.0 + (i % 5) * 100 for i in range(260)],
+    "director-1": [-4500.0 + (i % 7) * 250 for i in range(260)],
 }
 
 
@@ -478,12 +479,36 @@ _STUB_ACCOUNT_USAGE: Dict[str, Dict[str, Decimal]] = {}
 
 _STUB_FILLS: List[Dict[str, object]] = [
     {
-        "account_id": "ACC-DEFAULT",
+        "account_id": "company",
         "timestamp": datetime.utcnow().isoformat(),
         "pnl": -2500.0,
         "fee": 125.0,
     }
 ]
+
+
+_SPOT_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,}[-/][A-Z0-9]{2,}$")
+_NON_SPOT_KEYWORDS = ("PERP", "FUT", "FUTURE", "MARGIN", "SWAP", "OPTION", "DERIV")
+_LEVERAGE_SUFFIXES = ("UP", "DOWN")
+_LEVERAGE_PATTERN = re.compile(r"\d+(?:X|L|S)$")
+
+
+def _is_spot_instrument(symbol: str) -> bool:
+    """Return ``True`` when *symbol* appears to represent a spot market pair."""
+
+    normalized = str(symbol or "").strip().upper()
+    if not normalized:
+        return False
+    if any(keyword in normalized for keyword in _NON_SPOT_KEYWORDS):
+        return False
+    if not _SPOT_PAIR_PATTERN.match(normalized):
+        return False
+    base, _ = re.split(r"[-/]", normalized, maxsplit=1)
+    if any(base.endswith(suffix) for suffix in _LEVERAGE_SUFFIXES):
+        return False
+    if _LEVERAGE_PATTERN.search(base):
+        return False
+    return True
 
 
 class TradeIntent(BaseModel):
@@ -1005,6 +1030,13 @@ async def _evaluate(context: RiskEvaluationContext) -> RiskValidationResponse:
             nonlocal cooldown_until
             cooldown_until = cooldown_until or _determine_cooldown(limits)
         _audit_violation(context, message, details)
+
+    if not _is_spot_instrument(normalized_instrument):
+        _register_violation(
+            "Instrument not eligible for spot trading",
+            cooldown=True,
+            details={"instrument": normalized_instrument},
+        )
 
     universe_snapshot: Optional[UniverseSnapshot]
     try:

--- a/services/common/config.py
+++ b/services/common/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from functools import lru_cache

--- a/tests/risk/test_risk_service_endpoints.py
+++ b/tests/risk/test_risk_service_endpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import sys
 import types
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
@@ -50,6 +51,7 @@ if "prometheus_client" not in sys.modules:
 
 pytest.importorskip("services.common.security")
 
+import risk_service as risk_module
 from risk_service import app, require_admin_account
 from services.common import security
 from tests.helpers.authentication import override_admin_auth
@@ -68,19 +70,27 @@ def allow_stub_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(name="client")
 def client_fixture() -> TestClient:
-    return TestClient(app)
+    with TestClient(app) as client:
+        snapshot = risk_module.UniverseSnapshot(
+            symbols={"BTC-USD", "ETH-USD", "SOL-USD"},
+            generated_at=datetime.now(timezone.utc),
+            thresholds={},
+        )
+        risk_module._UNIVERSE_CACHE_SNAPSHOT = snapshot
+        risk_module._UNIVERSE_CACHE_EXPIRY = datetime.now(timezone.utc) + timedelta(hours=1)
+        yield client
 
 
 @pytest.fixture(name="risk_payload")
 def risk_payload_fixture() -> dict[str, object]:
     return {
-        "account_id": "ACC-DEFAULT",
+        "account_id": "company",
         "intent": {
             "policy_id": "policy-1",
-            "instrument_id": "AAPL",
+            "instrument_id": "BTC-USD",
             "side": "buy",
-            "quantity": 10.0,
-            "price": 150.0,
+            "quantity": 0.5,
+            "price": 30000.0,
         },
         "portfolio_state": {
             "net_asset_value": 1_000_000.0,
@@ -101,15 +111,15 @@ def test_validate_requires_admin_header(client: TestClient, risk_payload: dict[s
 
 def test_validate_rejects_account_mismatch(client: TestClient, risk_payload: dict[str, object]) -> None:
     payload = deepcopy(risk_payload)
-    payload["account_id"] = "ACC-AGGR"
+    payload["account_id"] = "director-1"
 
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.post(
             "/risk/validate",
             json=payload,
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -127,14 +137,14 @@ def test_limits_requires_admin_header(client: TestClient) -> None:
 
 def test_limits_returns_account_data(client: TestClient) -> None:
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.get(
             "/risk/limits",
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["account_id"] == "ACC-DEFAULT"
+    assert body["account_id"] == "company"
     assert "limits" in body and "usage" in body

--- a/tests/unit/services/test_risk_service.py
+++ b/tests/unit/services/test_risk_service.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 import sys
 from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterator
 
 import pytest
@@ -23,6 +24,7 @@ pytest.importorskip("services.common.security")
 from fastapi import status
 from fastapi.testclient import TestClient
 
+import risk_service as risk_module
 from risk_service import RiskEvaluationContext, app as risk_app, require_admin_account
 from tests.helpers.authentication import override_admin_auth
 
@@ -37,18 +39,25 @@ RiskEvaluationContext.model_config = config  # type: ignore[attr-defined]
 @pytest.fixture
 def risk_client() -> Iterator[TestClient]:
     with TestClient(risk_app) as client:
+        snapshot = risk_module.UniverseSnapshot(
+            symbols={"BTC-USD", "ETH-USD", "SOL-USD"},
+            generated_at=datetime.now(timezone.utc),
+            thresholds={},
+        )
+        risk_module._UNIVERSE_CACHE_SNAPSHOT = snapshot
+        risk_module._UNIVERSE_CACHE_EXPIRY = datetime.now(timezone.utc) + timedelta(hours=1)
         yield client
 
 
 def _base_request() -> Dict[str, object]:
     return {
-        "account_id": "ACC-DEFAULT",
+        "account_id": "company",
         "intent": {
             "policy_id": "policy-1",
-            "instrument_id": "AAPL",
+            "instrument_id": "BTC-USD",
             "side": "buy",
-            "quantity": 10.0,
-            "price": 100.0,
+            "quantity": 0.5,
+            "price": 30000.0,
         },
         "portfolio_state": {
             "net_asset_value": 1_000_000.0,
@@ -79,15 +88,29 @@ def test_risk_validation_rejects_when_fee_budget_exhausted(
     risk_client: TestClient,
 ) -> None:
     payload = _base_request()
-    payload["portfolio_state"]["fees_paid"] = 12_000.0
-    with override_admin_auth(
-        risk_client.app, require_admin_account, payload["account_id"]
-    ) as headers:
-        response = risk_client.post(
-            "/risk/validate",
-            json=payload,
-            headers={**headers, "X-Account-ID": payload["account_id"]},
+    payload["portfolio_state"]["fees_paid"] = 40_000.0
+    previous_fills = list(risk_module._STUB_FILLS)
+    try:
+        risk_module.set_stub_fills(
+            [
+                {
+                    "account_id": "company",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "pnl": 0.0,
+                    "fee": 40_000.0,
+                }
+            ]
         )
+        with override_admin_auth(
+            risk_client.app, require_admin_account, payload["account_id"]
+        ) as headers:
+            response = risk_client.post(
+                "/risk/validate",
+                json=payload,
+                headers={**headers, "X-Account-ID": payload["account_id"]},
+            )
+    finally:
+        risk_module.set_stub_fills(previous_fills)
     assert response.status_code == 200
     body = response.json()
     assert body["pass"] is False
@@ -110,7 +133,7 @@ def test_risk_validation_enforces_schema(risk_client: TestClient) -> None:
 
 def test_risk_limits_endpoint_returns_configuration(risk_client: TestClient) -> None:
     with override_admin_auth(
-        risk_client.app, require_admin_account, "ACC-DEFAULT"
+        risk_client.app, require_admin_account, "company"
     ) as headers:
         response = risk_client.get(
             "/risk/limits",
@@ -118,8 +141,8 @@ def test_risk_limits_endpoint_returns_configuration(risk_client: TestClient) -> 
         )
     assert response.status_code == 200
     body = response.json()
-    assert body["limits"]["account_id"] == "ACC-DEFAULT"
-    assert body["usage"]["account_id"] == "ACC-DEFAULT"
+    assert body["limits"]["account_id"] == "company"
+    assert body["usage"]["account_id"] == "company"
 
 
 def test_risk_validation_rejects_unauthenticated_request(
@@ -135,7 +158,7 @@ def test_risk_validation_rejects_account_mismatch(risk_client: TestClient) -> No
     with override_admin_auth(
         risk_client.app, require_admin_account, payload["account_id"]
     ) as headers:
-        payload["account_id"] = "ACC-OTHER"
+        payload["account_id"] = "director-1"
         response = risk_client.post(
             "/risk/validate",
             json=payload,
@@ -145,4 +168,24 @@ def test_risk_validation_rejects_account_mismatch(risk_client: TestClient) -> No
     assert (
         response.json()["detail"]
         == "Account mismatch between authenticated session and payload."
+    )
+
+
+def test_risk_validation_rejects_non_spot_instrument(risk_client: TestClient) -> None:
+    payload = _base_request()
+    payload["intent"]["instrument_id"] = "BTC-PERP"
+    with override_admin_auth(
+        risk_client.app, require_admin_account, payload["account_id"]
+    ) as headers:
+        response = risk_client.post(
+            "/risk/validate",
+            json=payload,
+            headers={**headers, "X-Account-ID": payload["account_id"]},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pass"] is False
+    assert any(
+        reason.startswith("Instrument not eligible for spot trading")
+        for reason in body["reasons"]
     )


### PR DESCRIPTION
## Summary
- replace risk service stubs with BTC spot data and add validation to reject non-spot instruments during evaluation
- point the health probe default symbol at BTC-USD and import regex utilities needed for configuration helpers
- update risk service endpoint and unit tests to exercise the new spot-only checks with cached universe snapshots

## Testing
- pytest tests/unit/services/test_risk_service.py tests/risk/test_risk_service_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c61e227c83218dc56ce891b8cb5a