### PR TITLE
Enforce USD-only spot trading compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository provides reference infrastructure for ingesting, validating, and
 serving market data for the Aether research platform. The stack centres around
 TimescaleDB for historical storage, Kafka/NATS for real-time dissemination, and
-Feast/Redis for feature serving.
+Feast/Redis for feature serving. **All trading logic is restricted to USD-quoted
+Kraken spot markets only.**
 
 ## Components
 

--- a/services/risk/portfolio_risk.py
+++ b/services/risk/portfolio_risk.py
@@ -37,14 +37,12 @@ DEFAULT_CLUSTER_LIMITS: Dict[str, float] = {
 }
 DEFAULT_CLUSTER_MAP: Dict[str, str] = {
     "BTC-USD": "BTC",
-    "BTC-USDT": "BTC",
     "ETH-USD": "ETH",
     "SOL-USD": "ALT",
     "ADA-USD": "ALT",
 }
 DEFAULT_BETA_MAP: Dict[str, float] = {
     "BTC-USD": 1.0,
-    "BTC-USDT": 1.0,
     "ETH-USD": 0.8,
     "SOL-USD": 1.4,
     "ADA-USD": 1.2,

--- a/shared/spot.py
+++ b/shared/spot.py
@@ -1,4 +1,4 @@
-"""Utilities for validating and normalising spot trading instruments."""
+"""Utilities for validating and normalising USD spot trading instruments."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ _SPOT_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,}-[A-Z0-9]{2,}$")
 _NON_SPOT_KEYWORDS: Sequence[str] = ("PERP", "FUT", "FUTURE", "MARGIN", "SWAP", "OPTION", "DERIV")
 _LEVERAGE_SUFFIXES: Sequence[str] = ("UP", "DOWN")
 _LEVERAGE_PATTERN = re.compile(r"\d+(?:X|L|S)$")
+_ALLOWED_QUOTES: Sequence[str] = ("USD",)
 
 
 def normalize_spot_symbol(symbol: object) -> str:
@@ -39,7 +40,7 @@ def normalize_spot_symbol(symbol: object) -> str:
 
 
 def is_spot_symbol(symbol: object) -> bool:
-    """Return ``True`` when *symbol* represents a spot market trading pair."""
+    """Return ``True`` when *symbol* represents a USD-quoted spot market pair."""
 
     normalized = normalize_spot_symbol(symbol)
     if not normalized:
@@ -51,7 +52,10 @@ def is_spot_symbol(symbol: object) -> bool:
     if not _SPOT_PAIR_PATTERN.match(normalized):
         return False
 
-    base, _ = normalized.split("-", maxsplit=1)
+    base, quote = normalized.split("-", maxsplit=1)
+
+    if quote not in _ALLOWED_QUOTES:
+        return False
 
     if any(base.endswith(suffix) for suffix in _LEVERAGE_SUFFIXES):
         return False

--- a/tests/common/test_intent_schemas.py
+++ b/tests/common/test_intent_schemas.py
@@ -19,12 +19,12 @@ def test_order_symbol_normalized_to_spot_pair() -> None:
     order = Order(
         client_id="client-spot",
         account_id="acct-1",
-        symbol="eth/usdt",
+        symbol="eth/usd",
         status="NEW",
         ts=_timestamp(),
     )
 
-    assert order.symbol == "ETH-USDT"
+    assert order.symbol == "ETH-USD"
 
 
 def test_order_rejects_non_spot_symbol() -> None:

--- a/tests/reports/test_trade_explain.py
+++ b/tests/reports/test_trade_explain.py
@@ -171,7 +171,7 @@ def test_trade_explain_normalises_instrument(monkeypatch) -> None:
 def test_filter_spot_instruments_drops_derivatives(caplog) -> None:
     frame = pd.DataFrame(
         {
-            "instrument": ["BTC-USD", "ETH-PERP", "eth_usd", "ADAUP-USDT", None],
+            "instrument": ["BTC-USD", "ETH-PERP", "eth_usd", "ADAUP-USD", None],
             "size": [1, 2, 3, 4, 5],
             "price": [10, 20, 30, 40, 50],
             "fee": [0, 0, 0, 0, 0],

--- a/tests/risk/test_cvar_forecast_spot.py
+++ b/tests/risk/test_cvar_forecast_spot.py
@@ -22,7 +22,7 @@ class _StubTimescaleAdapter:
             "BTC-USD": 25_000.0,
             "ETH/USD": 50_000.0,
             "ETH-PERP": 12_500.0,
-            "ADAUP-USDT": 5_000.0,
+            "ADAUP-USD": 5_000.0,
         }
 
     def record_cvar_result(

--- a/tests/risk/test_risk.py
+++ b/tests/risk/test_risk.py
@@ -21,7 +21,7 @@ def test_risk_validate_authorized_accounts():
     }
     for account in ADMIN_ACCOUNTS:
         payload["account_id"] = account
-        payload["instrument"] = "ETH-USD" if account != "director-2" else "ETH-USDT"
+        payload["instrument"] = "ETH-USD"
         response = client.post("/risk/validate", json=payload, headers={"X-Account-ID": account})
         assert response.status_code == 200
         data = response.json()

--- a/tests/unit/shared/test_spot.py
+++ b/tests/unit/shared/test_spot.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from shared import spot
+
+
+def test_is_spot_symbol_accepts_usd_pairs() -> None:
+    assert spot.is_spot_symbol("btc-usd")
+    assert spot.is_spot_symbol("ETH/USD")
+
+
+def test_is_spot_symbol_rejects_non_usd_quotes() -> None:
+    assert not spot.is_spot_symbol("ETH-USDT")
+    assert not spot.is_spot_symbol("BTC-EUR")
+
+
+def test_filter_spot_symbols_only_returns_usd_pairs() -> None:
+    symbols = ["btc-usd", "eth-usdt", "ada-usd", "BTC-PERP", "", None]
+    filtered = spot.filter_spot_symbols(symbols)
+    assert filtered == ["BTC-USD", "ADA-USD"]
+
+
+def test_is_spot_symbol_rejects_leveraged_suffixes() -> None:
+    assert not spot.is_spot_symbol("ADAUP-USD")
+    assert not spot.is_spot_symbol("BTCDOWN-USD")
+
+
+def test_normalize_spot_symbol_handles_delimiters() -> None:
+    assert spot.normalize_spot_symbol(" btc/usd ") == "BTC-USD"
+    assert spot.normalize_spot_symbol("eth_usd") == "ETH-USD"

--- a/tests/unit/test_hedging_service.py
+++ b/tests/unit/test_hedging_service.py
@@ -45,7 +45,7 @@ class _StubTimescale:
 def hedging_config() -> hs.HedgeConfig:
     return hs.HedgeConfig(
         account_id="acct-1",
-        hedge_symbol="eth/btc",
+        hedge_symbol="eth/usd",
         base_allocation_usd=1_000.0,
         max_allocation_usd=10_000.0,
         rebalance_tolerance_usd=0.0,
@@ -149,8 +149,8 @@ def test_rebalance_requires_precision_metadata(
 
 
 def test_hedge_config_normalizes_spot_symbol() -> None:
-    config = hs.HedgeConfig(account_id="acct-2", hedge_symbol="  btc_usdt  ")
-    assert config.hedge_symbol == "BTC-USDT"
+    config = hs.HedgeConfig(account_id="acct-2", hedge_symbol="  btc_usd  ")
+    assert config.hedge_symbol == "BTC-USD"
 
 
 def test_hedge_config_rejects_derivative_symbols() -> None:

--- a/tests/universe/test_endpoints.py
+++ b/tests/universe/test_endpoints.py
@@ -109,7 +109,7 @@ def test_get_universe_allows_admin_accounts(
     assert body["account_id"] == account_id
 
     assert isinstance(body["instruments"], list)
-    assert all(symbol.split("-")[-1] in {"USD", "USDT"} for symbol in body["instruments"])
+    assert all(symbol.endswith("-USD") for symbol in body["instruments"])
     assert isinstance(body["fee_overrides"], dict)
 
 

--- a/tests/universe/test_universe_repository_thresholds.py
+++ b/tests/universe/test_universe_repository_thresholds.py
@@ -106,7 +106,7 @@ def test_non_usd_pairs_are_ignored(universe_timescale: UniverseTimescaleFixture)
     )
     universe_timescale.add_snapshot(
         base_asset="ETH",
-        quote_asset="USDT",
+        quote_asset="EUR",
         market_cap=UniverseRepository.MARKET_CAP_THRESHOLD * 2,
         global_volume_24h=UniverseRepository.GLOBAL_VOLUME_THRESHOLD * 3,
         kraken_volume_24h=UniverseRepository.KRAKEN_VOLUME_THRESHOLD * 3,

--- a/tests/universe/test_universe_service.py
+++ b/tests/universe/test_universe_service.py
@@ -59,7 +59,7 @@ def test_non_usd_symbols_are_filtered() -> None:
             ),
             MarketSnapshot(
                 base_asset="ETH",
-                quote_asset="USDT",
+                quote_asset="EUR",
                 market_cap=4.0e11,
                 global_volume_24h=2.5e10,
                 kraken_volume_24h=1.2e10,


### PR DESCRIPTION
## Summary
- restrict shared spot validation to USD-quoted instruments and document spot-only operation
- align risk aggregation, hedging, and universe selection logic and tests with USD-only spot coverage
- add focused unit tests confirming leveraged, non-USD, and derivative symbols are rejected

## Testing
- pytest tests/unit/shared/test_spot.py
- pytest tests/unit/test_hedging_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e43cb5e11c83219c110b251fd8754d