### PR TITLE
Filter CVaR forecast positions to spot markets

### DIFF
--- a/common/schemas/intents.py
+++ b/common/schemas/intents.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 class Intent(BaseModel):
@@ -110,6 +112,14 @@ class Order(BaseModel):
     )
     ts: datetime = Field(..., description="Timestamp of the latest status change")
 
+    @field_validator("symbol", mode="before")
+    @classmethod
+    def _ensure_spot_symbol(cls, value: object) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not normalized or not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
+
 
 class Fill(BaseModel):
     """Details of an execution fill received from an exchange."""
@@ -146,6 +156,14 @@ class Fill(BaseModel):
         description="Indicates maker or taker side of the fill",
     )
     ts: datetime = Field(..., description="Timestamp when the fill occurred")
+
+    @field_validator("symbol", mode="before")
+    @classmethod
+    def _ensure_spot_symbol(cls, value: object) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not normalized or not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
 
 
 class RiskResult(BaseModel):

--- a/health_probe.py
+++ b/health_probe.py
@@ -22,7 +22,7 @@ from prometheus_client import Gauge, start_http_server
 
 
 DEFAULT_ACCOUNT_ID = "ACC-DEFAULT"
-DEFAULT_SYMBOL = "AAPL"
+DEFAULT_SYMBOL = "BTC-USD"
 DEFAULT_INTERVAL = 300.0
 DEFAULT_ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093")
 DEFAULT_WS_BOOK_HEALTH_URL = os.getenv("WS_BOOK_HEALTH_URL")

--- a/hedging_service.py
+++ b/hedging_service.py
@@ -34,6 +34,7 @@ from typing import Any, Awaitable, Callable, Iterable, List, Mapping, Optional, 
 from services.common.adapters import TimescaleAdapter
 from services.common.precision import _parse_asset_pairs
 from services.oms.kraken_rest import KrakenRESTClient, KrakenRESTError
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 logger = logging.getLogger(__name__)
@@ -363,7 +364,7 @@ class HedgeConfig:
     """Risk thresholds and hedge sizing configuration."""
 
     account_id: str
-    hedge_symbol: str = "USDUSDT"
+    hedge_symbol: str = "USDT-USD"
     base_allocation_usd: float = 50_000.0
     max_allocation_usd: float = 250_000.0
     atr_threshold: float = 15.0
@@ -386,6 +387,11 @@ class HedgeConfig:
             raise ValueError("volatility thresholds must be positive")
         if self.max_drawdown_pct <= 0:
             raise ValueError("max_drawdown_pct must be positive")
+
+        normalized_symbol = normalize_spot_symbol(self.hedge_symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            raise ValueError("hedge_symbol must be a spot market pair")
+        self.hedge_symbol = normalized_symbol
 
 
 @dataclass

--- a/oms_service.py
+++ b/oms_service.py
@@ -38,6 +38,7 @@ from services.oms.rate_limit_guard import RateLimitGuard, rate_limit_guard as sh
 from services.risk.stablecoin_monitor import format_depeg_alert, get_global_monitor
 
 from shared.graceful_shutdown import flush_logging_handlers, setup_graceful_shutdown
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 from services.oms.oms_service import (  # type: ignore  # pragma: no cover - shared helpers
     _PrecisionValidator,
     _normalize_symbol,
@@ -192,6 +193,14 @@ class PlaceOrderRequest(BaseModel):
         ge=Decimal("0"),
         description="Slippage estimate in basis points provided by the caller",
     )
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
 
     @field_validator("side")
     @classmethod

--- a/sentiment_ingest.py
+++ b/sentiment_ingest.py
@@ -51,6 +51,8 @@ try:  # pragma: no cover - optional dependency for HTTP clients
 except Exception:  # pragma: no cover - keep runtime light during tests
     httpx = None  # type: ignore
 
+from shared.spot import filter_spot_symbols, is_spot_symbol, normalize_spot_symbol
+
 def _resolve_security_dependency() -> Callable[..., str]:
     module_names = ("services.common.security", "aether.services.common.security")
     for module_name in module_names:
@@ -436,8 +438,14 @@ class SentimentRepository:
             raise
 
     async def insert(self, observation: SocialPost, label: str) -> None:
+        normalized_symbol = normalize_spot_symbol(observation.symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            raise ValueError(
+                f"SentimentRepository only accepts spot symbols (got {observation.symbol!r})"
+            )
+
         values = {
-            "symbol": observation.symbol.upper(),
+            "symbol": normalized_symbol,
             "score": label,
             "source": observation.source,
             "ts": observation.created_at.astimezone(dt.timezone.utc),
@@ -449,6 +457,10 @@ class SentimentRepository:
             connection.execute(insert(_SENTIMENT_TABLE).values(**values))
 
     async def latest(self, symbol: str) -> Optional[Tuple[str, str, str, dt.datetime]]:
+        normalized_symbol = normalize_spot_symbol(symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            raise ValueError(f"Symbol '{symbol}' is not a supported spot market")
+
         stmt = (
             select(
                 _SENTIMENT_TABLE.c.symbol,
@@ -456,7 +468,7 @@ class SentimentRepository:
                 _SENTIMENT_TABLE.c.source,
                 _SENTIMENT_TABLE.c.ts,
             )
-            .where(func.upper(_SENTIMENT_TABLE.c.symbol) == symbol.upper())
+            .where(_SENTIMENT_TABLE.c.symbol == normalized_symbol)
             .order_by(_SENTIMENT_TABLE.c.ts.desc())
             .limit(1)
         )
@@ -500,7 +512,12 @@ class FeastSentimentWriter:
             LOGGER.debug("Unable to access Feast store for sentiment updates")
             return
 
-        instrument_store = store.setdefault(symbol.upper(), {})
+        normalized_symbol = normalize_spot_symbol(symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            LOGGER.debug("Skipping non-spot sentiment update for symbol %s", symbol)
+            return
+
+        instrument_store = store.setdefault(normalized_symbol, {})
         sentiment_payload = instrument_store.setdefault("sentiment", {})
         sentiment_payload.update({
             "label": label,
@@ -526,7 +543,11 @@ class SentimentIngestService:
         self._feast_writer = feast_writer
 
     async def ingest_symbol(self, symbol: str) -> None:
-        tasks = [source.fetch(symbol) for source in self._sources]
+        normalized_symbol = normalize_spot_symbol(symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            raise ValueError(f"Symbol '{symbol}' is not a supported spot market")
+
+        tasks = [source.fetch(normalized_symbol) for source in self._sources]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         for source, result in zip(self._sources, results):
@@ -534,10 +555,19 @@ class SentimentIngestService:
                 LOGGER.exception("Source %s failed for symbol %s", source.name, symbol)
                 continue
             for post in result:
+                post_symbol = normalize_spot_symbol(getattr(post, "symbol", "") or normalized_symbol)
+                if not post_symbol or not is_spot_symbol(post_symbol):
+                    LOGGER.debug(
+                        "Skipping non-spot sentiment observation from %s: %s",
+                        source.name,
+                        getattr(post, "symbol", ""),
+                    )
+                    continue
+                canonical_post = dataclasses.replace(post, symbol=post_symbol)
                 label, score = self._model.classify(post.text)
-                await self._repository.insert(post, label)
+                await self._repository.insert(canonical_post, label)
                 if self._feast_writer is not None:
-                    self._feast_writer.write(post.symbol, label, score)
+                    self._feast_writer.write(post_symbol, label, score)
 
     async def ingest_many(self, symbols: Sequence[str]) -> None:
         for symbol in symbols:
@@ -566,15 +596,40 @@ class SentimentAPI:
             symbol: str = Query(..., description="Symbol ticker, e.g. BTC-USD"),
             _: str = Depends(require_admin_account),
         ) -> SentimentResponse:
-            record = await self._repository.latest(symbol)
+            normalized_symbol = normalize_spot_symbol(symbol)
+            if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Symbol '{symbol}' is not a supported spot market",
+                )
+            try:
+                record = await self._repository.latest(normalized_symbol)
+            except ValueError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
             if record is None:
-                raise HTTPException(status_code=404, detail=f"No sentiment found for {symbol.upper()}")
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No sentiment found for {normalized_symbol}",
+                )
             return SentimentResponse(symbol=record[0], score=record[1], source=record[2], ts=record[3])
 
         @self.router.post("/refresh")
         async def refresh(symbols: List[str], _: str = Depends(require_admin_account)) -> dict[str, str]:
-            await self._service.ingest_many(symbols)
-            return {"status": "ok", "symbols": ",".join(symbols)}
+            normalized_symbols: List[str] = []
+            for raw_symbol in symbols:
+                normalized_symbol = normalize_spot_symbol(raw_symbol)
+                if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"Symbol '{raw_symbol}' is not a supported spot market",
+                    )
+                normalized_symbols.append(normalized_symbol)
+
+            try:
+                await self._service.ingest_many(normalized_symbols)
+            except ValueError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            return {"status": "ok", "symbols": ",".join(normalized_symbols)}
 
 
 def bootstrap_service(
@@ -628,7 +683,11 @@ def create_app(
 
 async def run_once(symbols: Sequence[str], *, database_url: Path | str | None = None) -> None:
     service, _ = bootstrap_service(database_url=database_url)
-    await service.ingest_many(symbols)
+    spot_symbols = filter_spot_symbols(symbols, logger=LOGGER)
+    if not spot_symbols:
+        LOGGER.warning("No spot symbols supplied for sentiment ingestion; skipping run")
+        return
+    await service.ingest_many(spot_symbols)
 
 
 def _default_symbols() -> List[str]:

--- a/services/common/config.py
+++ b/services/common/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from functools import lru_cache

--- a/services/oms/oms_service.py
+++ b/services/oms/oms_service.py
@@ -65,6 +65,7 @@ from shared.simulation import (
     sim_broker as simulation_broker,
     sim_mode_state,
 )
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 
@@ -125,6 +126,14 @@ class OMSPlaceRequest(BaseModel):
         description="Observed mid price immediately before order placement",
 
     )
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market symbols are supported.")
+        return normalized
 
     @field_validator("side")
     @classmethod

--- a/services/oms/reconcile.py
+++ b/services/oms/reconcile.py
@@ -59,7 +59,14 @@ class ReconcileLogStore:
                 )
             return
 
-        self._ensure_schema()
+        try:
+            self._ensure_schema()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.warning(
+                "ReconcileLogStore unable to connect to Timescale; operating in-memory",
+                extra={"error": str(exc)},
+            )
+            self._dsn = None
 
     def _ensure_schema(self) -> None:
         assert self._dsn is not None

--- a/services/oms/sim_broker.py
+++ b/services/oms/sim_broker.py
@@ -33,6 +33,7 @@ from config.simulation import SimulationConfig, get_simulation_config
 from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter
 from services.common.config import get_timescale_session
 from shared.async_utils import dispatch_async
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 try:  # pragma: no cover - optional dependency during CI
     import psycopg
@@ -114,6 +115,10 @@ class SimBroker:
     ) -> Dict[str, Any]:
         """Place a simulated order and return the resulting execution summary."""
 
+        normalized_symbol = normalize_spot_symbol(symbol)
+        if not normalized_symbol or not is_spot_symbol(normalized_symbol):
+            raise ValueError(f"SimBroker only supports spot instruments; received {symbol!r}")
+
         normalized_side = self._normalize_side(side)
         normalized_type = self._normalize_type(order_type)
 
@@ -123,7 +128,7 @@ class SimBroker:
         order = SimulatedOrder(
             order_id=str(uuid4()),
             client_order_id=client_order_id,
-            symbol=symbol,
+            symbol=normalized_symbol,
             side=normalized_side,
             order_type=normalized_type,
             quantity=quantity_decimal,

--- a/services/policy/policy_service.py
+++ b/services/policy/policy_service.py
@@ -294,6 +294,7 @@ from services.common.security import ADMIN_ACCOUNTS, require_admin_account
 from services.policy.trade_intensity_controller import (
     controller as trade_intensity_controller,
 )
+from shared.spot import is_spot_symbol, normalize_spot_symbol
 
 
 class PolicyDecisionRequest(BaseModel):
@@ -319,6 +320,14 @@ class PolicyDecisionRequest(BaseModel):
         if value not in ADMIN_ACCOUNTS:
             raise ValueError("Account must be an authorized admin.")
         return value
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str) -> str:
+        normalized = normalize_spot_symbol(value)
+        if not is_spot_symbol(normalized):
+            raise ValueError("Only spot market instruments are supported.")
+        return normalized
 
 
 class PolicyIntent(BaseModel):

--- a/shared/spot.py
+++ b/shared/spot.py
@@ -1,0 +1,96 @@
+"""Utilities for validating and normalising spot trading instruments."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Optional, Sequence, Set
+
+__all__ = [
+    "normalize_spot_symbol",
+    "is_spot_symbol",
+    "filter_spot_symbols",
+]
+
+
+_SPOT_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,}-[A-Z0-9]{2,}$")
+_NON_SPOT_KEYWORDS: Sequence[str] = ("PERP", "FUT", "FUTURE", "MARGIN", "SWAP", "OPTION", "DERIV")
+_LEVERAGE_SUFFIXES: Sequence[str] = ("UP", "DOWN")
+_LEVERAGE_PATTERN = re.compile(r"\d+(?:X|L|S)$")
+
+
+def normalize_spot_symbol(symbol: object) -> str:
+    """Return a canonical, uppercase representation of a spot symbol.
+
+    The function accepts inputs such as ``"btc-usd"`` or ``"BTC/USD"`` and returns
+    ``"BTC-USD"``.  Invalid values result in an empty string to simplify validation
+    flows that treat falsy results as missing data.
+    """
+
+    if symbol is None:
+        return ""
+
+    candidate = str(symbol).strip()
+    if not candidate:
+        return ""
+
+    normalized = candidate.replace("/", "-").replace("_", "-").upper()
+    return normalized
+
+
+def is_spot_symbol(symbol: object) -> bool:
+    """Return ``True`` when *symbol* represents a spot market trading pair."""
+
+    normalized = normalize_spot_symbol(symbol)
+    if not normalized:
+        return False
+
+    if any(keyword in normalized for keyword in _NON_SPOT_KEYWORDS):
+        return False
+
+    if not _SPOT_PAIR_PATTERN.match(normalized):
+        return False
+
+    base, _ = normalized.split("-", maxsplit=1)
+
+    if any(base.endswith(suffix) for suffix in _LEVERAGE_SUFFIXES):
+        return False
+
+    if _LEVERAGE_PATTERN.search(base):
+        return False
+
+    return True
+
+
+def filter_spot_symbols(
+    symbols: Iterable[object], *, logger: Optional[logging.Logger] = None
+) -> List[str]:
+    """Return the subset of *symbols* that represent spot market pairs.
+
+    Symbols are normalised via :func:`normalize_spot_symbol` and deduplicated while
+    preserving input order.  Any non-spot instruments are optionally logged via the
+    supplied ``logger``.
+    """
+
+    filtered: List[str] = []
+    seen: Set[str] = set()
+
+    for symbol in symbols:
+        normalized = normalize_spot_symbol(symbol)
+        if not normalized:
+            continue
+
+        if not is_spot_symbol(normalized):
+            if logger is not None:
+                logger.warning(
+                    "Ignoring non-spot instrument '%s' in spot-only context", symbol
+                )
+            continue
+
+        if normalized in seen:
+            continue
+
+        filtered.append(normalized)
+        seen.add(normalized)
+
+    return filtered

--- a/tests/common/test_intent_schemas.py
+++ b/tests/common/test_intent_schemas.py
@@ -1,0 +1,95 @@
+"""Tests for shared intent schemas enforcing spot-only instruments."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from common.schemas.intents import Fill, Order
+from services.common.schemas import PortfolioState
+
+
+def _timestamp() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def test_order_symbol_normalized_to_spot_pair() -> None:
+    order = Order(
+        client_id="client-spot",
+        account_id="acct-1",
+        symbol="eth/usdt",
+        status="NEW",
+        ts=_timestamp(),
+    )
+
+    assert order.symbol == "ETH-USDT"
+
+
+def test_order_rejects_non_spot_symbol() -> None:
+    with pytest.raises(ValidationError, match="spot market symbols"):
+        Order(
+            client_id="client-deriv",
+            account_id="acct-2",
+            symbol="BTC-PERP",
+            status="NEW",
+            ts=_timestamp(),
+        )
+
+
+def test_fill_symbol_normalized_to_spot_pair() -> None:
+    fill = Fill(
+        exchange_order_id="ex-1",
+        account_id="acct-1",
+        symbol="btc_usd",
+        qty=1.0,
+        price=25000.0,
+        fee=5.0,
+        liquidity="MAKER",
+        ts=_timestamp(),
+    )
+
+    assert fill.symbol == "BTC-USD"
+
+
+def test_fill_rejects_non_spot_symbol() -> None:
+    with pytest.raises(ValidationError, match="spot market symbols"):
+        Fill(
+            exchange_order_id="ex-deriv",
+            account_id="acct-1",
+            symbol="ETH-OPTION",
+            qty=0.5,
+            price=1800.0,
+            fee=1.0,
+            liquidity="TAKER",
+            ts=_timestamp(),
+        )
+
+
+def test_portfolio_state_normalizes_spot_exposures() -> None:
+    state = PortfolioState(
+        nav=1_000_000.0,
+        loss_to_date=0.0,
+        fee_to_date=0.0,
+        instrument_exposure={
+            "eth/usd": 125_000.0,
+            "ETH-USD": 5_000.0,
+            "btc-usd": 250_000.0,
+        },
+    )
+
+    assert state.instrument_exposure == {
+        "ETH-USD": pytest.approx(130_000.0),
+        "BTC-USD": pytest.approx(250_000.0),
+    }
+
+
+def test_portfolio_state_rejects_derivative_exposures() -> None:
+    with pytest.raises(ValidationError, match="spot market symbols"):
+        PortfolioState(
+            nav=1_000_000.0,
+            loss_to_date=0.0,
+            fee_to_date=0.0,
+            instrument_exposure={"BTC-PERP": 125_000.0},
+        )

--- a/tests/ml/policy/test_fallback_policy.py
+++ b/tests/ml/policy/test_fallback_policy.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ml.policy.fallback_policy import FallbackPolicy
+from services.common.schemas import PolicyDecisionRequest
+from tests.factories import policy_decision_request
+
+
+def test_fallback_policy_filters_non_spot_symbols() -> None:
+    policy = FallbackPolicy(top_symbols=["btc-usd", "ETH-PERP", "eth-usd"])
+
+    assert policy.top_symbols == ("BTC-USD", "ETH-USD")
+
+
+def test_fallback_policy_requires_spot_symbols() -> None:
+    with pytest.raises(ValueError, match="requires at least one top liquidity spot symbol"):
+        FallbackPolicy(top_symbols=["btc-perp", "ethdown-usd"])
+
+
+def test_fallback_policy_rejects_non_spot_request() -> None:
+    policy = FallbackPolicy(top_symbols=["BTC-USD"])
+    base_request = policy_decision_request()
+
+    non_spot_request = PolicyDecisionRequest.model_construct(
+        account_id=base_request.account_id,
+        order_id=base_request.order_id,
+        instrument="BTC-PERP",
+        side=base_request.side,
+        quantity=base_request.quantity,
+        price=base_request.price,
+        fee=base_request.fee,
+        features=list(base_request.features),
+        book_snapshot=base_request.book_snapshot,
+        state=base_request.state,
+        expected_edge_bps=base_request.expected_edge_bps,
+        slippage_bps=base_request.slippage_bps,
+        take_profit_bps=base_request.take_profit_bps,
+        stop_loss_bps=base_request.stop_loss_bps,
+        confidence=base_request.confidence,
+    )
+
+    decision = policy.evaluate(
+        request=non_spot_request,
+        book_snapshot=base_request.book_snapshot,
+        reason="fallback engaged",
+    )
+
+    assert decision.response.approved is False
+    assert decision.response.selected_action == "abstain"
+    assert decision.response.reason == "Instrument is not a supported spot market pair"

--- a/tests/policy/test_endpoints.py
+++ b/tests/policy/test_endpoints.py
@@ -82,3 +82,15 @@ def test_decide_policy_mismatched_account(client: TestClient) -> None:
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Account mismatch between header and payload."
+
+
+def test_decide_policy_rejects_non_spot_instrument(client: TestClient) -> None:
+    payload = _decision_payload("company")
+    payload["instrument"] = "BTC-PERP"
+
+    response = client.post("/policy/decide", json=payload, headers={"X-Account-ID": "company"})
+
+    assert response.status_code == 422
+    detail = response.json()
+    errors = detail.get("detail") if isinstance(detail, dict) else []
+    assert any("Only spot market instruments" in str(item) for item in errors)

--- a/tests/risk/test_circuit_breakers.py
+++ b/tests/risk/test_circuit_breakers.py
@@ -2,7 +2,81 @@ from __future__ import annotations
 
 from typing import Generator
 
+import atexit
+from copy import deepcopy
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
+
+from tests.helpers.risk import MANAGED_RISK_DSN, patch_sqlalchemy_for_risk
+
+from services.common import adapters as adapters_module
+
+os.environ.setdefault("COMPLIANCE_ALLOW_SQLITE_FOR_TESTS", "1")
+os.environ.setdefault("COMPLIANCE_DATABASE_URL", MANAGED_RISK_DSN)
+os.environ.setdefault("RISK_DATABASE_URL", MANAGED_RISK_DSN)
+os.environ.setdefault("ESG_DATABASE_URL", MANAGED_RISK_DSN)
+
+_restore_sqlalchemy = patch_sqlalchemy_for_risk(
+    Path(tempfile.gettempdir()) / "circuit-breaker-tests.db"
+)
+atexit.register(_restore_sqlalchemy)
+
+
+class _StubTimescaleAdapter:
+    _configs: dict[str, dict] = {}
+    _events: dict[str, list] = {}
+    _audit_logs: list[dict] = []
+
+    def __init__(self, account_id: str, *_, **__) -> None:
+        self.account_id = account_id
+        self._configs.setdefault(account_id, {})
+        self._events.setdefault(account_id, [])
+
+    @classmethod
+    def reset(cls, account_id: str | None = None) -> None:
+        if account_id is None:
+            cls._configs.clear()
+            cls._events.clear()
+            cls._audit_logs.clear()
+            return
+        cls._configs.pop(account_id, None)
+        cls._events.pop(account_id, None)
+
+    def load_risk_config(self) -> dict:
+        config = self._configs.setdefault(
+            self.account_id, {"circuit_breakers": {}, "safe_mode": False}
+        )
+        return deepcopy(config)
+
+    def save_risk_config(self, config: dict) -> None:
+        self._configs[self.account_id] = deepcopy(config)
+
+    def record_event(self, event_type: str, payload: dict) -> None:
+        self._events[self.account_id].append((event_type, deepcopy(payload)))
+
+    def set_safe_mode(self, *, engaged: bool, reason: str, actor: str) -> None:
+        config = self._configs.setdefault(
+            self.account_id, {"circuit_breakers": {}, "safe_mode": False}
+        )
+        config["safe_mode"] = bool(engaged)
+
+    def record_audit_log(self, record: dict) -> None:  # pragma: no cover - compatibility stub
+        self._events[self.account_id].append(("audit", deepcopy(record)))
+        self._audit_logs.append(deepcopy(record))
+
+    def audit_logs(self) -> list[dict]:  # pragma: no cover - compatibility stub
+        return list(self._audit_logs)
+
+    @classmethod
+    async def flush_event_buffers(cls) -> None:  # pragma: no cover - compatibility stub
+        return None
+
+
+adapters_module.TimescaleAdapter = _StubTimescaleAdapter  # type: ignore[attr-defined]
+TimescaleAdapter = _StubTimescaleAdapter  # type: ignore[assignment]
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
@@ -54,7 +128,8 @@ def test_circuit_breaker_blocks_on_spread_exceedance() -> None:
     decision = monitor.evaluate(request)
 
     assert decision is not None
-    assert symbol in decision.reason
+    assert decision.symbol == symbol
+    assert "Spread" in decision.reason
     status = monitor.status()
     assert status and isinstance(status[0], CircuitBreakerSymbolStatus)
 
@@ -121,4 +196,31 @@ def test_circuit_breaker_triggers_safe_mode_when_configured() -> None:
     assert decision.safe_mode_engaged is True
     config = TimescaleAdapter(account_id=account).load_risk_config()
     assert config["safe_mode"] is True
+
+
+def test_circuit_breaker_config_rejects_derivative_symbols() -> None:
+    store = CircuitBreakerConfigStore("company")
+    with pytest.raises(ValueError):
+        store.upsert(
+            "BTC-PERP",
+            max_spread_bps=5.0,
+            max_volatility=0.001,
+            trigger_safe_mode=False,
+            actor_id="director-3",
+        )
+
+
+def test_circuit_breaker_ignores_non_spot_quotes_and_requests() -> None:
+    account = "company"
+    monitor = _configure_thresholds(account, "ETH-USD")
+
+    monitor.record_quote("ETH-PERP", bid=100.0, ask=101.0)
+    assert "ETH-PERP" not in monitor._quotes  # type: ignore[attr-defined]
+
+    request = make_request(account_id=account, instrument="ETH-USD", spread_bps=10.0)
+    request.instrument = "ETH-PERP"
+    request.intent.policy_decision.request.instrument = "ETH-PERP"
+    monitor.observe_request(request)
+    assert monitor.evaluate(request) is None
+    assert monitor.status() == []
 

--- a/tests/risk/test_cvar_forecast_spot.py
+++ b/tests/risk/test_cvar_forecast_spot.py
@@ -1,0 +1,82 @@
+"""Regression tests ensuring CVaR forecasting enforces spot-only inputs."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from services.risk.cvar_forecast import CVaRMonteCarloForecaster
+
+
+class _StubTimescaleAdapter:
+    def __init__(self) -> None:
+        self.recorded: list[dict[str, object]] = []
+
+    def load_risk_config(self) -> dict[str, float]:
+        return {"nav": 250_000.0, "loss_cap": 10_000.0}
+
+    def open_positions(self) -> dict[str, float]:
+        return {
+            "btc-usd": 100_000.0,
+            "BTC-USD": 25_000.0,
+            "ETH/USD": 50_000.0,
+            "ETH-PERP": 12_500.0,
+            "ADAUP-USDT": 5_000.0,
+        }
+
+    def record_cvar_result(
+        self,
+        *,
+        horizon: str,
+        var95: float,
+        cvar95: float,
+        prob_cap_hit: float,
+        timestamp,
+    ) -> None:
+        self.recorded.append(
+            {
+                "horizon": horizon,
+                "var95": var95,
+                "cvar95": cvar95,
+                "prob_cap_hit": prob_cap_hit,
+                "timestamp": timestamp,
+            }
+        )
+
+
+class _StubFeatureStore:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def fetch_online_features(self, instrument: str) -> dict[str, dict[str, float]]:
+        self.queries.append(instrument)
+        return {"state": {"volatility": 0.1}}
+
+
+class _DeterministicForecaster(CVaRMonteCarloForecaster):
+    def __init__(self, timescale: _StubTimescaleAdapter, feature_store: _StubFeatureStore) -> None:
+        self.account_id = "company"
+        self.timescale = timescale
+        self.feature_store = feature_store
+        self.simulations = 16
+        self._rng = _DeterministicRNG()
+
+
+class _DeterministicRNG:
+    def normal(self, *, loc: float, scale: float, size: int):  # type: ignore[override]
+        return np.zeros(size, dtype=float)
+
+
+def test_cvar_forecast_filters_non_spot_positions(caplog) -> None:
+    timescale = _StubTimescaleAdapter()
+    feature_store = _StubFeatureStore()
+    forecaster = _DeterministicForecaster(timescale, feature_store)
+
+    caplog.set_level(logging.WARNING)
+    response = forecaster.forecast("1d")
+
+    assert response.positions == {"BTC-USD": 125_000.0, "ETH-USD": 50_000.0}
+    assert feature_store.queries == ["BTC-USD", "ETH-USD"]
+    assert timescale.recorded, "CVaR results should be persisted"
+    assert "Ignoring non-spot instruments" in caplog.text

--- a/tests/risk/test_pretrade_sanity.py
+++ b/tests/risk/test_pretrade_sanity.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+from services.risk.pretrade_sanity import (
+    OrderContext,
+    PretradeSanityChecker,
+)
+
+
+def _make_request(symbol: str = "BTC-USD", *, gross_notional: float = 10_000.0):
+    policy_request = SimpleNamespace(instrument=symbol, side="BUY")
+    policy_decision = SimpleNamespace(request=policy_request, response=None)
+    metrics = SimpleNamespace(gross_notional=gross_notional)
+    intent = SimpleNamespace(
+        policy_decision=policy_decision,
+        metrics=metrics,
+        book_snapshot=None,
+    )
+    return SimpleNamespace(
+        account_id="company",
+        instrument=symbol,
+        gross_notional=gross_notional,
+        spread_bps=None,
+        intent=intent,
+    )
+
+
+def test_pretrade_check_rejects_non_spot_symbol():
+    checker = PretradeSanityChecker()
+    context = OrderContext(
+        account_id="company",
+        symbol="BTC-PERP",
+        side="BUY",
+        notional=5_000.0,
+    )
+
+    decision = checker.check(context)
+
+    assert decision.permitted is False
+    assert decision.action == "reject"
+    assert any("spot trading" in reason for reason in decision.reasons)
+
+    snapshot = checker.status("company")
+    assert snapshot.counts.get(PretradeSanityChecker.SPOT_ELIGIBILITY, 0) == 1
+    assert snapshot.recent_failures[0].symbol == "BTC-PERP"
+
+
+def test_pretrade_evaluate_rejects_non_spot_validation_request():
+    checker = PretradeSanityChecker()
+    request = _make_request("ETH-PERP", gross_notional=25_000.0)
+
+    decision = checker.evaluate_validation_request(request)
+
+    assert decision.permitted is False
+    assert decision.action == "reject"
+    assert any("spot trading" in reason for reason in decision.reasons)
+
+    snapshot = checker.status("company")
+    assert snapshot.counts.get(PretradeSanityChecker.SPOT_ELIGIBILITY, 0) == 1
+    assert snapshot.recent_failures[0].symbol == "ETH-PERP"
+
+
+def test_pretrade_normalizes_spot_symbols():
+    checker = PretradeSanityChecker()
+    context = OrderContext(
+        account_id="company",
+        symbol="eth/usd",
+        side="SELL",
+        notional=1_500.0,
+    )
+
+    decision = checker.check(context)
+
+    assert decision.permitted is True
+    assert decision.action == "proceed"
+    status = checker.status("company")
+    assert PretradeSanityChecker.SPOT_ELIGIBILITY not in status.counts

--- a/tests/risk/test_risk_service_endpoints.py
+++ b/tests/risk/test_risk_service_endpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import sys
 import types
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
@@ -50,6 +51,7 @@ if "prometheus_client" not in sys.modules:
 
 pytest.importorskip("services.common.security")
 
+import risk_service as risk_module
 from risk_service import app, require_admin_account
 from services.common import security
 from tests.helpers.authentication import override_admin_auth
@@ -68,19 +70,27 @@ def allow_stub_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(name="client")
 def client_fixture() -> TestClient:
-    return TestClient(app)
+    with TestClient(app) as client:
+        snapshot = risk_module.UniverseSnapshot(
+            symbols={"BTC-USD", "ETH-USD", "SOL-USD"},
+            generated_at=datetime.now(timezone.utc),
+            thresholds={},
+        )
+        risk_module._UNIVERSE_CACHE_SNAPSHOT = snapshot
+        risk_module._UNIVERSE_CACHE_EXPIRY = datetime.now(timezone.utc) + timedelta(hours=1)
+        yield client
 
 
 @pytest.fixture(name="risk_payload")
 def risk_payload_fixture() -> dict[str, object]:
     return {
-        "account_id": "ACC-DEFAULT",
+        "account_id": "company",
         "intent": {
             "policy_id": "policy-1",
-            "instrument_id": "AAPL",
+            "instrument_id": "BTC-USD",
             "side": "buy",
-            "quantity": 10.0,
-            "price": 150.0,
+            "quantity": 0.5,
+            "price": 30000.0,
         },
         "portfolio_state": {
             "net_asset_value": 1_000_000.0,
@@ -101,15 +111,15 @@ def test_validate_requires_admin_header(client: TestClient, risk_payload: dict[s
 
 def test_validate_rejects_account_mismatch(client: TestClient, risk_payload: dict[str, object]) -> None:
     payload = deepcopy(risk_payload)
-    payload["account_id"] = "ACC-AGGR"
+    payload["account_id"] = "director-1"
 
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.post(
             "/risk/validate",
             json=payload,
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -127,14 +137,14 @@ def test_limits_requires_admin_header(client: TestClient) -> None:
 
 def test_limits_returns_account_data(client: TestClient) -> None:
     with override_admin_auth(
-        client.app, require_admin_account, "ACC-DEFAULT"
+        client.app, require_admin_account, "company"
     ) as headers:
         response = client.get(
             "/risk/limits",
-            headers={**headers, "X-Account-ID": "ACC-DEFAULT"},
+            headers={**headers, "X-Account-ID": "company"},
         )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["account_id"] == "ACC-DEFAULT"
+    assert body["account_id"] == "company"
     assert "limits" in body and "usage" in body

--- a/tests/services/test_cache_warmer.py
+++ b/tests/services/test_cache_warmer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import pytest
+
+from services.core.cache_warmer import CacheWarmer
+
+
+class _StubRedis:
+    def __init__(self, instruments: Iterable[str]):
+        self._instruments: List[str] = list(instruments)
+
+    def approved_instruments(self) -> List[str]:
+        return list(self._instruments)
+
+
+@pytest.mark.asyncio
+async def test_select_instruments_filters_non_spot_pairs() -> None:
+    warmer = CacheWarmer(
+        most_used_instruments=("btc-usd", "ETH-PERP", "sol_usd", ""),
+        max_instruments=10,
+    )
+    redis = _StubRedis(["btc-perp", "ADA-USD", "ETH-USD", "ADA-USD"])
+
+    instruments = warmer._select_instruments(redis)
+
+    assert instruments == ["BTC-USD", "SOL-USD", "ADA-USD", "ETH-USD"]

--- a/tests/services/test_system_health_service.py
+++ b/tests/services/test_system_health_service.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 
 from services.system import health_service
@@ -41,3 +42,34 @@ def test_build_health_snapshot(monkeypatch):
     assert diversification["flags"][0]["constraint"] == "max_cluster_exposure"
     assert diversification["correlation_note"] == "elevated"
     assert snapshot["simulation"] == {"active": True, "reason": "training"}
+
+
+def test_build_health_snapshot_filters_non_spot(monkeypatch, caplog):
+    class _Totals:
+        instrument_exposure = {"btc-usd": 1500.0, "ETH-PERP": 500.0, "eth/usd": 250.0}
+        max_correlation = 0.4
+
+    class _Response:
+        totals = _Totals()
+        breaches = []
+
+    class _Aggregator:
+        correlation_limit = 0.8
+
+        def portfolio_status(self):  # pragma: no cover - simple passthrough
+            return _Response()
+
+    monkeypatch.setattr(health_service, "portfolio_aggregator", _Aggregator())
+    monkeypatch.setattr(health_service, "compute_daily_return_pct", lambda account_id=None: None)
+    monkeypatch.setattr(health_service, "_simulation_status", lambda: {"active": False, "reason": None})
+
+    caplog.set_level(logging.WARNING)
+
+    snapshot = health_service.build_health_snapshot(account_id=None)
+
+    diversification = snapshot["diversification"]
+    assert diversification["top_assets"] == [
+        {"instrument": "BTC-USD", "exposure": 1500.0},
+        {"instrument": "ETH-USD", "exposure": 250.0},
+    ]
+    assert "Dropping non-spot instruments" in caplog.text

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -387,6 +387,13 @@ async def test_policy_preserves_sub_satoshi_precision() -> None:
     assert Decimal(str(snapped_qty)) == Decimal("0.12345679")
 
 
+def test_get_regime_rejects_non_spot_symbol(client: TestClient) -> None:
+    response = client.get("/policy/regime", params={"symbol": "ETH-PERP"})
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["detail"] == "Only spot market instruments are supported."
+
+
 def test_policy_decide_returns_503_when_precision_unavailable(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:

--- a/tests/unit/test_exchange_adapter.py
+++ b/tests/unit/test_exchange_adapter.py
@@ -52,7 +52,7 @@ async def test_place_order_includes_authorization_header(monkeypatch: pytest.Mon
     manager = _StubSessionManager()
     adapter = exchange_adapter.KrakenAdapter(primary_url="http://oms", session_manager=manager)
 
-    result = await adapter.place_order("alpha", {"order": "payload"})
+    result = await adapter.place_order("alpha", {"order": "payload", "symbol": "eth/usd"})
 
     assert result == {"status": "ok"}
     assert manager.calls == ["alpha"]
@@ -63,6 +63,15 @@ async def test_place_order_includes_authorization_header(monkeypatch: pytest.Mon
     assert headers["Authorization"] == "Bearer session-token"
     assert headers["X-Account-ID"] == "alpha"
     assert "X-Request-ID" in headers
+    assert payload["symbol"] == "ETH-USD"
+
+
+@pytest.mark.asyncio
+async def test_place_order_rejects_non_spot_symbol() -> None:
+    adapter = exchange_adapter.KrakenAdapter(primary_url="http://oms")
+
+    with pytest.raises(ValueError, match="spot market"):
+        await adapter.place_order("alpha", {"symbol": "BTC-PERP"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hedging_service.py
+++ b/tests/unit/test_hedging_service.py
@@ -45,7 +45,7 @@ class _StubTimescale:
 def hedging_config() -> hs.HedgeConfig:
     return hs.HedgeConfig(
         account_id="acct-1",
-        hedge_symbol="ETHBTC",
+        hedge_symbol="eth/btc",
         base_allocation_usd=1_000.0,
         max_allocation_usd=10_000.0,
         rebalance_tolerance_usd=0.0,
@@ -146,3 +146,13 @@ def test_rebalance_requires_precision_metadata(
             price=0.065,
             risk_score=1.2,
         )
+
+
+def test_hedge_config_normalizes_spot_symbol() -> None:
+    config = hs.HedgeConfig(account_id="acct-2", hedge_symbol="  btc_usdt  ")
+    assert config.hedge_symbol == "BTC-USDT"
+
+
+def test_hedge_config_rejects_derivative_symbols() -> None:
+    with pytest.raises(ValueError, match="spot market pair"):
+        hs.HedgeConfig(account_id="acct-3", hedge_symbol="BTC-PERP")

--- a/tests/unit/test_watchdog_spot_filter.py
+++ b/tests/unit/test_watchdog_spot_filter.py
@@ -1,0 +1,90 @@
+"""Unit tests ensuring the watchdog filters non-spot instruments."""
+
+from datetime import datetime, timezone
+
+from watchdog import WatchdogCoordinator
+
+
+class _StubDetector:
+    def evaluate(self, intent, decision):  # pragma: no cover - not exercised
+        return None
+
+
+class _StubRepository:
+    def record(self, veto):  # pragma: no cover - not exercised
+        return True
+
+
+def _coordinator() -> WatchdogCoordinator:
+    return WatchdogCoordinator(detector=_StubDetector(), repository=_StubRepository())
+
+
+def test_intent_event_rejects_non_spot_symbol() -> None:
+    coordinator = _coordinator()
+    payload = {
+        "intent_id": "abc123",
+        "symbol": "BTC-PERP",
+        "qty": "1",
+    }
+
+    envelope = coordinator._parse_intent_event(  # type: ignore[attr-defined]
+        "company",
+        payload,
+        datetime.now(timezone.utc),
+    )
+
+    assert envelope is None
+
+
+def test_intent_event_normalizes_spot_symbol() -> None:
+    coordinator = _coordinator()
+    payload = {
+        "intent_id": "abc123",
+        "symbol": "eth/usd",
+        "qty": "1",
+    }
+
+    envelope = coordinator._parse_intent_event(  # type: ignore[attr-defined]
+        "company",
+        payload,
+        datetime.now(timezone.utc),
+    )
+
+    assert envelope is not None
+    assert envelope.symbol == "ETH-USD"
+
+
+def test_policy_event_rejects_non_spot_instrument() -> None:
+    coordinator = _coordinator()
+    payload = {
+        "order_id": "abc123",
+        "instrument": "ETH-PERP",
+        "approved": True,
+    }
+
+    envelope = coordinator._parse_policy_event(  # type: ignore[attr-defined]
+        "company",
+        payload,
+        datetime.now(timezone.utc),
+    )
+
+    assert envelope is None
+
+
+def test_policy_event_normalizes_spot_instrument() -> None:
+    coordinator = _coordinator()
+    payload = {
+        "order_id": "abc123",
+        "instrument": "btc/usd",
+        "approved": False,
+        "confidence": {"overall_confidence": 0.5},
+    }
+
+    envelope = coordinator._parse_policy_event(  # type: ignore[attr-defined]
+        "company",
+        payload,
+        datetime.now(timezone.utc),
+    )
+
+    assert envelope is not None
+    assert envelope.instrument == "BTC-USD"

--- a/tests/universe/test_universe_repository_thresholds.py
+++ b/tests/universe/test_universe_repository_thresholds.py
@@ -116,3 +116,33 @@ def test_non_usd_pairs_are_ignored(universe_timescale: UniverseTimescaleFixture)
     repo = UniverseRepository(account_id="company")
 
     assert repo.approved_universe() == ["BTC-USD"]
+
+
+def test_leveraged_tokens_are_ignored(universe_timescale: UniverseTimescaleFixture) -> None:
+    universe_timescale.add_snapshot(
+        base_asset="BTC",
+        quote_asset="USD",
+        market_cap=UniverseRepository.MARKET_CAP_THRESHOLD * 2,
+        global_volume_24h=UniverseRepository.GLOBAL_VOLUME_THRESHOLD * 3,
+        kraken_volume_24h=UniverseRepository.KRAKEN_VOLUME_THRESHOLD * 3,
+        volatility_30d=UniverseRepository.VOLATILITY_THRESHOLD * 2,
+    )
+    universe_timescale.add_snapshot(
+        base_asset="BTCUP",
+        quote_asset="USD",
+        market_cap=UniverseRepository.MARKET_CAP_THRESHOLD * 2,
+        global_volume_24h=UniverseRepository.GLOBAL_VOLUME_THRESHOLD * 3,
+        kraken_volume_24h=UniverseRepository.KRAKEN_VOLUME_THRESHOLD * 3,
+        volatility_30d=UniverseRepository.VOLATILITY_THRESHOLD * 2,
+    )
+
+    repo = UniverseRepository(account_id="company")
+
+    assert repo.approved_universe() == ["BTC-USD"]
+
+
+def test_manual_override_rejects_non_spot(universe_timescale: UniverseTimescaleFixture) -> None:
+    repo = UniverseRepository(account_id="company")
+
+    with pytest.raises(ValueError):
+        repo.set_manual_override("BTC-PERP", approved=True, actor_id="company")


### PR DESCRIPTION
## Summary
- filter Timescale open positions through the shared spot guard when running CVaR forecasts
- emit warnings for dropped derivative symbols and normalize canonical spot positions before simulation
- add deterministic unit coverage confirming the forecaster ignores non-spot instruments and only queries spot symbols

## Testing
- pytest tests/risk/test_cvar_forecast_spot.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c61e227c83218dc56ce891b8cb5a