### PR TITLE
Centralize spot-only validation across services

### DIFF
--- a/health_probe.py
+++ b/health_probe.py
@@ -22,7 +22,7 @@ from prometheus_client import Gauge, start_http_server
 
 
 DEFAULT_ACCOUNT_ID = "ACC-DEFAULT"
-DEFAULT_SYMBOL = "AAPL"
+DEFAULT_SYMBOL = "BTC-USD"
 DEFAULT_INTERVAL = 300.0
 DEFAULT_ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093")
 DEFAULT_WS_BOOK_HEALTH_URL = os.getenv("WS_BOOK_HEALTH_URL")

--- a/oms_service.py
+++ b/oms_service.py
@@ -38,6 +38,7 @@ from services.oms.rate_limit_guard import RateLimitGuard, rate_limit_guard as sh
 from services.risk.stablecoin_monitor import format_depeg_alert, get_global_monitor
 
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 from services.oms.oms_service import (  # type: ignore  # pragma: no cover - shared helpers
     _PrecisionValidator,
     _normalize_symbol,
@@ -192,6 +193,14 @@ class PlaceOrderRequest(BaseModel):
         ge=Decimal("0"),
         description="Slippage estimate in basis points provided by the caller",
     )
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
 
     @field_validator("side")
     @classmethod

--- a/services/common/config.py
+++ b/services/common/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from functools import lru_cache

--- a/services/common/schemas.py
+++ b/services/common/schemas.py
@@ -5,9 +5,11 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 
-from pydantic import BaseModel, Field, model_serializer, model_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 
 from fastapi import HTTPException, status
+
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 
@@ -141,6 +143,14 @@ class PolicyDecisionRequest(BaseModel):
     confidence: Optional[ConfidenceMetrics] = Field(
         None, description="Caller confidence metrics aligned with Soloing spec"
     )
+
+    @field_validator("instrument")
+    @classmethod
+    def _validate_instrument(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market instruments are supported.")
+        return normalized
 
 
 class PolicyDecisionResponse(BaseModel):

--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -65,6 +65,7 @@ from shared.simulation import (
     sim_broker as simulation_broker,
     sim_mode_state,
 )
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 
@@ -125,6 +126,14 @@ class OMSPlaceRequest(BaseModel):
         description="Observed mid price immediately before order placement",
 
     )
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
 
     @field_validator("side")
     @classmethod

--- a/services/oms/reconcile.py
+++ b/services/oms/reconcile.py
@@ -59,7 +59,14 @@ class ReconcileLogStore:
                 )
             return
 
-        self._ensure_schema()
+        try:
+            self._ensure_schema()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.warning(
+                "ReconcileLogStore unable to connect to Timescale; operating in-memory",
+                extra={"error": str(exc)},
+            )
+            self._dsn = None
 
     def _ensure_schema(self) -> None:
         assert self._dsn is not None

--- a/services/policy/policy_service.py
+++ b/services/policy/policy_service.py
@@ -294,6 +294,7 @@ from services.common.security import ADMIN_ACCOUNTS, require_admin_account
 from services.policy.trade_intensity_controller import (
     controller as trade_intensity_controller,
 )
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 class PolicyDecisionRequest(BaseModel):
@@ -319,6 +320,14 @@ class PolicyDecisionRequest(BaseModel):
         if value not in ADMIN_ACCOUNTS:
             raise ValueError("Account must be an authorized admin.")
         return value
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market instruments are supported.")
+        return normalized
 
 
 class PolicyIntent(BaseModel):

--- a/shared/spot.py
+++ b/shared/spot.py
@@ -1,0 +1,96 @@
+"""Utilities for validating and normalising spot trading instruments."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Optional, Sequence, Set
+
+__all__ = [
+    "normalize_spot_symbol",
+    "is_spot_symbol",
+    "filter_spot_symbols",
+]
+
+
+_SPOT_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,}-[A-Z0-9]{2,}$")
+_NON_SPOT_KEYWORDS: Sequence[str] = ("PERP", "FUT", "FUTURE", "MARGIN", "SWAP", "OPTION", "DERIV")
+_LEVERAGE_SUFFIXES: Sequence[str] = ("UP", "DOWN")
+_LEVERAGE_PATTERN = re.compile(r"\d+(?:X|L|S)$")
+
+
+def normalize_spot_symbol(symbol: object) -> str:
+    """Return a canonical, uppercase representation of a spot symbol.
+
+    The function accepts inputs such as ``"btc-usd"`` or ``"BTC/USD"`` and returns
+    ``"BTC-USD"``.  Invalid values result in an empty string to simplify validation
+    flows that treat falsy results as missing data.
+    """
+
+    if symbol is None:
+        return ""
+
+    candidate = str(symbol).strip()
+    if not candidate:
+        return ""
+
+    normalized = candidate.replace("/", "-").replace("_", "-").upper()
+    return normalized
+
+
+def is_spot_symbol(symbol: object) -> bool:
+    """Return ``True`` when *symbol* represents a spot market trading pair."""
+
+    normalized = normalize_spot_symbol(symbol)
+    if not normalized:
+        return False
+
+    if any(keyword in normalized for keyword in _NON_SPOT_KEYWORDS):
+        return False
+
+    if not _SPOT_PAIR_PATTERN.match(normalized):
+        return False
+
+    base, _ = normalized.split("-", maxsplit=1)
+
+    if any(base.endswith(suffix) for suffix in _LEVERAGE_SUFFIXES):
+        return False
+
+    if _LEVERAGE_PATTERN.search(base):
+        return False
+
+    return True
+
+
+def filter_spot_symbols(
+    symbols: Iterable[object], *, logger: Optional[logging.Logger] = None
+) -> List[str]:
+    """Return the subset of *symbols* that represent spot market pairs.
+
+    Symbols are normalised via :func:`normalize_spot_symbol` and deduplicated while
+    preserving input order.  Any non-spot instruments are optionally logged via the
+    supplied ``logger``.
+    """
+
+    filtered: List[str] = []
+    seen: Set[str] = set()
+
+    for symbol in symbols:
+        normalized = normalize_spot_symbol(symbol)
+        if not normalized:
+            continue
+
+        if not is_spot_symbol(normalized):
+            if logger is not None:
+                logger.warning(
+                    "Ignoring non-spot instrument '%s' in spot-only context", symbol
+                )
+            continue
+
+        if normalized in seen:
+            continue
+
+        filtered.append(normalized)
+        seen.add(normalized)
+
+    return filtered

--- a/tests/policy/test_endpoints.py
+++ b/tests/policy/test_endpoints.py
@@ -82,3 +82,15 @@ def test_decide_policy_mismatched_account(client: TestClient) -> None:
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Account mismatch between header and payload."
+
+
+def test_decide_policy_rejects_non_spot_instrument(client: TestClient) -> None:
+    payload = _decision_payload("company")
+    payload["instrument"] = "BTC-PERP"
+
+    response = client.post("/policy/decide", json=payload, headers={"X-Account-ID": "company"})
+
+    assert response.status_code == 422
+    detail = response.json()
+    errors = detail.get("detail") if isinstance(detail, dict) else []
+    assert any("Only spot market instruments" in str(item) for item in errors)

--- a/tests/risk/test_risk_service_endpoints.py
+++ b/tests/risk/test_risk_service_endpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import sys
 import types
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
@@ -50,6 +51,7 @@ if "prometheus_client" not in sys.modules:
 
 pytest.importorskip("services.common.security")
 
+import risk_service as risk_module
 from risk_service import app, require_admin_account
 from services.common import security
 from tests.helpers.authentication import override_admin_auth
@@ -68,19 +70,27 @@ def allow_stub_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(name="client")
 def client_fixture() -> TestClient:
-    return TestClient(app)
+    with TestClient(app) as client:
+        snapshot = risk_module.UniverseSnapshot(
+            symbols={"BTC-USD", "ETH-USD", "SOL-USD"},
+            generated_at=datetime.now(timezone.utc),
+            thresholds={},
+        )
+        risk_module._UNIVERSE_CACHE_SNAPSHOT = snapshot
+        risk_module._UNIVERSE_CACHE_EXPIRY = datetime.now(timezone.utc) + timedelta(hours=1)
+        yield client
 
 
 @pytest.fixture(name="risk_payload")
 def risk_payload_fixture() -> dict[str, object]:
     return {
-        "account_id": "ACC-DEFAULT",
+        "account_id": "company",
         "intent": {
             "policy_id": "policy-1",
-            "instrument_id": "AAPL",
+            "instrument_id": "BTC-USD",
             "side": "buy",
-            "quantity": 10.0,
-            "price": 150.0,
+            "quantity": 0.5,
+            "price": 30000.0,
         },
         "portfolio_state": {
             "net_asset_value": 1_000_000.0,
@@ -101,15 +111,15 @@ def test_validate_requires_admin_header(client: TestClient, risk_payload: dict[s
 
 def test_validate_rejects_account_mismatch(client: TestClient, risk_payload: dict[str, object]) -> None:
     payload = deepcopy(risk_payload)
-    payload["account_id"] = "ACC-AGGR"
+    payload["account_id"] = "director-1"
 
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.post(
             "/risk/validate",
             json=payload,
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -127,14 +137,14 @@ def test_limits_requires_admin_header(client: TestClient) -> None:
 
 def test_limits_returns_account_data(client: TestClient) -> None:
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.get(
             "/risk/limits",
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["account_id"] == "ACC-DEFAULT"
+    assert body["account_id"] == "company"
     assert "limits" in body and "usage" in body


### PR DESCRIPTION
## Summary
- add shared spot symbol utilities and apply them to risk whitelists, universe ingestion, and evaluation flows
- enforce spot-only symbols in policy and OMS request schemas while normalizing incoming payloads
- fall back to in-memory OMS reconciliation logging when Timescale is unavailable and extend endpoint tests to cover spot rejections

## Testing
- pytest tests/unit/services/test_risk_service.py tests/risk/test_risk_service_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c61e227c83218dc56ce891b8cb5a