### PR TITLE
Harden benchmark service database configuration

### DIFF
--- a/auth_service.py
+++ b/auth_service.py
@@ -44,11 +44,11 @@ encoder to avoid adding new packages to the environment.
 """
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import os
 import secrets
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
@@ -66,8 +66,8 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-from services.auth.jwt_tokens import create_jwt
-from shared.postgres import normalize_postgres_dsn
+from services.auth import jwt_tokens
+from shared.postgres import normalize_postgres_dsn, normalize_postgres_schema
 
 
 logger = logging.getLogger("auth_service")
@@ -100,14 +100,25 @@ def _resolve_database_url() -> tuple[Optional[str], Optional[RuntimeError]]:
             "AUTH_DATABASE_URL environment variable must be set before starting the auth service"
         )
 
+    allow_sqlite = "pytest" in sys.modules
+
     try:
-        normalized = normalize_postgres_dsn(url, label="Auth database DSN")
+        normalized = normalize_postgres_dsn(
+            url,
+            allow_sqlite=allow_sqlite,
+            label="Auth database DSN",
+        )
     except RuntimeError as exc:
         return None, RuntimeError(str(exc))
 
     if normalized == "sqlite:///./auth_sessions.db":
         return None, RuntimeError(
             "AUTH_DATABASE_URL must point at the shared Postgres/Timescale cluster instead of the legacy SQLite default"
+        )
+
+    if not allow_sqlite and normalized.startswith("sqlite"):
+        return None, RuntimeError(
+            "AUTH_DATABASE_URL must use a PostgreSQL/Timescale-compatible scheme"
         )
     return normalized, None
 
@@ -131,9 +142,21 @@ def _engine_options(url: str) -> Dict[str, Any]:
 def _resolve_schema(url: str) -> Optional[str]:
     sa_url = make_url(url)
     if sa_url.get_backend_name().startswith("postgresql"):
-        schema = os.getenv("AUTH_DATABASE_SCHEMA", "auth")
-        if schema:
-            return schema
+        override = os.getenv("AUTH_DATABASE_SCHEMA")
+        if override is None:
+            schema = "auth"
+        else:
+            if not override.strip():
+                raise RuntimeError(
+                    "AUTH_DATABASE_SCHEMA is set but empty; configure a valid schema identifier"
+                )
+            schema = override
+
+        return normalize_postgres_schema(
+            schema,
+            label="Auth database schema",
+            prefix_if_missing=None,
+        )
     return None
 
 
@@ -387,38 +410,30 @@ class MFAVerifier:
 
 
 
-def _b64url(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
-def _sign(data: bytes, secret: str) -> str:
-    import hmac
-    import hashlib
-
-    digest = hmac.new(secret.encode("utf-8"), data, hashlib.sha256).digest()
-    return _b64url(digest)
-
-
 def create_jwt(
-    *, subject: str, role: str, ttl_seconds: Optional[int] = None, secret: Optional[str] = None
+    *,
+    subject: str,
+    role: str,
+    ttl_seconds: Optional[int] = None,
+    secret: Optional[str] = None,
+    claims: Optional[Mapping[str, Any]] = None,
 ) -> tuple[str, datetime]:
-    ttl = ttl_seconds or int(os.getenv("AUTH_JWT_TTL_SECONDS", "3600"))
-    now = datetime.now(timezone.utc)
-    payload = {
-        "sub": subject,
-        "role": role,
-        "iat": int(now.timestamp()),
-        "exp": int((now + timedelta(seconds=ttl)).timestamp()),
-    }
-    header = {"alg": "HS256", "typ": "JWT"}
+    """Compatibility wrapper around ``services.auth.jwt_tokens.create_jwt``.
 
-    header_b64 = _b64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))
-    payload_b64 = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
-    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
-    signing_secret = secret or _get_configured_jwt_secret()
-    signature = _sign(signing_input, signing_secret)
-    token = f"{header_b64}.{payload_b64}.{signature}"
-    return token, now + timedelta(seconds=ttl)
+    The auth service initialises and stores the JWT signing secret during
+    application startup.  Downstream tests import ``auth_service.create_jwt`` to
+    mint tokens without directly depending on the internal module structure, so
+    this wrapper forwards to the shared helper while allowing an explicit secret
+    override (used in unit tests) and optional custom claims.
+    """
+
+    return jwt_tokens.create_jwt(
+        subject=subject,
+        role=role,
+        ttl_seconds=ttl_seconds,
+        secret=secret or _get_configured_jwt_secret(),
+        claims=claims,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -538,7 +553,11 @@ async def authenticate(
 
     role = _resolve_role(userinfo)
 
-    token, expires_at = create_jwt(subject=user_id, role=role, secret=jwt_secret)
+    token, expires_at = jwt_tokens.create_jwt(
+        subject=user_id,
+        role=role,
+        secret=jwt_secret,
+    )
     session = await _persist_session(sessions, user_id=user_id)
 
     builder_payload = BuilderFusionPayload(
@@ -621,6 +640,7 @@ __all__ = [
     "app",
     "authenticate",
     "AuthSession",
+    "create_jwt",
     "BuilderFusionPayload",
     "LoginRequest",
     "LoginResponse",

--- a/kill_switch.py
+++ b/kill_switch.py
@@ -1,12 +1,10 @@
 """FastAPI endpoint for triggering an immediate trading kill switch."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import logging
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
-
-import asyncio
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
@@ -14,6 +12,7 @@ from fastapi.responses import JSONResponse
 from kill_alerts import NotificationDispatchError, dispatch_notifications
 from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter
 from services.common.security import require_admin_account
+from shared.async_utils import dispatch_async
 
 try:  # pragma: no cover - optional audit dependency
     from common.utils.audit_logger import hash_ip, log_audit
@@ -76,7 +75,7 @@ def trigger_kill_switch(
     )
 
     kafka = KafkaNATSAdapter(account_id=normalized_account)
-    asyncio.run(
+    dispatch_async(
         kafka.publish(
             topic="risk.events",
             payload={
@@ -87,7 +86,9 @@ def trigger_kill_switch(
                 "actions": ["CANCEL_OPEN_ORDERS", "FLATTEN_POSITIONS"],
                 "reason_code": reason_code.value,
             },
-        )
+        ),
+        context="kill_switch.broadcast",
+        logger=LOGGER,
     )
 
     response_status = "ok"

--- a/safe_mode.py
+++ b/safe_mode.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from threading import Lock
 import logging
 import os
+import sys
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from fastapi import Body, Depends, FastAPI, HTTPException, Request, status
@@ -16,6 +16,7 @@ from fastapi import Body, Depends, FastAPI, HTTPException, Request, status
 from metrics import increment_safe_mode_triggers, setup_metrics
 from services.common.security import require_admin_account
 from common.utils.redis import create_redis_from_url
+from shared.async_utils import dispatch_async
 
 
 try:  # pragma: no cover - optional audit dependency
@@ -133,8 +134,25 @@ class SafeModeStateStore:
 
     @staticmethod
     def _create_default_client() -> Any:
-        redis_url = os.getenv("SAFE_MODE_REDIS_URL", "redis://localhost:6379/0")
-        client, _ = create_redis_from_url(redis_url, decode_responses=True, logger=LOGGER)
+        allow_stub = "pytest" in sys.modules
+
+        raw_url = os.getenv("SAFE_MODE_REDIS_URL")
+        if raw_url is None or not raw_url.strip():
+            if allow_stub:
+                raw_url = "redis://localhost:6379/0"
+            else:
+                raise RuntimeError(
+                    "SAFE_MODE_REDIS_URL environment variable must be set before starting the safe mode service"
+                )
+
+        redis_url = raw_url.strip()
+        client, used_stub = create_redis_from_url(redis_url, decode_responses=True, logger=LOGGER)
+
+        if used_stub and not allow_stub:
+            raise RuntimeError(
+                "Failed to connect to Redis at SAFE_MODE_REDIS_URL; safe mode requires a reachable Redis instance"
+            )
+
         return client
 
     def load(self) -> SafeModePersistedState:
@@ -441,29 +459,26 @@ class OrderControls:
         if adapter is None:
             return
         try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(
-                adapter.cancel_order(
-                    account_id,
-                    order.client_id,
-                    exchange_order_id=order.exchange_order_id,
-                )
+            coroutine = adapter.cancel_order(
+                account_id,
+                order.client_id,
+                exchange_order_id=order.exchange_order_id,
             )
-        else:
-            loop = asyncio.new_event_loop()
-            try:
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(
-                    adapter.cancel_order(
-                        account_id,
-                        order.client_id,
-                        exchange_order_id=order.exchange_order_id,
-                    )
-                )
-            finally:
-                asyncio.set_event_loop(None)
-                loop.close()
+        except Exception:
+            self._logger.exception(
+                "Failed to prepare safe mode cancel coroutine",
+                extra={
+                    "account_id": account_id,
+                    "client_id": order.client_id,
+                    "exchange_order_id": order.exchange_order_id,
+                },
+            )
+            return
+        dispatch_async(
+            coroutine,
+            context="safe_mode.cancel_order",
+            logger=self._logger,
+        )
 
     def _set_safe_mode_state(
         self, engaged: bool, *, reason: Optional[str], actor: Optional[str]
@@ -512,15 +527,22 @@ class KafkaSafeModePublisher:
         payload = event.to_payload()
         try:  # pragma: no cover - adapter import may fail in lightweight environments
             from services.common.adapters import KafkaNATSAdapter  # type: ignore
-
-            asyncio.run(
-                KafkaNATSAdapter(account_id=self._account_id).publish(
-                    topic=self._topic,
-                    payload=payload,
-                )
-            )
         except Exception:  # pragma: no cover - fall back to in-memory history
-            pass
+            LOGGER.debug(
+                "Kafka adapter unavailable for safe mode publish", exc_info=True
+            )
+        else:
+            try:
+                dispatch_async(
+                    KafkaNATSAdapter(account_id=self._account_id).publish(
+                        topic=self._topic,
+                        payload=payload,
+                    ),
+                    context="safe_mode.kafka_publish",
+                    logger=LOGGER,
+                )
+            except Exception:  # pragma: no cover - defensive scheduling guard
+                LOGGER.exception("Failed to schedule safe mode publish task")
 
         self._history.append({"topic": self._topic, "payload": payload})
 

--- a/services/auth/jwt_tokens.py
+++ b/services/auth/jwt_tokens.py
@@ -28,6 +28,7 @@ def create_jwt(
     role: Optional[str] = None,
     claims: Optional[Mapping[str, Any]] = None,
     ttl_seconds: Optional[int] = None,
+    secret: Optional[str] = None,
 ) -> Tuple[str, datetime]:
     """Create a signed JWT for the given subject.
 
@@ -38,8 +39,8 @@ def create_jwt(
     ``AUTH_JWT_TTL_SECONDS`` environment variable.
     """
 
-    secret = os.getenv("AUTH_JWT_SECRET")
-    if not secret:
+    signing_secret = secret or os.getenv("AUTH_JWT_SECRET")
+    if not signing_secret:
         raise ValueError("AUTH_JWT_SECRET environment variable must be set")
 
     ttl = ttl_seconds or int(os.getenv("AUTH_JWT_TTL_SECONDS", "3600"))
@@ -66,6 +67,6 @@ def create_jwt(
     header_b64 = _b64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))
     payload_b64 = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
     signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
-    signature = _sign(signing_input, secret)
+    signature = _sign(signing_input, signing_secret)
     token = f"{header_b64}.{payload_b64}.{signature}"
     return token, now + timedelta(seconds=ttl)

--- a/services/core/backpressure.py
+++ b/services/core/backpressure.py
@@ -72,12 +72,12 @@ class BackpressureEvent(BaseModel):
         return data
 
 
-def _default_publisher(account_id: str, dropped_count: int, ts: datetime) -> None:
+async def _default_publisher(account_id: str, dropped_count: int, ts: datetime) -> None:
     """Publish a backpressure event using the in-memory Kafka/NATS adapter."""
 
     adapter = KafkaNATSAdapter(account_id=account_id)
     event = BackpressureEvent(account_id=account_id, dropped_count=dropped_count, ts=ts)
-    asyncio.run(adapter.publish(_BACKPRESSURE_TOPIC, event.to_payload()))
+    await adapter.publish(_BACKPRESSURE_TOPIC, event.to_payload())
 
 
 class BackpressureStatus(BaseModel):

--- a/shared/async_utils.py
+++ b/shared/async_utils.py
@@ -1,0 +1,36 @@
+"""Async helpers shared across services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable
+
+LOGGER = logging.getLogger(__name__)
+
+
+def dispatch_async(
+    coro: Awaitable[object],
+    *,
+    context: str,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Run or schedule ``coro`` without breaking when a loop is active."""
+
+    log = logger or LOGGER
+
+    async def _run() -> None:
+        try:
+            await coro
+        except Exception:  # pragma: no cover - defensive logging
+            log.exception("Failed to execute %s", context)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_run())
+    else:
+        loop.create_task(_run())
+
+
+__all__ = ["dispatch_async"]

--- a/shared/sim_mode.py
+++ b/shared/sim_mode.py
@@ -16,6 +16,7 @@ import math
 import os
 import time
 from contextlib import contextmanager
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -27,9 +28,12 @@ from sqlalchemy import Boolean, Column, DateTime, Integer, Numeric, String, Text
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from common.schemas.contracts import FillEvent
 from services.common.adapters import KafkaNATSAdapter
+from shared.async_utils import dispatch_async
+from shared.postgres import normalize_sqlalchemy_dsn
 
 
 LOGGER = logging.getLogger(__name__)
@@ -39,26 +43,53 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+_TEST_DSN_ENV = "AETHER_SIM_MODE_TEST_DSN"
+_IN_MEMORY_SQLITE_URL = "sqlite+pysqlite:///:memory:"
+
+
 def _database_url() -> str:
-    candidates = [os.getenv("SIM_MODE_DATABASE_URL"), os.getenv("DATABASE_URL")]
+    candidates = [os.getenv("SIM_MODE_DATABASE_URL"), os.getenv("DATABASE_URL"), os.getenv(_TEST_DSN_ENV)]
+    if "pytest" in sys.modules:
+        candidates.append(_IN_MEMORY_SQLITE_URL)
+
     for candidate in candidates:
         if not candidate:
             continue
-        normalized = candidate
-        if normalized.startswith("postgres://"):
-            normalized = "postgresql://" + normalized.split("://", 1)[1]
+
+        try:
+            normalized = normalize_sqlalchemy_dsn(
+                candidate,
+                allow_sqlite=True,
+                label="Simulation mode DSN",
+            )
+        except RuntimeError as exc:  # pragma: no cover - defensive validation
+            raise RuntimeError("Invalid simulation mode database URL") from exc
+
         try:
             url_obj = make_url(normalized)
         except Exception as exc:  # pragma: no cover - defensive validation
             raise RuntimeError("Invalid simulation mode database URL") from exc
 
         driver = url_obj.drivername.lower()
-        if driver.startswith("postgresql") or driver.startswith("timescale"):
-            return str(url_obj)
+        if driver.startswith("postgresql"):
+            return normalized
+
+        if driver.startswith("sqlite"):
+            if candidate == _IN_MEMORY_SQLITE_URL:
+                LOGGER.warning("Simulation mode DSN missing; using in-memory SQLite for tests")
+                return normalized
+            if candidate == os.getenv(_TEST_DSN_ENV):
+                LOGGER.warning("Simulation mode DSN missing; using %s for tests", _TEST_DSN_ENV)
+                return normalized
+            raise RuntimeError(
+                "Simulation mode requires a PostgreSQL/TimescaleDB DSN; received sqlite://"
+            )
+
         raise RuntimeError(
             "Simulation mode requires a PostgreSQL/TimescaleDB DSN; "
             f"received driver '{url_obj.drivername}'."
         )
+
     raise RuntimeError(
         "SIM_MODE_DATABASE_URL (or DATABASE_URL) must be set to a PostgreSQL/TimescaleDB DSN."
     )
@@ -81,7 +112,10 @@ def _engine() -> Engine:
             pool_timeout=int(os.getenv("SIM_MODE_DB_POOL_TIMEOUT", "30")),
             pool_recycle=int(os.getenv("SIM_MODE_DB_POOL_RECYCLE", "1800")),
         )
-    else:  # pragma: no cover - only exercised in tests with alternative engines
+    elif driver.startswith("sqlite"):  # pragma: no cover - only exercised in tests with alternative engines
+        connect_args["check_same_thread"] = False
+        engine_kwargs["poolclass"] = StaticPool
+    else:  # pragma: no cover - defensive guard for unexpected drivers
         connect_args["check_same_thread"] = False
 
     if connect_args:
@@ -474,7 +508,11 @@ class SimBroker:
                 liquidity=execution.liquidity,
                 ts=_utcnow(),
             )
-            asyncio.run(adapter.publish("oms.fills.simulated", event.model_dump(mode="json")))
+            dispatch_async(
+                adapter.publish("oms.fills.simulated", event.model_dump(mode="json")),
+                context="simulated fill event",
+                logger=LOGGER,
+            )
         return execution
 
     def cancel_order(self, account_id: str, client_id: str) -> Optional[SimulatedOrderSnapshot]:

--- a/tests/compliance/test_compliance_scanner_config.py
+++ b/tests/compliance/test_compliance_scanner_config.py
@@ -1,0 +1,71 @@
+"""Configuration regression tests for the compliance scanner service."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+MODULE_NAME = "compliance_scanner"
+_ENV_KEYS = (
+    "COMPLIANCE_DATABASE_URL",
+    "RISK_DATABASE_URL",
+    "TIMESCALE_DSN",
+    "DATABASE_URL",
+)
+
+
+def _reset_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    sys.modules.pop(MODULE_NAME, None)
+
+
+def _restore_pytest(original: object | None) -> None:
+    if original is not None:
+        sys.modules["pytest"] = original
+
+
+def test_compliance_scanner_requires_configured_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even under pytest a database URL must be provided."""
+
+    _reset_module(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="must be configured even under pytest"):
+        importlib.import_module(MODULE_NAME)
+
+    sys.modules.pop(MODULE_NAME, None)
+
+
+def test_compliance_scanner_accepts_timescale_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timescale/PostgreSQL URLs are normalised for SQLAlchemy use."""
+
+    _reset_module(monkeypatch)
+    monkeypatch.setenv(
+        "COMPLIANCE_DATABASE_URL",
+        "timescale://user:pass@timescale.example.com:5432/compliance",
+    )
+
+    module = importlib.import_module(MODULE_NAME)
+    try:
+        assert module._DB_URL.startswith("postgresql+")
+    finally:
+        sys.modules.pop(MODULE_NAME, None)
+
+
+def test_compliance_scanner_rejects_sqlite_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production imports must not fall back to sqlite URLs."""
+
+    _reset_module(monkeypatch)
+    monkeypatch.setenv("COMPLIANCE_DATABASE_URL", "sqlite:///./compliance.db")
+    original_pytest = sys.modules.pop("pytest", None)
+
+    try:
+        with pytest.raises(RuntimeError, match="PostgreSQL/Timescale compatible"):
+            importlib.import_module(MODULE_NAME)
+    finally:
+        _restore_pytest(original_pytest)
+        sys.modules.pop(MODULE_NAME, None)

--- a/tests/data/ingest/test_ingest_database_config.py
+++ b/tests/data/ingest/test_ingest_database_config.py
@@ -1,0 +1,110 @@
+"""Configuration regression tests for data ingestion scripts."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from types import ModuleType
+from typing import Tuple
+
+import pytest
+
+
+MODULE_MATRIX: Tuple[Tuple[str, str], ...] = (
+    ("data.ingest.feature_jobs", "FEATURE_JOBS_ALLOW_SQLITE_FOR_TESTS"),
+    ("data.ingest.coingecko_job", "COINGECKO_ALLOW_SQLITE_FOR_TESTS"),
+    ("data.ingest.kraken_ws", "KRAKEN_WS_ALLOW_SQLITE_FOR_TESTS"),
+)
+
+
+def _import_fresh(module_name: str) -> ModuleType:
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+@pytest.fixture(autouse=True)
+def _disable_optional_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent optional heavy dependencies from being imported during tests."""
+
+    real_find_spec = importlib.util.find_spec
+
+    def _guarded_find_spec(name: str, package: str | None = None):  # type: ignore[override]
+        if name in {"pandas", "numpy", "feast"}:
+            return None
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _guarded_find_spec)
+    for module_name in (
+        "pandas",
+        "numpy",
+        "numpy.random",
+        "numpy.random._pickle",
+        "feast",
+    ):
+        sys.modules.pop(module_name, None)
+
+
+@pytest.mark.parametrize("module_name, _", MODULE_MATRIX)
+def test_ingest_scripts_require_database_url(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, _: str
+) -> None:
+    """Ingestion modules must fail fast when DATABASE_URL is absent."""
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        _import_fresh(module_name)
+    sys.modules.pop(module_name, None)
+
+
+@pytest.mark.parametrize("module_name, _", MODULE_MATRIX)
+def test_ingest_scripts_normalize_timescale_urls(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, _: str
+) -> None:
+    """Timescale URLs should normalise to psycopg-compatible SQLAlchemy URIs."""
+
+    monkeypatch.setenv("DATABASE_URL", "timescale://user:secret@example.com/aether")
+    module = _import_fresh(module_name)
+    try:
+        database_url = getattr(module, "DATABASE_URL")
+    finally:
+        sys.modules.pop(module_name, None)
+    assert database_url.startswith("postgresql+psycopg2://")
+
+
+@pytest.mark.parametrize("module_name, sqlite_flag", MODULE_MATRIX)
+def test_ingest_scripts_reject_sqlite_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, sqlite_flag: str
+) -> None:
+    """SQLite DSNs must not be accepted when pytest (or explicit flag) is absent."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./ingest.db")
+    saved_pytest = sys.modules.pop("pytest", None)
+    try:
+        with pytest.raises(RuntimeError, match="PostgreSQL/Timescale"):
+            _import_fresh(module_name)
+    finally:
+        if saved_pytest is not None:
+            sys.modules["pytest"] = saved_pytest
+        sys.modules.pop(module_name, None)
+
+
+@pytest.mark.parametrize("module_name, sqlite_flag", MODULE_MATRIX)
+def test_ingest_scripts_allow_sqlite_when_flag_enabled(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, sqlite_flag: str
+) -> None:
+    """Explicit overrides may permit sqlite for local testing."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    saved_pytest = sys.modules.pop("pytest", None)
+    monkeypatch.setenv(sqlite_flag, "1")
+    try:
+        module = _import_fresh(module_name)
+        database_url = getattr(module, "DATABASE_URL")
+    finally:
+        if saved_pytest is not None:
+            sys.modules["pytest"] = saved_pytest
+        monkeypatch.delenv(sqlite_flag, raising=False)
+        sys.modules.pop(module_name, None)
+    assert database_url == "sqlite+pysqlite:///:memory:"
+

--- a/tests/integration/test_alert_prioritizer_persistence.py
+++ b/tests/integration/test_alert_prioritizer_persistence.py
@@ -214,3 +214,17 @@ async def test_alert_classifications_visible_across_instances() -> None:
 
     await service_a.close()
     await service_b.close()
+
+
+def test_alert_prioritizer_rejects_sqlite_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    from alert_prioritizer import AlertPrioritizerService
+
+    monkeypatch.delenv("ALERT_PRIORITIZER_DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="PostgreSQL/Timescale"):
+        AlertPrioritizerService(
+            database_url="sqlite:///tmp/test.db",
+            psycopg_module=_MemoryPsycopg(),
+            model=_StubModel(),
+            label_encoder=_StubLabelEncoder(),
+        )

--- a/tests/integration/test_fee_aware_sizing.py
+++ b/tests/integration/test_fee_aware_sizing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import types
@@ -20,12 +21,30 @@ from tests import factories
 
 
 if "metrics" not in sys.modules:
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
     metrics_stub = types.SimpleNamespace(
         record_abstention_rate=lambda *args, **kwargs: None,
         record_drift_score=lambda *args, **kwargs: None,
         setup_metrics=lambda *args, **kwargs: None,
         get_request_id=lambda *args, **kwargs: "test-request",
+        TransportType=_TransportType,
     )
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     sys.modules["metrics"] = metrics_stub
 
 import policy_service

--- a/tests/integration/test_fee_enforcement.py
+++ b/tests/integration/test_fee_enforcement.py
@@ -16,6 +16,21 @@ import pytest
 def test_fee_enforcement_blocks_negative_edge(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure intents with insufficient edge are rejected before reaching the OMS."""
 
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
     metrics_stub = types.SimpleNamespace(
         increment_rejected_intents=lambda *args, **kwargs: None,
         increment_trades_submitted=lambda *args, **kwargs: None,
@@ -28,7 +43,10 @@ def test_fee_enforcement_blocks_negative_edge(monkeypatch: pytest.MonkeyPatch) -
         record_scaling_state=lambda *args, **kwargs: None,
         observe_scaling_evaluation=lambda *args, **kwargs: None,
         get_request_id=lambda: None,
+        TransportType=_TransportType,
     )
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     monkeypatch.setitem(sys.modules, "metrics", metrics_stub)
 
     fastapi_stub = types.ModuleType("fastapi")

--- a/tests/integration/test_ml_portfolio_security.py
+++ b/tests/integration/test_ml_portfolio_security.py
@@ -151,6 +151,9 @@ def test_training_bootstrap_populates_all_backends(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(coingecko_ingest, "aggregate_daily_rows", _fake_aggregate_daily_rows)
     monkeypatch.setattr(coingecko_ingest, "upsert_ohlcv_rows", _fake_upsert)
 
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    sys.modules.pop("data.ingest.feature_jobs", None)
+
     try:
         from data.ingest import feature_jobs as feature_jobs_module
     except ImportError as exc:  # pragma: no cover - highlight missing dependency explicitly

--- a/tests/integration/test_trading_pipeline.py
+++ b/tests/integration/test_trading_pipeline.py
@@ -112,6 +112,21 @@ class Sequencer:
 def test_trading_pipeline_emits_fill_event(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
     metrics_stub = types.SimpleNamespace(
         setup_metrics=lambda *args, **kwargs: None,
         record_abstention_rate=lambda *args, **kwargs: None,
@@ -128,7 +143,10 @@ def test_trading_pipeline_emits_fill_event(
         observe_risk_validation_latency=lambda *args, **kwargs: None,
         traced_span=lambda *args, **kwargs: contextlib.nullcontext(),
         get_request_id=lambda: None,
+        TransportType=_TransportType,
     )
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     sys.modules["metrics"] = metrics_stub
 
     monkeypatch.setenv("ENABLE_SHADOW_EXECUTION", "false")

--- a/tests/integration/test_warm_start.py
+++ b/tests/integration/test_warm_start.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import sys
 import types
@@ -186,6 +187,21 @@ if "metrics" not in sys.modules:
     def _noop(*args: Any, **kwargs: Any) -> None:
         return None
 
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
     metrics_stub.increment_oms_child_orders_total = _noop
     metrics_stub.increment_oms_error_count = _noop
     metrics_stub.record_oms_latency = _noop
@@ -197,6 +213,9 @@ if "metrics" not in sys.modules:
     metrics_stub.record_scaling_state = _noop
     metrics_stub.observe_scaling_evaluation = _noop
     metrics_stub.get_request_id = lambda: None
+    metrics_stub.TransportType = _TransportType
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     sys.modules["metrics"] = metrics_stub
 
 from services.common.adapters import KafkaNATSAdapter, TimescaleAdapter

--- a/tests/ml/training/test_training_service_config.py
+++ b/tests/ml/training/test_training_service_config.py
@@ -1,0 +1,186 @@
+"""Configuration regression tests for the ML training FastAPI service."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "ml" / "training" / "training_service.py"
+
+
+def _install_training_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install lightweight module stubs so the training service can import."""
+
+    if "pandas" not in sys.modules:
+        panda_stub = SimpleNamespace(
+            DataFrame=object,
+            Timestamp=object,
+            Series=object,
+            concat=lambda *args, **kwargs: [],
+            to_datetime=lambda value, **kwargs: value,
+            isna=lambda value: False,
+        )
+        monkeypatch.setitem(sys.modules, "pandas", panda_stub)
+
+    if "ml.features.build_features" not in sys.modules:
+        build_features_module = ModuleType("ml.features.build_features")
+
+        class FeatureBuildConfig:  # noqa: D401 - test stub
+            """Stub FeatureBuildConfig with a permissive constructor."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - test stub
+                self.args = args
+                self.kwargs = kwargs
+
+        build_features_module.FeatureBuildConfig = FeatureBuildConfig  # type: ignore[attr-defined]
+        build_features_module.OHLCV_TABLE = "ohlcv_bars"
+        build_features_module.ENTITY_COLUMN = "market"
+        build_features_module.EVENT_TIMESTAMP_COLUMN = "event_timestamp"
+        build_features_module.CREATED_AT_COLUMN = "created_at"
+        build_features_module.materialise_features = lambda *args, **kwargs: SimpleNamespace(  # type: ignore[attr-defined]
+            empty=True,
+            columns=[],
+        )
+
+        features_package = ModuleType("ml.features")
+        features_package.build_features = build_features_module  # type: ignore[attr-defined]
+
+        monkeypatch.setitem(sys.modules, "ml.features.build_features", build_features_module)
+        monkeypatch.setitem(sys.modules, "ml.features", features_package)
+
+    if "ml.training.data_loader_coingecko" not in sys.modules:
+        coingecko_module = ModuleType("ml.training.data_loader_coingecko")
+        coingecko_module.fetch_ohlcv = lambda *args, **kwargs: SimpleNamespace(empty=True)  # type: ignore[attr-defined]
+        coingecko_module.upsert_timescale = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "ml.training.data_loader_coingecko", coingecko_module)
+
+    if "ml.training.workflow" not in sys.modules:
+        workflow_module = ModuleType("ml.training.workflow")
+
+        class _StubBase:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        class TimescaleSourceConfig(_StubBase):
+            pass
+
+        class MetricThresholds(_StubBase):
+            pass
+
+        class ObjectStorageConfig(_StubBase):
+            pass
+
+        class TrainingMetadata(_StubBase):
+            pass
+
+        class MLflowConfig(_StubBase):
+            pass
+
+        class ModelConfig(_StubBase):
+            pass
+
+        class TrainingConfig(_StubBase):
+            pass
+
+        class ChronologicalSplitConfig(_StubBase):
+            pass
+
+        class OutlierConfig(_StubBase):
+            pass
+
+        def run_training_job(*args: object, **kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(model_version=None, metrics={})
+
+        workflow_module.TimescaleSourceConfig = TimescaleSourceConfig  # type: ignore[attr-defined]
+        workflow_module.MetricThresholds = MetricThresholds  # type: ignore[attr-defined]
+        workflow_module.ObjectStorageConfig = ObjectStorageConfig  # type: ignore[attr-defined]
+        workflow_module.TrainingMetadata = TrainingMetadata  # type: ignore[attr-defined]
+        workflow_module.MLflowConfig = MLflowConfig  # type: ignore[attr-defined]
+        workflow_module.ModelConfig = ModelConfig  # type: ignore[attr-defined]
+        workflow_module.TrainingConfig = TrainingConfig  # type: ignore[attr-defined]
+        workflow_module.ChronologicalSplitConfig = ChronologicalSplitConfig  # type: ignore[attr-defined]
+        workflow_module.OutlierConfig = OutlierConfig  # type: ignore[attr-defined]
+        workflow_module.run_training_job = run_training_job  # type: ignore[attr-defined]
+        workflow_module.mlflow = SimpleNamespace(tracking=SimpleNamespace(MlflowClient=lambda: None))
+
+        training_package = ModuleType("ml.training")
+        training_package.workflow = workflow_module  # type: ignore[attr-defined]
+        training_package.data_loader_coingecko = sys.modules["ml.training.data_loader_coingecko"]
+
+        monkeypatch.setitem(sys.modules, "ml.training.workflow", workflow_module)
+        monkeypatch.setitem(sys.modules, "ml.training", training_package)
+
+
+def _load_training_module(module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise ModuleNotFoundError(module_name)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _dispose_training_module(module_name: str) -> None:
+    sys.modules.pop(module_name, None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TRAINING_TIMESCALE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("TRAINING_ALLOW_SQLITE_FOR_TESTS", raising=False)
+
+    _install_training_stubs(monkeypatch)
+
+
+def test_training_service_requires_database_url() -> None:
+    module_name = "tests.ml.training.training_service_missing_dsn"
+    with pytest.raises(RuntimeError, match="must be configured"):
+        _load_training_module(module_name)
+
+
+def test_training_service_normalizes_timescale_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "TRAINING_TIMESCALE_URI",
+        "timescale://user:pass@example.com:5432/training",
+    )
+
+    module_name = "tests.ml.training.training_service_timescale"
+    module = _load_training_module(module_name)
+    try:
+        assert module.DEFAULT_TIMESCALE_URI.startswith("postgresql+psycopg2://")  # type: ignore[attr-defined]
+    finally:
+        _dispose_training_module(module_name)
+
+
+def test_training_service_rejects_sqlite_without_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAINING_TIMESCALE_URI", "sqlite:///./training.db")
+
+    module_name = "tests.ml.training.training_service_sqlite_rejected"
+    with pytest.raises(RuntimeError, match="PostgreSQL/Timescale compatible scheme"):
+        _load_training_module(module_name)
+
+
+def test_training_service_allows_sqlite_when_flag_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAINING_TIMESCALE_URI", "sqlite:///./training.db")
+    monkeypatch.setenv("TRAINING_ALLOW_SQLITE_FOR_TESTS", "1")
+
+    module_name = "tests.ml.training.training_service_sqlite_allowed"
+    module = _load_training_module(module_name)
+    try:
+        assert module.DEFAULT_TIMESCALE_URI.startswith("sqlite")  # type: ignore[attr-defined]
+    finally:
+        _dispose_training_module(module_name)

--- a/tests/ops/test_release_manifest_config.py
+++ b/tests/ops/test_release_manifest_config.py
@@ -1,0 +1,65 @@
+"""Configuration guards for :mod:`ops.releases.release_manifest`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+MODULE_NAME = "ops.releases.release_manifest"
+
+
+@pytest.fixture(name="release_manifest_module")
+def fixture_release_manifest_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RELEASE_MANIFEST_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.setenv("RELEASE_MANIFEST_DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.setenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.setenv("CONFIG_DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+    module = importlib.import_module(MODULE_NAME)
+    monkeypatch.setitem(sys.modules, MODULE_NAME, module)
+    return module
+
+
+def test_release_manifest_requires_explicit_database_url(
+    release_manifest_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in ("RELEASE_MANIFEST_DATABASE_URL", "RELEASE_DATABASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(RuntimeError, match="RELEASE_MANIFEST_DATABASE_URL"):
+        release_manifest_module._resolve_release_db_url()
+
+
+def test_release_manifest_normalises_timescale_urls(
+    release_manifest_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "RELEASE_MANIFEST_DATABASE_URL",
+        "timescale://admin:secret@localhost:5432/releases",
+    )
+
+    resolved = release_manifest_module._resolve_release_db_url()
+    assert resolved.startswith("postgresql+psycopg2://")
+
+
+def test_release_manifest_rejects_sqlite_without_flag(
+    release_manifest_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("RELEASE_MANIFEST_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.setenv("RELEASE_MANIFEST_DATABASE_URL", "sqlite:///tmp/releases.db")
+
+    with pytest.raises(RuntimeError, match="PostgreSQL/Timescale"):
+        release_manifest_module._resolve_release_db_url()
+
+
+def test_release_manifest_allows_sqlite_when_flag_enabled(
+    release_manifest_module, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RELEASE_MANIFEST_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.setenv("RELEASE_MANIFEST_DATABASE_URL", "sqlite:///tmp/releases.db")
+
+    resolved = release_manifest_module._resolve_release_db_url()
+    assert resolved.startswith("sqlite://")

--- a/tests/policy/test_policy_service.py
+++ b/tests/policy/test_policy_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import importlib
 import os
 import sys
 import types
@@ -28,6 +30,25 @@ if "metrics" not in sys.modules:
     metrics_stub.record_scaling_state = lambda *args, **kwargs: None
     metrics_stub.observe_scaling_evaluation = lambda *args, **kwargs: None
     metrics_stub.get_request_id = lambda: None
+
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
+    metrics_stub.TransportType = _TransportType
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     sys.modules["metrics"] = metrics_stub
 
 os.environ.setdefault("SESSION_REDIS_URL", "memory://policy-tests")
@@ -367,4 +388,42 @@ def test_regime_endpoint_allows_authenticated_access(
     )
 
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_policy_service_requires_session_store_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "policy_service"
+    cached_module = sys.modules.pop(module_name, None)
+    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="SESSION_REDIS_URL is not configured"):
+        importlib.import_module(module_name)
+
+    sys.modules.pop(module_name, None)
+    if cached_module is not None:
+        sys.modules[module_name] = cached_module
+    else:
+        monkeypatch.setenv("SESSION_REDIS_URL", "memory://policy-tests")
+        importlib.import_module(module_name)
+
+
+def test_policy_service_rejects_memory_session_store_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://policy-prod")
+    cached_pytest = sys.modules.get("pytest")
+    if cached_pytest is not None:
+        sys.modules.pop("pytest")
+
+    try:
+        with pytest.raises(RuntimeError, match="must use a redis:// or rediss:// DSN outside pytest"):
+            policy_service._configure_session_store(app)
+    finally:
+        if cached_pytest is not None:
+            sys.modules["pytest"] = cached_pytest
+
 

--- a/tests/reports/test_report_service_config.py
+++ b/tests/reports/test_report_service_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+pytest.importorskip("pandas", exc_type=ImportError)
+
+import report_service as module
+
+
+@pytest.fixture(autouse=True)
+def _reload_module(monkeypatch: pytest.MonkeyPatch):
+    for key in ("REPORT_DATABASE_URL", "TIMESCALE_DSN", "DATABASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+    yield
+    importlib.reload(module)
+
+
+def test_database_url_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REPORT_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(HTTPException) as excinfo:
+        module._database_url()
+
+    assert excinfo.value.status_code == 503
+    assert "Report service database URL is not configured" in excinfo.value.detail
+
+
+def test_database_url_normalizes_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REPORT_DATABASE_URL", "timescale://user:pass@host:5432/db")
+
+    resolved = module._database_url()
+
+    assert resolved == "postgresql://user:pass@host:5432/db"
+
+
+def test_database_url_rejects_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REPORT_DATABASE_URL", "sqlite:///tmp/reports.db")
+
+    with pytest.raises(HTTPException) as excinfo:
+        module._database_url()
+
+    assert excinfo.value.status_code == 500
+    assert "PostgreSQL/Timescale" in excinfo.value.detail

--- a/tests/security/test_compliance_scanner_authorization.py
+++ b/tests/security/test_compliance_scanner_authorization.py
@@ -22,6 +22,7 @@ from services.common.security import require_admin_account
 def compliance_scanner_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     """Create a test client for the compliance scanner admin endpoints."""
 
+    monkeypatch.setenv("COMPLIANCE_DATABASE_URL", "sqlite+pysqlite:///:memory:")
     module = importlib.import_module("compliance_scanner")
 
     async def fake_refresh_watchlists() -> None:

--- a/tests/services/alerts/test_alert_dedupe.py
+++ b/tests/services/alerts/test_alert_dedupe.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
+import pytest
 from prometheus_client import CollectorRegistry
 
-from services.alerts.alert_dedupe import AlertDedupeMetrics, AlertDedupeService, AlertPolicy
+from services.alerts.alert_dedupe import (
+    AlertDedupeMetrics,
+    AlertDedupeService,
+    AlertPolicy,
+    HTTPException,
+)
 
 
 def _metric_value(metric: object) -> float:
@@ -137,3 +145,113 @@ def test_alerts_escalate_after_threshold() -> None:
     policies = service.policies()
     assert policies["suppression_window_seconds"] == int(timedelta(minutes=10).total_seconds())
     assert policies["escalation_threshold"] == 3
+
+
+@pytest.mark.asyncio
+async def test_alert_dedupe_uses_configured_http_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: dict[str, object] = {}
+
+    class DummyAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            created["timeout"] = kwargs.get("timeout")
+
+    fake_httpx = SimpleNamespace(AsyncClient=DummyAsyncClient)
+
+    original = sys.modules.get("httpx")
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    try:
+        service = AlertDedupeService(http_timeout=7.5)
+        client = await service._get_client()
+    finally:
+        if original is None:
+            monkeypatch.delitem(sys.modules, "httpx", raising=False)
+        else:
+            monkeypatch.setitem(sys.modules, "httpx", original)
+
+    assert isinstance(client, DummyAsyncClient)
+    assert created["timeout"] == 7.5
+
+
+@pytest.mark.asyncio
+async def test_default_fetch_converts_request_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyRequestError(Exception):
+        pass
+
+    class DummyTimeout(DummyRequestError):
+        pass
+
+    class DummyHTTPStatusError(Exception):
+        pass
+
+    class DummyClient:
+        async def get(self, url: str) -> None:  # pragma: no cover - runtime path
+            raise DummyRequestError("boom")
+
+    fake_httpx = SimpleNamespace(
+        AsyncClient=lambda *args, **kwargs: DummyClient(),
+        RequestError=DummyRequestError,
+        TimeoutException=DummyTimeout,
+        HTTPStatusError=DummyHTTPStatusError,
+    )
+
+    original = sys.modules.get("httpx")
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    try:
+        metrics = AlertDedupeMetrics(registry=CollectorRegistry())
+        service = AlertDedupeService(metrics=metrics)
+        service._client = DummyClient()
+
+        with pytest.raises(HTTPException) as excinfo:
+            await service._default_fetch()
+    finally:
+        if original is None:
+            monkeypatch.delitem(sys.modules, "httpx", raising=False)
+        else:
+            monkeypatch.setitem(sys.modules, "httpx", original)
+
+    assert excinfo.value.status_code == 502
+    assert "Alertmanager request failed" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_default_fetch_converts_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyRequestError(Exception):
+        pass
+
+    class DummyTimeout(DummyRequestError):
+        pass
+
+    class DummyHTTPStatusError(Exception):
+        pass
+
+    class DummyClient:
+        async def get(self, url: str) -> None:  # pragma: no cover - runtime path
+            raise DummyTimeout("boom")
+
+    fake_httpx = SimpleNamespace(
+        AsyncClient=lambda *args, **kwargs: DummyClient(),
+        RequestError=DummyRequestError,
+        TimeoutException=DummyTimeout,
+        HTTPStatusError=DummyHTTPStatusError,
+    )
+
+    original = sys.modules.get("httpx")
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    try:
+        metrics = AlertDedupeMetrics(registry=CollectorRegistry())
+        service = AlertDedupeService(metrics=metrics)
+        service._client = DummyClient()
+
+        with pytest.raises(HTTPException) as excinfo:
+            await service._default_fetch()
+    finally:
+        if original is None:
+            monkeypatch.delitem(sys.modules, "httpx", raising=False)
+        else:
+            monkeypatch.setitem(sys.modules, "httpx", original)
+
+    assert excinfo.value.status_code == 504
+    assert "timed out" in excinfo.value.detail

--- a/tests/services/analytics/test_crossasset_database_config.py
+++ b/tests/services/analytics/test_crossasset_database_config.py
@@ -1,0 +1,92 @@
+"""Regression tests for the cross-asset analytics service configuration guards."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _reset_prometheus_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    import prometheus_client
+    from prometheus_client import metrics as metrics_module
+    from prometheus_client import registry as registry_module
+
+    fresh_registry = registry_module.CollectorRegistry()
+    monkeypatch.setattr(registry_module, "REGISTRY", fresh_registry)
+    monkeypatch.setattr(metrics_module, "REGISTRY", fresh_registry, raising=False)
+    monkeypatch.setattr(prometheus_client, "REGISTRY", fresh_registry, raising=False)
+
+    class _GaugeStub:
+        def __init__(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - trivial
+            pass
+
+        def labels(self, **kwargs: object) -> "_GaugeStub":  # pragma: no cover - trivial
+            return self
+
+        def set(self, value: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(prometheus_client, "Gauge", _GaugeStub)
+
+
+MODULE = "services.analytics.crossasset_service"
+_CONFIG_VARS = ("CROSSASSET_DATABASE_URL", "ANALYTICS_DATABASE_URL", "DATABASE_URL")
+
+
+def _import_module() -> object:
+    sys.modules.pop(MODULE, None)
+    return importlib.import_module(MODULE)
+
+
+def test_requires_database_url_outside_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production imports must fail fast when no DSN is configured."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+    _reset_prometheus_registry(monkeypatch)
+
+    sys.modules.pop(MODULE, None)
+    with pytest.raises(RuntimeError, match="Cross-asset analytics database DSN is not configured"):
+        importlib.import_module(MODULE)
+    sys.modules.pop(MODULE, None)
+
+
+def test_allows_sqlite_when_pytest_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local tests may rely on sqlite connections when pytest is active."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv("CROSSASSET_DATABASE_URL", "sqlite:///./crossasset.db")
+
+    _reset_prometheus_registry(monkeypatch)
+    module = _import_module()
+    try:
+        assert getattr(module, "DATABASE_URL") == "sqlite:///./crossasset.db"
+    finally:
+        sys.modules.pop(MODULE, None)
+
+
+def test_normalizes_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timescale/PostgreSQL DSNs are normalised for SQLAlchemy usage."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv(
+        "CROSSASSET_DATABASE_URL",
+        "timescale://user:secret@db.internal:5432/crossasset",
+    )
+
+    _reset_prometheus_registry(monkeypatch)
+    module = _import_module()
+    try:
+        assert getattr(module, "DATABASE_URL") == (
+            "postgresql+psycopg2://user:secret@db.internal:5432/crossasset"
+        )
+    finally:
+        sys.modules.pop(MODULE, None)

--- a/tests/services/analytics/test_orderflow_market_data_config.py
+++ b/tests/services/analytics/test_orderflow_market_data_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+MODULE_PATH = "services.analytics.orderflow_service"
+
+
+def _reload_module() -> object:
+    sys.modules.pop(MODULE_PATH, None)
+    return importlib.import_module(MODULE_PATH)
+
+
+def _clear_market_data_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var in (
+        "ORDERFLOW_MARKET_DATA_URL",
+        "ANALYTICS_MARKET_DATA_URL",
+        "MARKET_DATA_DATABASE_URL",
+        "ANALYTICS_DATABASE_URL",
+        "DATABASE_URL",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_market_data_falls_back_to_sqlite_in_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_market_data_env(monkeypatch)
+
+    module = _reload_module()
+
+    dsn = module._resolve_market_data_dsn()
+    assert dsn.startswith("sqlite"), dsn
+
+
+def test_market_data_requires_configuration_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_market_data_env(monkeypatch)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    with pytest.raises(RuntimeError, match="Orderflow market data DSN is not configured"):
+        _reload_module()
+
+
+def test_market_data_rejects_sqlite_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_market_data_env(monkeypatch)
+    monkeypatch.setenv("ORDERFLOW_MARKET_DATA_URL", "sqlite:///orderflow.db")
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    with pytest.raises(RuntimeError, match="PostgreSQL/Timescale"):
+        _reload_module()
+
+
+def test_market_data_normalises_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_market_data_env(monkeypatch)
+    monkeypatch.setenv(
+        "ORDERFLOW_MARKET_DATA_URL",
+        "timescale://analytics:secret@db:5432/market_data",
+    )
+
+    module = _reload_module()
+
+    dsn = module._resolve_market_data_dsn()
+    assert dsn.startswith("postgresql+"), dsn

--- a/tests/services/analytics/test_orderflow_session_store_config.py
+++ b/tests/services/analytics/test_orderflow_session_store_config.py
@@ -1,0 +1,50 @@
+"""Regression tests for the orderflow session store configuration safeguards."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from fastapi import FastAPI
+
+
+MODULE_PATH = "services.analytics.orderflow_service"
+
+
+def _reload_orderflow_module() -> object:
+    sys.modules.pop(MODULE_PATH, None)
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_orderflow_session_store_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
+    monkeypatch.delenv("SESSION_STORE_URL", raising=False)
+    monkeypatch.delenv("SESSION_BACKEND_DSN", raising=False)
+
+    module = _reload_orderflow_module()
+
+    with pytest.raises(RuntimeError, match="Session store misconfigured"):
+        module._configure_session_store(FastAPI())
+
+
+def test_orderflow_session_store_allows_memory_in_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _reload_orderflow_module()
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://orderflow-tests")
+
+    store = module._configure_session_store(FastAPI())
+
+    from auth.service import InMemorySessionStore
+
+    assert isinstance(store, InMemorySessionStore)
+
+
+def test_orderflow_session_store_rejects_memory_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _reload_orderflow_module()
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://orderflow-prod")
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    with pytest.raises(RuntimeError, match="memory:// DSNs are only permitted"):
+        module._configure_session_store(FastAPI())

--- a/tests/services/analytics/test_seasonality_session_store_config.py
+++ b/tests/services/analytics/test_seasonality_session_store_config.py
@@ -1,0 +1,58 @@
+"""Validate seasonality session store configuration requirements."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from fastapi import FastAPI
+
+import services.analytics.seasonality_service as seasonality
+
+
+def _fresh_app() -> FastAPI:
+    application = FastAPI()
+    application.state.session_store = None
+    return application
+
+
+def _reset_session_store() -> None:
+    seasonality.SESSION_STORE = None
+    seasonality.security.set_default_session_store(None)
+
+
+def test_seasonality_session_store_requires_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
+    monkeypatch.delenv("SESSION_STORE_URL", raising=False)
+    monkeypatch.delenv("SESSION_BACKEND_DSN", raising=False)
+
+    _reset_session_store()
+
+    with pytest.raises(RuntimeError, match="Session store misconfigured"):
+        seasonality._configure_session_store(_fresh_app())
+
+
+def test_seasonality_session_store_allows_memory_in_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://seasonality-tests")
+    _reset_session_store()
+
+    store = seasonality._configure_session_store(_fresh_app())
+
+    from auth.service import InMemorySessionStore
+
+    assert isinstance(store, InMemorySessionStore)
+
+
+def test_seasonality_session_store_rejects_memory_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SESSION_REDIS_URL", "memory://seasonality-prod")
+    _reset_session_store()
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    with pytest.raises(RuntimeError, match="memory:// DSNs are only supported"):
+        seasonality._configure_session_store(_fresh_app())

--- a/tests/services/analytics/test_vwap_database_config.py
+++ b/tests/services/analytics/test_vwap_database_config.py
@@ -1,0 +1,63 @@
+"""Regression tests for VWAP analytics database configuration guards."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+MODULE_PATH = "services.analytics.vwap_service"
+
+
+def _reload_vwap_module() -> object:
+    sys.modules.pop(MODULE_PATH, None)
+    return importlib.import_module(MODULE_PATH)
+
+
+def _clear_database_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "VWAP_DATABASE_URL",
+        "TIMESCALE_DATABASE_URI",
+        "TIMESCALE_DSN",
+        "DATABASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_vwap_database_requires_configuration_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    module = _reload_vwap_module()
+
+    with pytest.raises(RuntimeError, match="VWAP analytics database DSN is not configured"):
+        module.VWAPAnalyticsService()
+
+
+def test_vwap_database_normalizes_timescale_uris(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(
+        "TIMESCALE_DATABASE_URI",
+        "timescale://user:secret@localhost:5432/analytics",
+    )
+
+    module = _reload_vwap_module()
+
+    resolved = module.VWAPAnalyticsService._database_url()
+    assert resolved.startswith("postgresql+psycopg2://user:secret@localhost:5432/analytics")
+
+
+def test_vwap_database_rejects_sqlite_outside_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("VWAP_DATABASE_URL", "sqlite:///./analytics.db")
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    module = _reload_vwap_module()
+
+    with pytest.raises(RuntimeError, match="must use a PostgreSQL/Timescale compatible scheme"):
+        module.VWAPAnalyticsService._database_url()
+

--- a/tests/services/anomaly/test_execution_anomaly_config.py
+++ b/tests/services/anomaly/test_execution_anomaly_config.py
@@ -1,0 +1,84 @@
+"""Configuration regression tests for the execution anomaly service."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+MODULE = "services.anomaly.execution_anomaly"
+_CONFIG_VARS = (
+    "EXECUTION_ANOMALY_DATABASE_URL",
+    "ANALYTICS_DATABASE_URL",
+    "DATABASE_URL",
+)
+
+
+def _import_module() -> object:
+    sys.modules.pop(MODULE, None)
+    return importlib.import_module(MODULE)
+
+
+def test_requires_database_url_outside_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production imports must fail when no DSN is configured."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    original_pytest = sys.modules.pop("pytest", None)
+
+    with pytest.raises(RuntimeError, match="Execution anomaly database DSN is not configured"):
+        _import_module()
+
+    sys.modules.pop(MODULE, None)
+    if original_pytest is not None:
+        sys.modules["pytest"] = original_pytest
+
+
+def test_allows_sqlite_when_pytest_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local tests may rely on sqlite when pytest is active."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv("EXECUTION_ANOMALY_DATABASE_URL", "sqlite:///:memory:")
+
+    module = _import_module()
+    try:
+        assert getattr(module, "DATABASE_URL") == "sqlite:///:memory:"
+    finally:
+        sys.modules.pop(MODULE, None)
+
+
+def test_normalizes_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timescale DSNs are normalised for SQLAlchemy usage."""
+
+    for var in _CONFIG_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv(
+        "EXECUTION_ANOMALY_DATABASE_URL",
+        "timescale://user:secret@db.internal:5432/anomalies",
+    )
+
+    import sqlalchemy
+
+    captured: dict[str, str] = {}
+    real_create_engine = sqlalchemy.create_engine
+
+    def _fake_create_engine(url: str, **options: object):  # type: ignore[override]
+        captured["url"] = url
+        return real_create_engine("sqlite+pysqlite:///:memory:", **options)
+
+    monkeypatch.setattr(sqlalchemy, "create_engine", _fake_create_engine)
+
+    module = _import_module()
+    try:
+        assert getattr(module, "DATABASE_URL") == (
+            "postgresql+psycopg2://user:secret@db.internal:5432/anomalies"
+        )
+        assert captured["url"] == "postgresql+psycopg2://user:secret@db.internal:5432/anomalies"
+    finally:
+        sys.modules.pop(MODULE, None)

--- a/tests/services/common/test_config.py
+++ b/tests/services/common/test_config.py
@@ -1,4 +1,5 @@
 import importlib.util
+import importlib
 import sys
 from pathlib import Path
 
@@ -33,12 +34,14 @@ import services.common.config as config
 
 
 @pytest.fixture(autouse=True)
-def _clear_timescale_cache():
+def _clear_config_cache():
     config.get_timescale_session.cache_clear()
+    config.get_redis_client.cache_clear()
     try:
         yield
     finally:
         config.get_timescale_session.cache_clear()
+        config.get_redis_client.cache_clear()
 
 
 def test_get_timescale_session_requires_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,6 +50,48 @@ def test_get_timescale_session_requires_config(monkeypatch: pytest.MonkeyPatch) 
 
     with pytest.raises(RuntimeError, match="Timescale DSN is not configured"):
         config.get_timescale_session("company")
+
+
+def test_get_redis_client_requires_explicit_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AETHER_COMPANY_REDIS_DSN", raising=False)
+
+    with pytest.raises(RuntimeError, match="Redis DSN is not configured"):
+        config.get_redis_client("company")
+
+
+def test_get_redis_client_rejects_blank_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AETHER_COMPANY_REDIS_DSN", "   ")
+
+    with pytest.raises(RuntimeError, match="is set but empty"):
+        config.get_redis_client("company")
+
+
+def test_get_redis_client_accepts_memory_scheme_for_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AETHER_COMPANY_REDIS_DSN", "memory://")
+
+    client = config.get_redis_client("company")
+    assert client.dsn == "memory://"
+
+
+def test_get_redis_client_rejects_memory_scheme_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AETHER_COMPANY_REDIS_DSN", "memory://")
+    original_pytest = sys.modules.get("pytest")
+    try:
+        if "pytest" in sys.modules:
+            del sys.modules["pytest"]
+        with pytest.raises(RuntimeError, match="must use a redis:// or rediss:// DSN outside pytest"):
+            config.get_redis_client("company")
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
 
 
 def test_get_timescale_session_uses_account_specific_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,4 +124,54 @@ def test_get_timescale_session_rejects_unsupported_scheme(monkeypatch: pytest.Mo
     monkeypatch.setenv("TIMESCALE_DSN", "mysql://user:pass@host:3306/db")
 
     with pytest.raises(RuntimeError, match="Timescale DSN must use a PostgreSQL/Timescale"):
+        config.get_timescale_session("company")
+
+
+def test_get_timescale_session_sanitizes_default_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+
+    session = config.get_timescale_session("Director-1")
+
+    assert session.account_schema == "acct_director_1"
+
+
+def test_get_timescale_session_sanitizes_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+    monkeypatch.setenv("AETHER_COMPANY_TIMESCALE_SCHEMA", " Trading-Agg \n")
+
+    session = config.get_timescale_session("company")
+
+    assert session.account_schema == "trading_agg"
+
+
+def test_get_timescale_session_rejects_invalid_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+    monkeypatch.setenv("AETHER_COMPANY_TIMESCALE_SCHEMA", "123bad")
+
+    with pytest.raises(RuntimeError, match="Timescale schema must not start with a digit"):
+        config.get_timescale_session("company")
+
+
+def test_get_timescale_session_rejects_blank_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+    monkeypatch.setenv("AETHER_COMPANY_TIMESCALE_SCHEMA", "  \t  ")
+
+    with pytest.raises(RuntimeError, match="is set but empty; configure a valid schema"):
+        config.get_timescale_session("company")
+
+
+def test_get_timescale_session_rejects_overlong_default_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+
+    overlong_account = "director" + "x" * 70
+
+    with pytest.raises(RuntimeError, match="63 characters or fewer"):
+        config.get_timescale_session(overlong_account)
+
+
+def test_get_timescale_session_rejects_overlong_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMESCALE_DSN", "postgresql://user:pass@host:5432/db")
+    monkeypatch.setenv("AETHER_COMPANY_TIMESCALE_SCHEMA", "schema" + "y" * 70)
+
+    with pytest.raises(RuntimeError, match="63 characters or fewer"):
         config.get_timescale_session("company")

--- a/tests/services/core/test_backpressure.py
+++ b/tests/services/core/test_backpressure.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from services.core import backpressure
+
+
+@pytest.mark.asyncio
+async def test_default_publisher_runs_inside_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    published: list[tuple[str, dict[str, object]]] = []
+
+    class _DummyAdapter:
+        def __init__(self, account_id: str) -> None:  # pragma: no cover - trivial attribute assignment
+            self.account_id = account_id
+
+        async def publish(self, topic: str, payload: dict[str, object]) -> None:
+            published.append((topic, payload))
+
+    monkeypatch.setattr(backpressure, "KafkaNATSAdapter", _DummyAdapter)
+
+    ts = datetime.now(timezone.utc)
+
+    await backpressure._default_publisher("company", 3, ts)
+
+    assert published == [
+        (
+            "backpressure.events",
+            {
+                "account_id": "company",
+                "dropped_count": 3,
+                "ts": ts.isoformat(),
+                "type": "backpressure_event",
+            },
+        )
+    ]

--- a/tests/services/test_auth_jwt.py
+++ b/tests/services/test_auth_jwt.py
@@ -46,6 +46,20 @@ def test_create_jwt_missing_secret(monkeypatch):
         create_jwt(subject="user-456", role="auditor")
 
 
+def test_create_jwt_accepts_explicit_secret(monkeypatch):
+    monkeypatch.delenv("AUTH_JWT_SECRET", raising=False)
+
+    token, expires_at = create_jwt(subject="user-654", role="admin", secret="inline-secret")
+
+    parts = token.split(".")
+    assert len(parts) == 3
+
+    payload = _decode_segment(parts[1])
+    assert payload["sub"] == "user-654"
+    assert payload["role"] == "admin"
+    assert expires_at.tzinfo is timezone.utc
+
+
 def test_create_jwt_accepts_claim_mapping(monkeypatch):
     monkeypatch.setenv("AUTH_JWT_SECRET", "super-secret-key")
     extra_claims = {"role": "auditor", "permissions": ["read"]}

--- a/tests/shared/test_async_utils.py
+++ b/tests/shared/test_async_utils.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import pytest
+
+from shared.async_utils import dispatch_async
+
+
+def test_dispatch_async_without_running_loop():
+    invoked = False
+
+    async def _stub():
+        nonlocal invoked
+        invoked = True
+
+    dispatch_async(_stub(), context="test")
+    assert invoked
+
+
+@pytest.mark.asyncio
+async def test_dispatch_async_with_running_loop():
+    invoked = False
+
+    async def _stub():
+        nonlocal invoked
+        invoked = True
+
+    dispatch_async(_stub(), context="test")
+    await asyncio.sleep(0)
+    assert invoked

--- a/tests/shared/test_sim_mode_config.py
+++ b/tests/shared/test_sim_mode_config.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def sim_mode_module(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AETHER_SIM_MODE_TEST_DSN", raising=False)
+    monkeypatch.delenv("SIM_MODE_DATABASE_URL", raising=False)
+    sys.modules.pop("shared.sim_mode", None)
+    return importlib.import_module("shared.sim_mode")
+
+
+def test_database_url_normalizes_timescale_scheme(monkeypatch, sim_mode_module):
+    monkeypatch.setenv("SIM_MODE_DATABASE_URL", "timescale://user:secret@db.example/sim")
+    normalized = sim_mode_module._database_url()
+    assert normalized == "postgresql+psycopg2://user:secret@db.example/sim"
+    scheme, _, remainder = normalized.partition("://")
+    assert scheme.startswith("postgresql+")
+    assert remainder == "user:secret@db.example/sim"

--- a/tests/test_anomaly_service_config.py
+++ b/tests/test_anomaly_service_config.py
@@ -1,0 +1,120 @@
+"""Regression tests covering anomaly service database configuration guards."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from sqlalchemy import create_engine as real_create_engine
+from sqlalchemy.pool import StaticPool
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "anomaly_service.py"
+
+
+def _load_module(module_name: str) -> ModuleType:
+    """Import ``anomaly_service`` under *module_name* and return the module."""
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise ModuleNotFoundError(module_name)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _dispose_module(module_name: str) -> None:
+    module = sys.modules.pop(module_name, None)
+    engine = getattr(module, "ENGINE", None)
+    if engine is not None and hasattr(engine, "dispose"):
+        engine.dispose()
+
+
+def _stub_create_engine(monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]) -> None:
+    """Replace ``sqlalchemy.create_engine`` with a deterministic stub."""
+
+    def _fake_create_engine(url: str, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return real_create_engine(
+            "sqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+
+
+def test_anomaly_service_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANOMALY_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+
+    module_name = "tests.anomaly_missing_dsn"
+    with pytest.raises(
+        RuntimeError,
+        match="ANOMALY_DATABASE_URL or TIMESCALE_DSN must be set to a PostgreSQL/Timescale DSN",
+    ):
+        _load_module(module_name)
+    assert module_name not in sys.modules
+
+
+def test_anomaly_service_normalizes_timescale_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANOMALY_DATABASE_URL", "timescale://user:pass@example.com/anomaly")
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+
+    captured: dict[str, object] = {}
+    _stub_create_engine(monkeypatch, captured)
+
+    module_name = "tests.anomaly_timescale_config"
+    module = _load_module(module_name)
+    try:
+        assert str(captured["url"]).startswith("postgresql+psycopg2://")
+    finally:
+        _dispose_module(module_name)
+
+
+def test_anomaly_service_rejects_sqlite_without_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANOMALY_DATABASE_URL", "sqlite:///./anomaly.db")
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+
+    original_pytest = sys.modules.get("pytest")
+    try:
+        if "pytest" in sys.modules:
+            del sys.modules["pytest"]
+        module_name = "tests.anomaly_sqlite_rejected"
+        with pytest.raises(
+            RuntimeError,
+            match="Anomaly service database DSN must use a PostgreSQL/Timescale compatible scheme",
+        ):
+            _load_module(module_name)
+        assert module_name not in sys.modules
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
+
+
+def test_anomaly_service_allows_sqlite_during_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANOMALY_DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+
+    captured: dict[str, object] = {}
+    _stub_create_engine(monkeypatch, captured)
+
+    module_name = "tests.anomaly_sqlite_allowed"
+    module = _load_module(module_name)
+    try:
+        assert str(captured["url"]).startswith("sqlite+pysqlite:///:memory:")
+    finally:
+        _dispose_module(module_name)

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -248,6 +248,28 @@ def test_auth_database_url_normalizes_supported_schemes(
     _clear_auth_service_module()
 
 
+def test_auth_database_url_rejects_sqlite_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SQLite DSNs should be rejected when pytest is not present."""
+
+    sqlite_url = f"sqlite:///{tmp_path/'auth.db'}"
+    monkeypatch.setenv("AUTH_DATABASE_URL", sqlite_url)
+    monkeypatch.setenv("AUTH_JWT_SECRET", "secret")
+    _install_dependency_stubs(monkeypatch)
+    _clear_auth_service_module()
+
+    module = importlib.import_module("auth_service")
+    monkeypatch.delitem(module.sys.modules, "pytest", raising=False)
+
+    resolved, error = module._resolve_database_url()
+    assert resolved is None
+    assert isinstance(error, RuntimeError)
+    assert "PostgreSQL/Timescale" in str(error)
+
+    _clear_auth_service_module()
+
+
 def test_auth_database_url_rejects_blank_values(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -259,12 +281,37 @@ def test_auth_database_url_rejects_blank_values(
     _install_dependency_stubs(monkeypatch)
     _clear_auth_service_module()
 
+
+def test_auth_database_schema_sanitizes_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configured schemas should be normalised to safe Postgres identifiers."""
+
+    monkeypatch.setenv("AUTH_DATABASE_URL", "sqlite:///./auth.db")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "secret")
+    monkeypatch.delenv("AUTH_DATABASE_SCHEMA", raising=False)
+    _install_dependency_stubs(monkeypatch)
+    _clear_auth_service_module()
+
     module = importlib.import_module("auth_service")
-    monkeypatch.setenv("AUTH_DATABASE_URL", "   ")
-    resolved, error = module._resolve_database_url()
-    assert resolved is None
-    assert isinstance(error, RuntimeError)
-    assert "must be set" in str(error)
+    monkeypatch.setenv("AUTH_DATABASE_SCHEMA", "  Audit-Logs  ")
+    schema = module._resolve_schema("postgresql://user:pass@host:5432/auth")
+    assert schema == "audit_logs"
+
+    _clear_auth_service_module()
+
+
+def test_auth_database_schema_rejects_invalid_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Schemas beginning with digits should be rejected to avoid invalid identifiers."""
+
+    monkeypatch.setenv("AUTH_DATABASE_URL", "sqlite:///./auth.db")
+    monkeypatch.setenv("AUTH_JWT_SECRET", "secret")
+    monkeypatch.delenv("AUTH_DATABASE_SCHEMA", raising=False)
+    _install_dependency_stubs(monkeypatch)
+    _clear_auth_service_module()
+
+    module = importlib.import_module("auth_service")
+    monkeypatch.setenv("AUTH_DATABASE_SCHEMA", "123-admin")
+    with pytest.raises(RuntimeError, match="must not start with a digit"):
+        module._resolve_schema("postgresql://user:pass@host:5432/auth")
 
     _clear_auth_service_module()
 

--- a/tests/test_benchmark_service_security.py
+++ b/tests/test_benchmark_service_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import sys
 
 import pytest
 
@@ -11,12 +12,22 @@ pytest.importorskip("fastapi")
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-import benchmark_service
+from tests.helpers.benchmark_service import bootstrap_benchmark_service
 
 
 @pytest.fixture()
-def benchmark_client() -> TestClient:
-    with TestClient(benchmark_service.app) as client:
+def benchmark_module(tmp_path, monkeypatch):
+    module = bootstrap_benchmark_service(tmp_path, monkeypatch, reset=True)
+    try:
+        yield module
+    finally:
+        module.ENGINE.dispose()
+        sys.modules.pop("benchmark_service", None)
+
+
+@pytest.fixture()
+def benchmark_client(benchmark_module) -> TestClient:
+    with TestClient(benchmark_module.app) as client:
         yield client
 
 
@@ -29,22 +40,26 @@ def _sample_payload() -> dict[str, object]:
     }
 
 
-def test_upsert_rejects_unauthorized_callers(benchmark_client: TestClient) -> None:
+def test_upsert_rejects_unauthorized_callers(
+    benchmark_module, benchmark_client: TestClient
+) -> None:
     def deny() -> str:
         raise HTTPException(status_code=403, detail="forbidden")
 
-    benchmark_client.app.dependency_overrides[benchmark_service.require_admin_account] = deny
+    benchmark_client.app.dependency_overrides[benchmark_module.require_admin_account] = deny
     try:
         response = benchmark_client.post("/benchmark/curves", json=_sample_payload())
         assert response.status_code == 403
     finally:
         benchmark_client.app.dependency_overrides.pop(
-            benchmark_service.require_admin_account, None
+            benchmark_module.require_admin_account, None
         )
 
 
-def test_benchmark_endpoints_allow_admin_override(benchmark_client: TestClient) -> None:
-    benchmark_client.app.dependency_overrides[benchmark_service.require_admin_account] = (
+def test_benchmark_endpoints_allow_admin_override(
+    benchmark_module, benchmark_client: TestClient
+) -> None:
+    benchmark_client.app.dependency_overrides[benchmark_module.require_admin_account] = (
         lambda: "ops-admin"
     )
     try:
@@ -61,5 +76,5 @@ def test_benchmark_endpoints_allow_admin_override(benchmark_client: TestClient) 
         assert "aether_return" in body
     finally:
         benchmark_client.app.dependency_overrides.pop(
-            benchmark_service.require_admin_account, None
+            benchmark_module.require_admin_account, None
         )

--- a/tests/test_capital_optimizer_config.py
+++ b/tests/test_capital_optimizer_config.py
@@ -1,0 +1,73 @@
+"""Configuration regression tests for the capital optimizer service."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _reload_capital_optimizer() -> ModuleType:
+    sys.modules.pop("capital_optimizer", None)
+    return importlib.import_module("capital_optimizer")
+
+
+def test_capital_optimizer_requires_configured_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production imports must fail when no database DSN is configured."""
+
+    for key in (
+        "CAPITAL_OPTIMIZER_DB_URL",
+        "CAPITAL_OPTIMIZER_DATABASE_URL",
+        "TIMESCALE_DSN",
+        "DATABASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    original_pytest = sys.modules.pop("pytest", None)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            _reload_capital_optimizer()
+        assert "Capital optimizer database DSN is not configured" in str(excinfo.value)
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
+        sys.modules.pop("capital_optimizer", None)
+
+
+def test_capital_optimizer_rejects_sqlite_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SQLite DSNs must be rejected when pytest is not present."""
+
+    monkeypatch.setenv("CAPITAL_OPTIMIZER_DB_URL", "sqlite:///./capital_optimizer.db")
+
+    original_pytest = sys.modules.pop("pytest", None)
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            _reload_capital_optimizer()
+        assert "PostgreSQL/Timescale" in str(excinfo.value)
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
+        sys.modules.pop("capital_optimizer", None)
+
+
+def test_capital_optimizer_normalises_timescale_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timescale DSNs should normalise to psycopg-compatible URLs."""
+
+    for key in (
+        "CAPITAL_OPTIMIZER_DB_URL",
+        "CAPITAL_OPTIMIZER_DATABASE_URL",
+        "DATABASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("TIMESCALE_DSN", "timescale://user:pass@host:5432/db")
+
+    module = _reload_capital_optimizer()
+
+    try:
+        assert module._database_url() == "postgresql+psycopg2://user:pass@host:5432/db"
+    finally:
+        sys.modules.pop("capital_optimizer", None)

--- a/tests/test_config_sandbox_config.py
+++ b/tests/test_config_sandbox_config.py
@@ -1,0 +1,95 @@
+"""Regression tests for the config sandbox database configuration guards."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MODULE_PATH = ROOT / "config_sandbox.py"
+
+
+def _load_module(module_name: str) -> object:
+    """Import ``config_sandbox`` under *module_name* and return the module."""
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ModuleNotFoundError(module_name)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _dispose_module(module_name: str) -> None:
+    module = sys.modules.pop(module_name, None)
+    engine = getattr(module, "ENGINE", None)
+    if engine is not None and hasattr(engine, "dispose"):
+        engine.dispose()
+
+
+def test_config_sandbox_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CONFIG_SANDBOX_DATABASE_URL", raising=False)
+
+    module_name = "tests.config_sandbox_missing_dsn"
+    with pytest.raises(RuntimeError, match="Config sandbox database URL must be provided"):
+        _load_module(module_name)
+
+
+def test_config_sandbox_normalizes_timescale_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIG_SANDBOX_DATABASE_URL", "timescale://user:pass@example.com/sandbox")
+
+    captured: dict[str, object] = {}
+
+    from sqlalchemy import create_engine as real_create_engine
+    from sqlalchemy.pool import StaticPool
+
+    def _fake_create_engine(url: str, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return real_create_engine(
+            "sqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+
+    module_name = "tests.config_sandbox_timescale"
+    module = _load_module(module_name)
+    try:
+        assert str(captured["url"]).startswith("postgresql+psycopg2://")
+    finally:
+        _dispose_module(module_name)
+
+
+def test_config_sandbox_rejects_sqlite_outside_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIG_SANDBOX_DATABASE_URL", "sqlite:///./sandbox.db")
+    monkeypatch.delenv("CONFIG_SANDBOX_ALLOW_SQLITE", raising=False)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    module_name = "tests.config_sandbox_sqlite"
+    with pytest.raises(RuntimeError, match="Timescale compatible scheme"):
+        _load_module(module_name)
+
+
+def test_config_sandbox_rejects_blank_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIG_SANDBOX_DATABASE_URL", "   ")
+
+    module_name = "tests.config_sandbox_blank_dsn"
+    with pytest.raises(RuntimeError, match="must be provided"):
+        _load_module(module_name)
+

--- a/tests/test_config_service_config.py
+++ b/tests/test_config_service_config.py
@@ -1,0 +1,112 @@
+"""Regression tests for the config service database configuration guards."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MODULE_PATH = ROOT / "config_service.py"
+
+
+def _load_module(module_name: str) -> object:
+    """Import ``config_service`` under *module_name* and return the module."""
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ModuleNotFoundError(module_name)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _dispose_module(module_name: str) -> None:
+    module = sys.modules.pop(module_name, None)
+    engine = getattr(module, "ENGINE", None)
+    if engine is not None and hasattr(engine, "dispose"):
+        engine.dispose()
+
+
+def test_config_service_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CONFIG_DATABASE_URL", raising=False)
+
+    module_name = "tests.config_service_missing_dsn"
+    module = _load_module(module_name)
+    try:
+        with pytest.raises(RuntimeError, match="CONFIG_DATABASE_URL environment variable is required"):
+            module._initialise_database(module.app)  # type: ignore[attr-defined]
+    finally:
+        _dispose_module(module_name)
+
+
+def test_config_service_normalizes_timescale_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.setenv("CONFIG_DATABASE_URL", "timescale://user:pass@example.com/config")
+
+    captured: dict[str, object] = {}
+
+    from sqlalchemy import create_engine as real_create_engine
+    from sqlalchemy.pool import StaticPool
+
+    def _fake_create_engine(url: str, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return real_create_engine(
+            "sqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+
+    module_name = "tests.config_service_timescale"
+    module = _load_module(module_name)
+    try:
+        module._initialise_database(module.app)  # type: ignore[attr-defined]
+        assert str(captured["url"]).startswith("postgresql+psycopg2://")
+    finally:
+        _dispose_module(module_name)
+
+
+def test_config_service_rejects_sqlite_without_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.setenv("CONFIG_DATABASE_URL", "sqlite:///./config.db")
+
+    module_name = "tests.config_service_sqlite"
+    module = _load_module(module_name)
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="Config service database URL must use a PostgreSQL/Timescale compatible scheme",
+        ):
+            module._initialise_database(module.app)  # type: ignore[attr-defined]
+    finally:
+        _dispose_module(module_name)
+
+
+def test_config_service_allows_sqlite_when_flag_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONFIG_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.setenv("CONFIG_DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
+    module_name = "tests.config_service_sqlite_allowed"
+    module = _load_module(module_name)
+    try:
+        module._initialise_database(module.app)  # type: ignore[attr-defined]
+        engine = module.app.state.db_engine  # type: ignore[attr-defined]
+        assert str(engine.url).startswith("sqlite+pysqlite:///:memory:")
+    finally:
+        _dispose_module(module_name)

--- a/tests/test_override_service_config.py
+++ b/tests/test_override_service_config.py
@@ -1,0 +1,88 @@
+"""Regression tests for override service database configuration guards."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import sqlalchemy
+
+
+@pytest.fixture
+def stub_create_engine(monkeypatch):
+    """Patch ``sqlalchemy.create_engine`` to avoid external connections."""
+
+    real_create_engine = sqlalchemy.create_engine
+
+    def _fake_create_engine(url: str, **kwargs):  # type: ignore[override]
+        engine = real_create_engine("sqlite+pysqlite:///:memory:", future=True)
+        engine.captured_url = url  # type: ignore[attr-defined]
+        engine.captured_kwargs = kwargs  # type: ignore[attr-defined]
+        return engine
+
+    monkeypatch.setattr(sqlalchemy, "create_engine", _fake_create_engine)
+
+
+def _reload_override_service(monkeypatch) -> SimpleNamespace:
+    sys.modules.pop("override_service", None)
+    module = importlib.import_module("override_service")
+    return module  # type: ignore[return-value]
+
+
+def test_override_service_requires_database_url(monkeypatch):
+    monkeypatch.delenv("OVERRIDE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("OVERRIDE_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    sys.modules.pop("override_service", None)
+    with pytest.raises(RuntimeError, match="OVERRIDE_DATABASE_URL must be configured"):
+        importlib.import_module("override_service")
+
+    sys.modules.pop("override_service", None)
+
+
+def test_override_service_allows_sqlite_with_flag(monkeypatch, stub_create_engine, tmp_path):
+    sqlite_url = f"sqlite:///{tmp_path / 'override.db'}"
+    monkeypatch.setenv("OVERRIDE_DATABASE_URL", sqlite_url)
+    monkeypatch.setenv("OVERRIDE_ALLOW_SQLITE_FOR_TESTS", "1")
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    module = _reload_override_service(monkeypatch)
+    try:
+        assert str(module.ENGINE.captured_url) == sqlite_url  # type: ignore[attr-defined]
+        kwargs = module.ENGINE.captured_kwargs  # type: ignore[attr-defined]
+        assert kwargs["connect_args"]["check_same_thread"] is False
+    finally:
+        module.ENGINE.dispose()
+        sys.modules.pop("override_service", None)
+
+
+def test_override_service_rejects_sqlite_without_flag(monkeypatch):
+    sqlite_url = "sqlite:///./override.db"
+    monkeypatch.setenv("OVERRIDE_DATABASE_URL", sqlite_url)
+    monkeypatch.delenv("OVERRIDE_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    sys.modules.pop("override_service", None)
+    with pytest.raises(RuntimeError, match="Override service database URL"):
+        importlib.import_module("override_service")
+
+    sys.modules.pop("override_service", None)
+
+
+def test_override_service_normalizes_timescale_url(monkeypatch, stub_create_engine):
+    monkeypatch.setenv("OVERRIDE_DATABASE_URL", "timescale://user:pass@host/db")
+    monkeypatch.delenv("OVERRIDE_ALLOW_SQLITE_FOR_TESTS", raising=False)
+    monkeypatch.delitem(sys.modules, "pytest", raising=False)
+
+    module = _reload_override_service(monkeypatch)
+    try:
+        normalized = str(module.ENGINE.captured_url)  # type: ignore[attr-defined]
+        assert normalized.startswith("postgresql+psycopg2://")
+    finally:
+        module.ENGINE.dispose()
+        sys.modules.pop("override_service", None)
+

--- a/tests/test_policy_service_api.py
+++ b/tests/test_policy_service_api.py
@@ -30,9 +30,28 @@ if "metrics" not in sys.modules:
     metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     metrics_stub.get_request_id = lambda: None
 
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
+    metrics_stub.TransportType = _TransportType
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+
     sys.modules["metrics"] = metrics_stub
 
 import policy_service
+from services.policy import main as policy_main
 
 from services.common.precision import PrecisionMetadataUnavailable
 from services.common.schemas import (
@@ -300,6 +319,230 @@ def test_policy_decide_approves_when_edge_beats_costs(
     assert dispatched == [
         {"order_id": "abc-123", "approved": True, "actor": "company"}
     ]
+
+
+def test_policy_decide_normalises_feature_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[dict[str, object]] = []
+
+    class _Intent:
+        approved = True
+        edge_bps = 18.0
+        reason = None
+        take_profit_bps = 20.0
+        stop_loss_bps = 10.0
+        is_null = False
+        confidence = ConfidenceMetrics(
+            model_confidence=0.8,
+            state_confidence=0.8,
+            execution_confidence=0.8,
+            overall_confidence=0.8,
+        )
+
+    def _fake_registry() -> object:
+        class _Registry:
+            def get_latest_ensemble(self, account_id: str, symbol: str) -> object:
+                class _Ensemble:
+                    confidence_threshold = 0.6
+
+                return _Ensemble()
+
+        return _Registry()
+
+    async def _noop_publish(*_: object, **__: object) -> None:
+        return None
+
+    class _KafkaStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def publish(self, *args: object, **kwargs: object) -> None:
+            await _noop_publish(*args, **kwargs)
+
+    class _RedisStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def fetch_online_features(self, instrument: str) -> dict[str, object]:
+            return {
+                "features": {
+                    "alpha": "0.5",
+                    "beta": 1.75,
+                    "ignored": "not-a-number",
+                },
+                "book_snapshot": {
+                    "mid_price": 30125.4,
+                    "spread_bps": 2.4,
+                    "imbalance": 0.05,
+                },
+                "state": {
+                    "regime": "range",
+                    "volatility": 0.2,
+                    "liquidity_score": 0.4,
+                    "conviction": 0.6,
+                },
+            }
+
+    class _TimescaleStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def record_decision(self, *, order_id: str, payload: dict[str, object]) -> None:
+            recorded.append({"order_id": order_id, **payload})
+
+    monkeypatch.setattr(policy_main, "get_model_registry", _fake_registry)
+    monkeypatch.setattr(policy_main, "predict_intent", lambda **_: _Intent())
+    dispatched_contexts: list[str] = []
+
+    def _run_dispatch(
+        coro: object,
+        *,
+        context: str,
+        logger: object | None = None,
+    ) -> None:
+        del logger
+        dispatched_contexts.append(context)
+        asyncio.run(coro)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(policy_main, "dispatch_async", _run_dispatch)
+    monkeypatch.setattr(policy_main, "KafkaNATSAdapter", _KafkaStub)
+    monkeypatch.setattr(policy_main, "RedisFeastAdapter", _RedisStub)
+    monkeypatch.setattr(policy_main, "TimescaleAdapter", _TimescaleStub)
+
+    payload = _decision_request_payload("company")
+    payload.pop("features", None)
+    payload.pop("book_snapshot", None)
+
+    policy_main.app.dependency_overrides[policy_main.require_admin_account] = lambda: "company"
+    try:
+        with TestClient(policy_main.app) as client:
+            response = client.post("/policy/decide", json=payload)
+            assert response.status_code == status.HTTP_200_OK, response.text
+            body = PolicyDecisionResponse.model_validate(response.json())
+    finally:
+        policy_main.app.dependency_overrides.pop(policy_main.require_admin_account, None)
+
+    assert body.features == pytest.approx([0.5, 1.75])
+    assert recorded and recorded[-1]["features"] == pytest.approx([0.5, 1.75])
+    assert dispatched_contexts == ["publish policy.decisions"]
+
+
+def test_policy_decide_respects_explicit_zero_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[dict[str, object]] = []
+
+    class _Registry:
+        def get_latest_ensemble(self, account_id: str, symbol: str) -> object:
+            class _Ensemble:
+                confidence_threshold = 0.5
+
+            return _Ensemble()
+
+    intent = Intent(
+        edge_bps=18.0,
+        confidence=ConfidenceMetrics(
+            model_confidence=0.9,
+            state_confidence=0.8,
+            execution_confidence=0.85,
+            overall_confidence=0.88,
+        ),
+        take_profit_bps=22.0,
+        stop_loss_bps=11.0,
+        selected_action="maker",
+        action_templates=[
+            ActionTemplate(
+                name="maker",
+                venue_type="maker",
+                edge_bps=18.0,
+                fee_bps=0.0,
+                confidence=0.85,
+            )
+        ],
+        approved=True,
+    )
+
+    class _KafkaStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def publish(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    class _RedisStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def fetch_online_features(self, instrument: str) -> dict[str, object]:
+            return {
+                "features": [9.0, 1.0],
+                "book_snapshot": {
+                    "mid_price": 101.0,
+                    "spread_bps": 1.0,
+                    "imbalance": 0.0,
+                },
+                "state": {
+                    "regime": "flat",
+                    "volatility": 0.1,
+                    "liquidity_score": 0.5,
+                    "conviction": 0.2,
+                },
+                "expected_edge_bps": 7.5,
+                "take_profit_bps": 14.0,
+                "stop_loss_bps": 6.0,
+            }
+
+    class _TimescaleStub:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def record_decision(self, *, order_id: str, payload: dict[str, object]) -> None:
+            recorded.append({"order_id": order_id, **payload})
+
+    def _run_dispatch(
+        coro: object,
+        *,
+        context: str,
+        logger: object | None = None,
+    ) -> None:
+        del logger
+        asyncio.run(coro)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(policy_main, "get_model_registry", lambda: _Registry())
+    monkeypatch.setattr(policy_main, "predict_intent", lambda **_: intent)
+    monkeypatch.setattr(policy_main, "KafkaNATSAdapter", _KafkaStub)
+    monkeypatch.setattr(policy_main, "RedisFeastAdapter", _RedisStub)
+    monkeypatch.setattr(policy_main, "TimescaleAdapter", _TimescaleStub)
+    monkeypatch.setattr(policy_main, "dispatch_async", _run_dispatch)
+
+    payload = _decision_request_payload("company")
+    payload.update(
+        {
+            "features": [],
+            "expected_edge_bps": 0.0,
+            "take_profit_bps": 0.0,
+            "stop_loss_bps": 0.0,
+            "state": {
+                "regime": "neutral",
+                "volatility": 0.0,
+                "liquidity_score": 0.0,
+                "conviction": 0.0,
+            },
+        }
+    )
+
+    policy_main.app.dependency_overrides[policy_main.require_admin_account] = lambda: "company"
+    try:
+        with TestClient(policy_main.app) as client:
+            response = client.post("/policy/decide", json=payload)
+            assert response.status_code == status.HTTP_200_OK, response.text
+            body = PolicyDecisionResponse.model_validate(response.json())
+    finally:
+        policy_main.app.dependency_overrides.pop(policy_main.require_admin_account, None)
+
+    assert body.features == []
+    assert body.take_profit_bps == pytest.approx(0.0)
+    assert body.stop_loss_bps == pytest.approx(0.0)
+    assert recorded and recorded[-1]["features"] == []
 
 
 def test_policy_decide_preserves_tick_precision(

--- a/tests/test_risk_correlation_service_config.py
+++ b/tests/test_risk_correlation_service_config.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+def _install_alert_manager_stub() -> types.ModuleType | None:
+    """Provide a minimal alert manager implementation for module reloads."""
+
+    original = sys.modules.get("services.alert_manager")
+    module = types.ModuleType("services.alert_manager")
+
+    @dataclass(slots=True)
+    class _RiskEvent:
+        event_type: str
+        severity: str
+        description: str
+        labels: dict[str, str] | None = None
+
+    class _AlertManager:
+        def __init__(self, *_, **__) -> None:
+            pass
+
+        def handle_risk_event(self, *_: object, **__: object) -> None:  # pragma: no cover - noop
+            return None
+
+    module.AlertManager = _AlertManager  # type: ignore[attr-defined]
+    module.RiskEvent = _RiskEvent  # type: ignore[attr-defined]
+    module.get_alert_metrics = lambda: object()  # type: ignore[attr-defined]
+
+    sys.modules["services.alert_manager"] = module
+    return original
+
+
+def _install_pandas_stub() -> types.ModuleType | None:
+    """Provide a light-weight pandas stub so imports succeed without numpy."""
+
+    original = sys.modules.get("pandas")
+    module = types.ModuleType("pandas")
+
+    class _Frame:  # pragma: no cover - placeholder for import-time use only
+        def __init__(self, *_, **__):
+            pass
+
+        def pct_change(self, *_, **__):
+            return self
+
+        def dropna(self, *_, **__):
+            return self
+
+        def corr(self, *_, **__):
+            return self
+
+        def iterrows(self):
+            return iter(())
+
+    class _Series:  # pragma: no cover - placeholder for import-time use only
+        def __init__(self, *_, **__):
+            pass
+
+    module.DataFrame = _Frame  # type: ignore[attr-defined]
+    module.Series = _Series  # type: ignore[attr-defined]
+    module.Index = tuple  # type: ignore[attr-defined]
+
+    sys.modules["pandas"] = module
+    return original
+
+
+def _reload_correlation_service() -> None:
+    sys.modules.pop("services.risk.correlation_service", None)
+    importlib.import_module("services.risk.correlation_service")
+
+
+@pytest.fixture(autouse=True)
+def _ensure_services_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        monkeypatch.syspath_prepend(str(project_root))
+
+
+def test_correlation_service_requires_configured_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_alert_manager = _install_alert_manager_stub()
+    original_pandas = _install_pandas_stub()
+
+    monkeypatch.delenv("RISK_CORRELATION_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("RISK_MARKETDATA_URL", raising=False)
+    monkeypatch.delenv("RISK_MARKETDATA_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DATABASE_URI", raising=False)
+
+    original_pytest = sys.modules.pop("pytest", None)
+    try:
+        with pytest.raises(RuntimeError, match="Risk correlation database DSN"):
+            _reload_correlation_service()
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
+        if original_alert_manager is not None:
+            sys.modules["services.alert_manager"] = original_alert_manager
+        else:
+            sys.modules.pop("services.alert_manager", None)
+        if original_pandas is not None:
+            sys.modules["pandas"] = original_pandas
+        else:
+            sys.modules.pop("pandas", None)
+        sys.modules.pop("services.risk.correlation_service", None)
+
+
+def test_correlation_service_rejects_sqlite_dsn_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_alert_manager = _install_alert_manager_stub()
+    original_pandas = _install_pandas_stub()
+
+    monkeypatch.setenv("RISK_CORRELATION_DATABASE_URL", "sqlite:///./correlations.db")
+    monkeypatch.delenv("RISK_MARKETDATA_URL", raising=False)
+    monkeypatch.delenv("RISK_MARKETDATA_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DATABASE_URI", raising=False)
+
+    original_pytest = sys.modules.pop("pytest", None)
+    try:
+        with pytest.raises(RuntimeError, match="PostgreSQL"):
+            _reload_correlation_service()
+    finally:
+        if original_pytest is not None:
+            sys.modules["pytest"] = original_pytest
+        if original_alert_manager is not None:
+            sys.modules["services.alert_manager"] = original_alert_manager
+        else:
+            sys.modules.pop("services.alert_manager", None)
+        if original_pandas is not None:
+            sys.modules["pandas"] = original_pandas
+        else:
+            sys.modules.pop("pandas", None)
+        sys.modules.pop("services.risk.correlation_service", None)

--- a/tests/test_sequencer_api.py
+++ b/tests/test_sequencer_api.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from importlib import import_module, util
-from pathlib import Path
+import contextlib
 import sys
 import types
+from importlib import import_module, util
+from pathlib import Path
 from types import ModuleType
 
 import pytest
@@ -45,6 +46,25 @@ if "metrics" not in sys.modules:
         return _Span()
 
     metrics_stub.traced_span = _span_factory
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
+    metrics_stub.TransportType = _TransportType
 
     sys.modules["metrics"] = metrics_stub
 

--- a/tests/test_training_service_config.py
+++ b/tests/test_training_service_config.py
@@ -1,0 +1,123 @@
+"""Configuration regression tests for the training service."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+import pytest
+
+from sqlalchemy import create_engine as real_create_engine
+from sqlalchemy.pool import StaticPool
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "training_service.py"
+
+
+def _load_training_module(module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive safeguard
+        raise ModuleNotFoundError(module_name)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _dispose_training_module(module_name: str) -> None:
+    module = sys.modules.pop(module_name, None)
+    if module is None:
+        return
+
+    engine = getattr(module, "ENGINE", None)
+    if engine is not None and hasattr(engine, "dispose"):
+        try:
+            engine.dispose()
+        except Exception:  # pragma: no cover - defensive cleanup
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TRAINING_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TIMESCALE_DSN", raising=False)
+    monkeypatch.delenv("TRAINING_ALLOW_SQLITE_FOR_TESTS", raising=False)
+
+
+def test_training_service_requires_database_url() -> None:
+    module_name = "tests.training_service_missing_dsn"
+    with pytest.raises(RuntimeError, match="must be configured"):
+        _load_training_module(module_name)
+
+
+def test_training_service_normalizes_timescale_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "TRAINING_DATABASE_URL",
+        "timescale://user:pass@example.com:5432/training",
+    )
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_create_engine(url: str, **kwargs: Any):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return real_create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+
+    module_name = "tests.training_service_timescale"
+    module = _load_training_module(module_name)
+    try:
+        assert str(captured["url"]).startswith("postgresql+psycopg2://")
+        assert module.DATABASE_URL.startswith("postgresql+psycopg2://")  # type: ignore[attr-defined]
+    finally:
+        _dispose_training_module(module_name)
+
+
+def test_training_service_rejects_sqlite_without_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAINING_DATABASE_URL", "sqlite:///./training.db")
+
+    module_name = "tests.training_service_sqlite_rejected"
+    with pytest.raises(RuntimeError, match="PostgreSQL/Timescale compatible scheme"):
+        _load_training_module(module_name)
+
+
+def test_training_service_allows_sqlite_when_flag_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAINING_DATABASE_URL", "sqlite:///./training.db")
+    monkeypatch.setenv("TRAINING_ALLOW_SQLITE_FOR_TESTS", "1")
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_create_engine(url: str, **kwargs: Any):
+        captured["url"] = url
+        return real_create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    monkeypatch.setattr("sqlalchemy.create_engine", _fake_create_engine)
+
+    module_name = "tests.training_service_sqlite_allowed"
+    module = _load_training_module(module_name)
+    try:
+        assert str(captured["url"]).startswith("sqlite")
+        assert module.DATABASE_URL.startswith("sqlite")  # type: ignore[attr-defined]
+    finally:
+        _dispose_training_module(module_name)

--- a/tests/unit/services/test_oms_kraken_reconciliation.py
+++ b/tests/unit/services/test_oms_kraken_reconciliation.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import contextlib
 import sys
 import types
 from decimal import Decimal
@@ -169,6 +170,28 @@ metrics_stub.record_scaling_state = _noop
 metrics_stub.observe_scaling_evaluation = _noop
 metrics_stub.get_request_id = lambda: None
 metrics_stub._REGISTRY = object()
+
+
+class _TransportMember:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class _TransportType:
+    UNKNOWN = _TransportMember("unknown")
+    INTERNAL = _TransportMember("internal")
+    REST = _TransportMember("rest")
+    WEBSOCKET = _TransportMember("websocket")
+    FIX = _TransportMember("fix")
+    BATCH = _TransportMember("batch")
+
+
+metrics_stub.TransportType = _TransportType
+metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
 sys.modules['metrics'] = metrics_stub
 
 

--- a/tests/unit/test_oms_service_precision.py
+++ b/tests/unit/test_oms_service_precision.py
@@ -1,4 +1,5 @@
 from decimal import Decimal, ROUND_HALF_EVEN
+import contextlib
 import sys
 import types
 from typing import Dict, List
@@ -94,6 +95,25 @@ if "metrics" not in sys.modules:
     metrics_stub.traced_span = traced_span
     metrics_stub.get_request_id = lambda: None
     metrics_stub._REGISTRY = object()
+
+    class _TransportMember:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    class _TransportType:
+        UNKNOWN = _TransportMember("unknown")
+        INTERNAL = _TransportMember("internal")
+        REST = _TransportMember("rest")
+        WEBSOCKET = _TransportMember("websocket")
+        FIX = _TransportMember("fix")
+        BATCH = _TransportMember("batch")
+
+    metrics_stub.TransportType = _TransportType
+    metrics_stub.bind_metric_context = lambda *args, **kwargs: contextlib.nullcontext()
+    metrics_stub.metric_context = lambda *args, **kwargs: contextlib.nullcontext()
     sys.modules["metrics"] = metrics_stub
 
 if "services.oms.oms_service" not in sys.modules:


### PR DESCRIPTION
## Summary
- normalize the benchmark service database URL via the shared PostgreSQL helper and gate sqlite fallbacks behind a pytest-aware flag while switching to a FastAPI lifespan for table creation
- simplify the benchmark service test helper to rely on the module's sqlite configuration and update authorization tests to bootstrap the service with the hardened settings

## Testing
- pytest tests/test_benchmark_service_security.py -q
- pytest tests/smoke/test_benchmark_service_persistence.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e381a5cf50832184e074aa2419050f